### PR TITLE
Enhance `from_entries` operation to support both array and object for…

### DIFF
--- a/crates/transform_rules/tests/fixtures/t26_chain_all_ops/expected.json
+++ b/crates/transform_rules/tests/fixtures/t26_chain_all_ops/expected.json
@@ -41,6 +41,12 @@
       {"key": "b", "value": 2},
       {"key": "nested", "value": {"x": 1, "y": 2}}
     ],
+    "json_entries_roundtrip": {
+      "a": 1,
+      "arr": [1, 2],
+      "b": 2,
+      "nested": {"x": 1, "y": 2}
+    },
     "json_from_entries_zip": {
       "1": "a",
       "2": "b",

--- a/crates/transform_rules/tests/fixtures/t26_chain_all_ops/rules.yaml
+++ b/crates/transform_rules/tests/fixtures/t26_chain_all_ops/rules.yaml
@@ -55,6 +55,14 @@ mappings:
         - { ref: "input.base" }
         - op: "entries"
           args: []
+  - target: "json_entries_roundtrip"
+    expr:
+      chain:
+        - { ref: "input.base" }
+        - op: "entries"
+          args: []
+        - op: "from_entries"
+          args: []
   - target: "json_from_entries_zip"
     expr:
       chain:

--- a/docs/rules_spec_en.md
+++ b/docs/rules_spec_en.md
@@ -255,7 +255,7 @@ expr:
 | `values` | `obj` | Array of values. |
 | `entries` | `obj` | Array of `{key, value}` entries. |
 | `len` | `value` | Length of string/array/object. |
-| `from_entries` | `entries` / `key, value` | Build object from pairs or key/value. |
+| `from_entries` | `entries` / `key, value` | Build object from pairs (`[key,value]` or `{key,value}`) or key/value. |
 | `object_flatten` | `obj` | Flatten object keys into path strings. |
 | `object_unflatten` | `obj` | Expand path keys into nested objects. |
 
@@ -347,7 +347,7 @@ expr:
   - `get`: path must be a valid non-empty path string.
   - `len`: `missing` stays `missing`; `null` is an error.
   - `len`: supports string/array/object only (string length counts Unicode scalar values).
-  - `from_entries`: with 1 arg, returns object as-is or builds from `[key, value]` pairs.
+  - `from_entries`: with 1 arg, returns object as-is or builds from `[key,value]`/`{key,value}` entries.
   - `from_entries`: with 2 args, builds object from `key, value`. `key` is string/number/bool; duplicates are last-wins.
   - `from_entries`: `missing` stays `missing`, `key` `null` is an error. `value` can be any JSON (including `null`).
   - Object ops (`merge`/`deep_merge`/`pick`/`omit`/`keys`/`values`/`entries`/`object_*`):

--- a/docs/rules_spec_ja.md
+++ b/docs/rules_spec_ja.md
@@ -255,7 +255,7 @@ expr:
 | `values` | `obj` | 値の配列。 |
 | `entries` | `obj` | `{key, value}` の配列。 |
 | `len` | `value` | string/array/object の長さを返す。 |
-| `from_entries` | `entries` / `key, value` | ペア配列 or key/value から object を生成。 |
+| `from_entries` | `entries` / `key, value` | ペア配列（`[key,value]` or `{key,value}`）や key/value から object を生成。 |
 | `object_flatten` | `obj` | オブジェクトを path キーで平坦化。 |
 | `object_unflatten` | `obj` | path キーからオブジェクトを再構成。 |
 
@@ -347,7 +347,7 @@ expr:
   - `get`: path は空文字不可の valid path 文字列。
   - `len`: `missing` は `missing`、`null` はエラー。
   - `len`: string/array/object のみ対応（文字数は Unicode スカラー数）。
-  - `from_entries`: 1 引数は object をそのまま返すか、`[key, value]` の配列から object を生成。
+  - `from_entries`: 1 引数は object をそのまま返すか、`[key,value]`/`{key,value}` の配列から object を生成。
   - `from_entries`: 2 引数は `key, value` で object を生成。`key` は string/number/bool、重複は後勝ち。
   - `from_entries`: `missing` は `missing`、`key` の `null` はエラー。`value` は任意 JSON（`null` 可）。
   - オブジェクト系（`merge`/`deep_merge`/`pick`/`omit`/`keys`/`values`/`entries`/`object_*`）:


### PR DESCRIPTION
…mats

- Updated the `from_entries` operation to accept entries as either arrays of pairs or objects with key-value pairs.
- Improved error handling for invalid entry formats, ensuring robust validation for both types.
- Added new test cases to verify the functionality with various input structures.
- Updated documentation to clarify the accepted formats for the `from_entries` operation.