### PR TITLE
Harden release and OSS security boundaries

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -5,30 +5,35 @@ on:
     types: [published]
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   update-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4 pinned 2026-05-09.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: main
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           VERSION="${TAG#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extracted version: ${VERSION}"
 
       - name: Update Cargo.toml files
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           for TOML in crates/rulemorph/Cargo.toml \
                       crates/rulemorph_cli/Cargo.toml \
                       crates/rulemorph_mcp/Cargo.toml \
@@ -41,12 +46,19 @@ jobs:
           done
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable pinned 2026-05-09.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
 
       - name: Update Cargo.lock
         run: cargo update -w
 
       - name: Commit and push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -54,20 +66,28 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
-            git push origin main
+            git commit -m "chore: bump version to ${VERSION}"
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
+              push "https://github.com/${REPOSITORY}.git" HEAD:main
           fi
 
   publish-crates-io:
     needs: update-version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4 pinned 2026-05-09.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: main
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable pinned 2026-05-09.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
 
       - name: Publish to crates.io
         env:
@@ -77,6 +97,8 @@ jobs:
   build-and-upload:
     needs: update-version
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -91,17 +113,22 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4 pinned 2026-05-09.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: main
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable pinned 2026-05-09.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        # actions/setup-node@v4 pinned 2026-05-09.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
           cache: "npm"
@@ -188,20 +215,27 @@ jobs:
           Compress-Archive -Path "$McpbDir\*" -DestinationPath "$OutDir\rulemorph-mcp-$env:VERSION-$env:TARGET.mcpb"
 
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release upload "${RELEASE_TAG}" dist/* --clobber
 
   publish-mcp-registry:
     needs: build-and-upload
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       VERSION: ${{ github.ref_name }}
       REPO_URL: https://github.com/${{ github.repository }}
+      MCP_PUBLISHER_VERSION: v1.7.8
+      MCP_PUBLISHER_SHA256: 48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4 pinned 2026-05-09.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Download .mcpb files and compute SHA256
         run: |
@@ -262,9 +296,11 @@ jobs:
 
       - name: Download mcp-publisher
         run: |
-          LATEST_TAG=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | jq -r '.tag_name')
-          echo "Downloading mcp-publisher ${LATEST_TAG}"
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${LATEST_TAG}/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          echo "Downloading mcp-publisher ${MCP_PUBLISHER_VERSION}"
+          curl -L -o mcp-publisher_linux_amd64.tar.gz "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher_linux_amd64.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher_linux_amd64.tar.gz mcp-publisher
           chmod +x mcp-publisher
 
       - name: Publish to MCP Registry
@@ -275,6 +311,8 @@ jobs:
   update-homebrew:
     needs: build-and-upload
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       VERSION: ${{ github.ref_name }}
       REPO_URL: https://github.com/${{ github.repository }}
@@ -323,18 +361,34 @@ jobs:
           done
 
       - name: Trigger Homebrew formula update
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.TAP_REPO_TOKEN }}
-          repository: vinhphatfsg/homebrew-tap
-          event-type: update-formula
-          client-payload: |
-            {
-              "version": "${{ github.ref_name }}",
-              "sha256_arm": "${{ env.SHA256_aarch64_apple_darwin }}",
-              "sha256_intel": "${{ env.SHA256_x86_64_apple_darwin }}",
-              "sha256_linux": "${{ env.SHA256_x86_64_unknown_linux_gnu }}",
-              "server_sha256_arm": "${{ env.SERVER_SHA256_aarch64_apple_darwin }}",
-              "server_sha256_intel": "${{ env.SERVER_SHA256_x86_64_apple_darwin }}",
-              "server_sha256_linux": "${{ env.SERVER_SHA256_x86_64_unknown_linux_gnu }}"
-            }
+        env:
+          TAP_REPO_TOKEN: ${{ secrets.TAP_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg event_type "update-formula" \
+            --arg version "${VERSION}" \
+            --arg sha_arm "${SHA256_aarch64_apple_darwin}" \
+            --arg sha_intel "${SHA256_x86_64_apple_darwin}" \
+            --arg sha_linux "${SHA256_x86_64_unknown_linux_gnu}" \
+            --arg server_sha_arm "${SERVER_SHA256_aarch64_apple_darwin}" \
+            --arg server_sha_intel "${SERVER_SHA256_x86_64_apple_darwin}" \
+            --arg server_sha_linux "${SERVER_SHA256_x86_64_unknown_linux_gnu}" \
+            '{
+              event_type: $event_type,
+              client_payload: {
+                version: $version,
+                sha256_arm: $sha_arm,
+                sha256_intel: $sha_intel,
+                sha256_linux: $sha_linux,
+                server_sha256_arm: $server_sha_arm,
+                server_sha256_intel: $server_sha_intel,
+                server_sha256_linux: $server_sha_linux
+              }
+            }' > dispatch.json
+          curl -fsS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TAP_REPO_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/vinhphatfsg/homebrew-tap/dispatches \
+            --data @dispatch.json

--- a/crates/rulemorph/src/dto.rs
+++ b/crates/rulemorph/src/dto.rs
@@ -42,17 +42,17 @@ pub fn generate_dto(
     language: DtoLanguage,
     name: Option<&str>,
 ) -> Result<String, DtoError> {
-    let name = name.unwrap_or("Record");
+    let name = safe_type_name(language, name.unwrap_or("Record"));
     let schema = build_schema(rule)?;
 
     match language {
-        DtoLanguage::Rust => render_rust(&schema, name),
-        DtoLanguage::TypeScript => render_typescript(&schema, name),
-        DtoLanguage::Python => render_python(&schema, name),
-        DtoLanguage::Go => render_go(&schema, name),
-        DtoLanguage::Java => render_java(&schema, name),
-        DtoLanguage::Kotlin => render_kotlin(&schema, name),
-        DtoLanguage::Swift => render_swift(&schema, name),
+        DtoLanguage::Rust => render_rust(&schema, &name),
+        DtoLanguage::TypeScript => render_typescript(&schema, &name),
+        DtoLanguage::Python => render_python(&schema, &name),
+        DtoLanguage::Go => render_go(&schema, &name),
+        DtoLanguage::Java => render_java(&schema, &name),
+        DtoLanguage::Kotlin => render_kotlin(&schema, &name),
+        DtoLanguage::Swift => render_swift(&schema, &name),
     }
 }
 
@@ -331,6 +331,87 @@ fn field_identifier(lang: DtoLanguage, key: &str, used: &mut HashMap<String, usi
         *entry = 1;
         ident
     }
+}
+
+fn safe_type_name(lang: DtoLanguage, name: &str) -> String {
+    let words = words_from_key(name);
+    let mut ident = pascal_case(&words);
+    if ident.is_empty() {
+        ident = "Record".to_string();
+    }
+    if ident
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(true)
+    {
+        ident = format!("Record{}", ident);
+    }
+    if is_reserved(lang, &ident) {
+        ident.push_str("Record");
+    }
+    ident
+}
+
+fn rust_string_literal(value: &str) -> String {
+    format!("{:?}", value)
+}
+
+fn json_string_literal(value: &str) -> String {
+    serde_json::to_string(value).expect("string serialization should not fail")
+}
+
+fn swift_string_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if ch.is_control() => out.push_str(&format!("\\u{{{:x}}}", ch as u32)),
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn safe_comment_text(value: &str) -> String {
+    value.replace("*/", "* /").replace(['\r', '\n'], "\\n")
+}
+
+fn go_json_tag_literal(key: &str, optional: bool) -> String {
+    if !key.contains('`')
+        && !key.contains('"')
+        && !key.contains('\\')
+        && !key.contains('\r')
+        && !key.contains('\n')
+    {
+        if optional {
+            return format!("`json:\"{},omitempty\"`", key);
+        }
+        return format!("`json:\"{}\"`", key);
+    }
+    let mut tag_key = String::with_capacity(key.len());
+    for ch in key.chars() {
+        match ch {
+            '\\' => tag_key.push_str("\\\\"),
+            '"' => tag_key.push_str("\\\""),
+            '\n' => tag_key.push_str("\\n"),
+            '\r' => tag_key.push_str("\\r"),
+            '\t' => tag_key.push_str("\\t"),
+            ch => tag_key.push(ch),
+        }
+    }
+    let tag = if optional {
+        format!("json:\"{},omitempty\"", tag_key)
+    } else {
+        format!("json:\"{}\"", tag_key)
+    };
+    json_string_literal(&tag)
 }
 
 fn words_from_key(key: &str) -> Vec<String> {
@@ -749,7 +830,7 @@ fn render_rust(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
                 attrs.push("skip_serializing_if = \"Option::is_none\"".to_string());
             }
             if rename {
-                attrs.push(format!("rename = \"{}\"", field.key));
+                attrs.push(format!("rename = {}", rust_string_literal(&field.key)));
             }
 
             if !attrs.is_empty() {
@@ -806,7 +887,10 @@ fn render_typescript(schema: &SchemaNode, name: &str) -> Result<String, DtoError
             };
             let field_type = typescript_type_for_field(field, &def.path, &registry);
             if rename {
-                out.push_str(&format!("  /** json: \"{}\" */\n", field.key));
+                out.push_str(&format!(
+                    "  /** json: {} */\n",
+                    json_string_literal(&safe_comment_text(&field.key))
+                ));
             }
             let suffix = if optional { "?" } else { "" };
             out.push_str(&format!("  {}{}: {};\n", ident, suffix, field_type));
@@ -908,19 +992,26 @@ fn render_python(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
             .chain(fields.iter().filter(|field| field.optional))
         {
             if field.rename {
-                out.push_str(&format!("    # json: \"{}\"\n", field.key));
+                out.push_str(&format!(
+                    "    # json: {}\n",
+                    json_string_literal(&safe_comment_text(&field.key))
+                ));
             }
 
             if field.rename {
                 if field.optional {
                     out.push_str(&format!(
-                        "    {}: {} = field(default=None, metadata={{\"json_key\": \"{}\"}})\n",
-                        field.ident, field.field_type, field.key
+                        "    {}: {} = field(default=None, metadata={{\"json_key\": {}}})\n",
+                        field.ident,
+                        field.field_type,
+                        json_string_literal(&field.key)
                     ));
                 } else {
                     out.push_str(&format!(
-                        "    {}: {} = field(metadata={{\"json_key\": \"{}\"}})\n",
-                        field.ident, field.field_type, field.key
+                        "    {}: {} = field(metadata={{\"json_key\": {}}})\n",
+                        field.ident,
+                        field.field_type,
+                        json_string_literal(&field.key)
                     ));
                 }
             } else if field.optional {
@@ -990,11 +1081,7 @@ fn render_go(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
                 _ => field.optional,
             };
             let field_type = go_type_for_field(field, &def.path, &registry, optional);
-            let tag = if optional {
-                format!("`json:\"{},omitempty\"`", field.key)
-            } else {
-                format!("`json:\"{}\"`", field.key)
-            };
+            let tag = go_json_tag_literal(&field.key, optional);
             out.push_str(&format!("    {} {} {}\n", ident, field_type, tag));
         }
         out.push_str("}\n\n");
@@ -1065,7 +1152,10 @@ fn render_java(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
             let field_type = java_type_for_field(field, &def.path, &registry, optional);
 
             if rename {
-                out.push_str(&format!("    @JsonProperty(\"{}\")\n", field.key));
+                out.push_str(&format!(
+                    "    @JsonProperty({})\n",
+                    json_string_literal(&field.key)
+                ));
             }
             out.push_str(&format!("    public {} {};\n", field_type, ident));
         }
@@ -1136,7 +1226,10 @@ fn render_kotlin(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
             let field_type = kotlin_type_for_field(field, &def.path, &registry, optional);
 
             if rename {
-                out.push_str(&format!("    @JsonProperty(\"{}\")\n", field.key));
+                out.push_str(&format!(
+                    "    @JsonProperty({})\n",
+                    json_string_literal(&field.key)
+                ));
             }
             let suffix = if index + 1 == def.node.fields.len() {
                 ""
@@ -1199,7 +1292,11 @@ fn render_swift(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
 
             out.push_str(&format!("    let {}: {}\n", ident, field_type));
             if rename {
-                coding_keys.push(format!("        case {} = \"{}\"", ident, field.key));
+                coding_keys.push(format!(
+                    "        case {} = {}",
+                    ident,
+                    swift_string_literal(&field.key)
+                ));
             }
         }
 

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -24,6 +24,7 @@ use crate::v2_parser::{
 };
 
 const REGEX_CACHE_CAPACITY: usize = 128;
+const BRANCH_MAX_DEPTH: usize = 64;
 
 fn regex_cache() -> &'static Mutex<LruCache<String, Regex>> {
     static REGEX_CACHE: OnceLock<Mutex<LruCache<String, Regex>>> = OnceLock::new();
@@ -138,12 +139,14 @@ impl<'a> Iterator for TransformStream<'a> {
             };
 
             let mut warnings = Vec::new();
+            let mut branch_context = BranchContext::default();
             match apply_rule_to_record(
                 self.rule,
                 &record,
                 self.context,
                 &mut warnings,
                 self.base_dir,
+                &mut branch_context,
             ) {
                 Ok(output) => {
                     if output.is_none() && warnings.is_empty() {
@@ -219,9 +222,15 @@ fn transform_with_warnings_inner(
         while let Some(record) = records.next() {
             let record = record?;
             let mut record_warnings = Vec::new();
-            if let Some(output) =
-                apply_rule_to_record(rule, &record, context, &mut record_warnings, base_dir)?
-            {
+            let mut branch_context = BranchContext::default();
+            if let Some(output) = apply_rule_to_record(
+                rule,
+                &record,
+                context,
+                &mut record_warnings,
+                base_dir,
+                &mut branch_context,
+            )? {
                 output_records.push(output);
             }
             warnings.extend(record_warnings);
@@ -273,7 +282,8 @@ pub fn transform_record_with_warnings(
     record: &JsonValue,
     context: Option<&JsonValue>,
 ) -> Result<(Option<JsonValue>, Vec<TransformWarning>), TransformError> {
-    transform_record_with_warnings_inner(rule, record, context, None)
+    let mut branch_context = BranchContext::default();
+    transform_record_with_warnings_inner(rule, record, context, None, &mut branch_context)
 }
 
 pub fn transform_record_with_warnings_with_base_dir(
@@ -282,7 +292,8 @@ pub fn transform_record_with_warnings_with_base_dir(
     context: Option<&JsonValue>,
     base_dir: &Path,
 ) -> Result<(Option<JsonValue>, Vec<TransformWarning>), TransformError> {
-    transform_record_with_warnings_inner(rule, record, context, Some(base_dir))
+    let mut branch_context = BranchContext::default();
+    transform_record_with_warnings_inner(rule, record, context, Some(base_dir), &mut branch_context)
 }
 
 fn transform_record_with_warnings_inner(
@@ -290,9 +301,17 @@ fn transform_record_with_warnings_inner(
     record: &JsonValue,
     context: Option<&JsonValue>,
     base_dir: Option<&Path>,
+    branch_context: &mut BranchContext,
 ) -> Result<(Option<JsonValue>, Vec<TransformWarning>), TransformError> {
     let mut warnings = Vec::new();
-    let output = apply_rule_to_record(rule, record, context, &mut warnings, base_dir)?;
+    let output = apply_rule_to_record(
+        rule,
+        record,
+        context,
+        &mut warnings,
+        base_dir,
+        branch_context,
+    )?;
     if output.is_none() {
         return Ok((None, warnings));
     }
@@ -337,9 +356,15 @@ fn preflight_validate_with_warnings_inner(
         while let Some(record) = records.next() {
             let record = record?;
             let mut record_warnings = Vec::new();
-            if let Some(output) =
-                apply_rule_to_record(rule, &record, context, &mut record_warnings, base_dir)?
-            {
+            let mut branch_context = BranchContext::default();
+            if let Some(output) = apply_rule_to_record(
+                rule,
+                &record,
+                context,
+                &mut record_warnings,
+                base_dir,
+                &mut branch_context,
+            )? {
                 output_records.push(output);
             }
             warnings.extend(record_warnings);
@@ -415,9 +440,18 @@ fn apply_rule_to_record(
     context: Option<&JsonValue>,
     warnings: &mut Vec<TransformWarning>,
     base_dir: Option<&Path>,
+    branch_context: &mut BranchContext,
 ) -> Result<Option<JsonValue>, TransformError> {
     if let Some(steps) = &rule.steps {
-        return apply_steps(steps, record, context, warnings, rule.version, base_dir);
+        return apply_steps(
+            steps,
+            record,
+            context,
+            warnings,
+            rule.version,
+            base_dir,
+            branch_context,
+        );
     }
 
     if !eval_record_when(rule, record, context, warnings) {
@@ -435,6 +469,7 @@ fn apply_steps(
     warnings: &mut Vec<TransformWarning>,
     rule_version: u8,
     base_dir: Option<&Path>,
+    branch_context: &mut BranchContext,
 ) -> Result<Option<JsonValue>, TransformError> {
     let mut out = JsonValue::Object(Map::new());
 
@@ -504,15 +539,22 @@ fn apply_steps(
                 (branch.r#else.as_deref(), "else")
             };
             if let Some(target) = target {
-                let (branch_rule, branch_base_dir) = load_rule_from_path(base_dir, target)
+                let branch_path_guard = branch_context
+                    .enter(base_dir, target)
                     .map_err(|err| err.with_path(format!("{}.{}", branch_path, target_field)))?;
+                let (branch_rule, branch_base_dir) =
+                    load_rule_from_path(base_dir, target, branch_context.allowed_root()).map_err(
+                        |err| err.with_path(format!("{}.{}", branch_path, target_field)),
+                    )?;
                 let branch_input = out.clone();
                 let (branch_output, branch_warnings) = transform_record_with_warnings_inner(
                     &branch_rule,
                     &branch_input,
                     context,
                     Some(&branch_base_dir),
+                    branch_context,
                 )?;
+                branch_context.exit(branch_path_guard);
                 warnings.extend(branch_warnings);
                 let Some(branch_output) = branch_output else {
                     return Ok(None);
@@ -550,6 +592,73 @@ fn merge_branch_output(
     Ok(())
 }
 
+#[derive(Default)]
+struct BranchContext {
+    stack: Vec<PathBuf>,
+    allowed_root: Option<PathBuf>,
+}
+
+impl BranchContext {
+    fn enter(
+        &mut self,
+        base_dir: Option<&Path>,
+        target: &str,
+    ) -> Result<BranchPathGuard, TransformError> {
+        if self.stack.len() >= BRANCH_MAX_DEPTH {
+            return Err(TransformError::new(
+                TransformErrorKind::InvalidInput,
+                "branch rule depth limit exceeded",
+            ));
+        }
+        let resolved = resolve_rule_path(base_dir, target);
+        let canonical = resolved.canonicalize().map_err(|err| {
+            TransformError::new(
+                TransformErrorKind::InvalidInput,
+                format!("failed to resolve branch rule: {}", err),
+            )
+        })?;
+        let allowed_root = match (&self.allowed_root, base_dir) {
+            (Some(root), _) => Some(root.clone()),
+            (None, Some(base_dir)) => Some(base_dir.canonicalize().map_err(|err| {
+                TransformError::new(
+                    TransformErrorKind::InvalidInput,
+                    format!("failed to resolve branch base directory: {}", err),
+                )
+            })?),
+            (None, None) => None,
+        };
+        if let Some(root) = &allowed_root {
+            if !canonical.starts_with(root) {
+                return Err(TransformError::new(
+                    TransformErrorKind::InvalidInput,
+                    "branch rule path must stay under the base directory",
+                ));
+            }
+        }
+        if self.stack.iter().any(|path| path == &canonical) {
+            return Err(TransformError::new(
+                TransformErrorKind::InvalidInput,
+                "branch rule cycle detected",
+            ));
+        }
+        if self.allowed_root.is_none() {
+            self.allowed_root = allowed_root;
+        }
+        self.stack.push(canonical);
+        Ok(BranchPathGuard)
+    }
+
+    fn allowed_root(&self) -> Option<&Path> {
+        self.allowed_root.as_deref()
+    }
+
+    fn exit(&mut self, _guard: BranchPathGuard) {
+        self.stack.pop();
+    }
+}
+
+struct BranchPathGuard;
+
 fn merge_object_maps(out_map: &mut Map<String, JsonValue>, other_map: &Map<String, JsonValue>) {
     for (key, other_value) in other_map {
         match (out_map.get_mut(key), other_value) {
@@ -566,8 +675,25 @@ fn merge_object_maps(out_map: &mut Map<String, JsonValue>, other_map: &Map<Strin
 fn load_rule_from_path(
     base_dir: Option<&Path>,
     path: &str,
+    allowed_root: Option<&Path>,
 ) -> Result<(RuleFile, PathBuf), TransformError> {
     let resolved = resolve_rule_path(base_dir, path);
+    if let Some(allowed_root) = allowed_root {
+        let canonical_resolved = resolved.canonicalize().map_err(|err| {
+            TransformError::new(
+                TransformErrorKind::InvalidInput,
+                format!("failed to resolve branch rule: {}", err),
+            )
+            .with_path(path)
+        })?;
+        if !canonical_resolved.starts_with(allowed_root) {
+            return Err(TransformError::new(
+                TransformErrorKind::InvalidInput,
+                "branch rule path must stay under the base directory",
+            )
+            .with_path(path));
+        }
+    }
     let yaml = std::fs::read_to_string(&resolved).map_err(|err| {
         TransformError::new(
             TransformErrorKind::InvalidInput,

--- a/crates/rulemorph/tests/branch_security.rs
+++ b/crates/rulemorph/tests/branch_security.rs
@@ -1,0 +1,125 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rulemorph::{parse_rule_file, transform_with_base_dir};
+
+fn unique_temp_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("rulemorph-{name}-{nanos}"));
+    fs::create_dir_all(&path).expect("create temp dir");
+    path
+}
+
+#[test]
+fn branch_self_cycle_is_rejected() {
+    let dir = unique_temp_dir("branch-self-cycle");
+    let rule_path = dir.join("self.yaml");
+    fs::write(
+        &rule_path,
+        r#"version: 2
+input:
+  format: json
+  json: {}
+steps:
+  - branch:
+      when: { eq: [1, 1] }
+      then: self.yaml
+"#,
+    )
+    .expect("write rule");
+    let rule = parse_rule_file(&fs::read_to_string(&rule_path).expect("read rule")).expect("parse");
+    let err = transform_with_base_dir(&rule, r#"{"id":1}"#, None, &dir)
+        .expect_err("cycle should be rejected");
+    assert!(err.to_string().contains("cycle"));
+}
+
+#[test]
+fn branch_path_must_stay_under_base_dir() {
+    let dir = unique_temp_dir("branch-base");
+    let outside = unique_temp_dir("branch-outside");
+    let outside_rule = outside.join("outside.yaml");
+    fs::write(
+        &outside_rule,
+        r#"version: 2
+input:
+  format: json
+  json: {}
+mappings: []
+"#,
+    )
+    .expect("write outside rule");
+    let rule = parse_rule_file(&format!(
+        r#"version: 2
+input:
+  format: json
+  json: {{}}
+steps:
+  - branch:
+      when: {{ eq: [1, 1] }}
+      then: {}
+"#,
+        outside_rule.display()
+    ))
+    .expect("parse");
+    let err = transform_with_base_dir(&rule, r#"{"id":1}"#, None, &dir)
+        .expect_err("outside branch should be rejected");
+    assert!(err.to_string().contains("base directory"));
+}
+
+#[test]
+fn nested_branch_can_reference_parent_within_base_dir() {
+    let dir = unique_temp_dir("branch-nested-parent");
+    let subdir = dir.join("sub");
+    fs::create_dir_all(&subdir).expect("create subdir");
+    let main_rule = dir.join("main.yaml");
+    let child_rule = subdir.join("child.yaml");
+    let common_rule = dir.join("common.yaml");
+    fs::write(
+        &main_rule,
+        r#"version: 2
+input:
+  format: json
+  json: {}
+steps:
+  - branch:
+      when: { eq: [1, 1] }
+      then: sub/child.yaml
+      return: true
+"#,
+    )
+    .expect("write main");
+    fs::write(
+        &child_rule,
+        r#"version: 2
+input:
+  format: json
+  json: {}
+steps:
+  - branch:
+      when: { eq: [1, 1] }
+      then: ../common.yaml
+      return: true
+"#,
+    )
+    .expect("write child");
+    fs::write(
+        &common_rule,
+        r#"version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: ok
+    value: true
+"#,
+    )
+    .expect("write common");
+    let rule = parse_rule_file(&fs::read_to_string(&main_rule).expect("read main")).expect("parse");
+    let output =
+        transform_with_base_dir(&rule, r#"{"id":1}"#, None, &dir).expect("nested branch succeeds");
+    assert_eq!(output, serde_json::json!([{ "ok": true }]));
+}

--- a/crates/rulemorph/tests/dto_security.rs
+++ b/crates/rulemorph/tests/dto_security.rs
@@ -1,0 +1,47 @@
+use rulemorph::{DtoLanguage, generate_dto, parse_rule_file};
+
+fn malicious_rule() -> rulemorph::RuleFile {
+    parse_rule_file(
+        r#"version: 1
+input:
+  format: json
+  json: {}
+mappings:
+  - target: '["bad\"key"]'
+    value: "x"
+  - target: "['tick`key']"
+    value: "x"
+  - target: "['bad*/key']"
+    value: "x"
+"#,
+    )
+    .expect("parse rule")
+}
+
+#[test]
+fn dto_generation_sanitizes_type_name_and_escapes_json_keys() {
+    let rule = malicious_rule();
+    for language in [
+        DtoLanguage::Rust,
+        DtoLanguage::TypeScript,
+        DtoLanguage::Python,
+        DtoLanguage::Go,
+        DtoLanguage::Java,
+        DtoLanguage::Kotlin,
+        DtoLanguage::Swift,
+    ] {
+        let output = generate_dto(&rule, language, Some("Record { hacked"))
+            .expect("generate dto should not fail");
+        assert!(!output.contains("Record { hacked"));
+        assert!(!output.contains("bad*/key */"));
+    }
+
+    let rust =
+        generate_dto(&rule, DtoLanguage::Rust, Some("Record { hacked")).expect("generate rust dto");
+    assert!(rust.contains(r#"rename = "bad\"key""#));
+
+    let go =
+        generate_dto(&rule, DtoLanguage::Go, Some("Record { hacked")).expect("generate go dto");
+    assert!(go.contains(r#""json:\"bad\\\"key\"""#));
+    assert!(go.contains(r#""json:\"tick`key\"""#));
+}

--- a/crates/rulemorph_endpoint/src/endpoint_engine.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -39,6 +39,7 @@ const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
 const DEFAULT_MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const MULTIPART_IMPORT_MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 const MULTIPART_IMPORT_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+const MULTIPART_IMPORT_MAX_ENTRIES: usize = 4096;
 use uuid::Uuid;
 
 use crate::ssrf::{ResolvedSsrTarget, resolve_ssrf_target};
@@ -448,7 +449,7 @@ impl EndpointEngine {
             .endpoint_rule
             .match_endpoint(&method, &path)
             .ok_or_else(|| anyhow!("no endpoint matched"))?;
-        let is_multipart = is_multipart_form_data(&parts.headers);
+        let is_multipart = is_multipart_import_request(&method, &path, &parts.headers);
         let body_limit = if is_multipart {
             MULTIPART_IMPORT_MAX_TOTAL_BYTES as usize
         } else {
@@ -2091,6 +2092,10 @@ fn is_multipart_form_data(headers: &HeaderMap) -> bool {
         .is_some_and(|value| multer::parse_boundary(value).is_ok())
 }
 
+fn is_multipart_import_request(method: &Method, path: &str, headers: &HeaderMap) -> bool {
+    method == Method::POST && path == "/api/import" && is_multipart_form_data(headers)
+}
+
 async fn build_multipart_import_body(
     headers: &HeaderMap,
     body_bytes: Bytes,
@@ -2152,6 +2157,10 @@ fn extract_zip(path: &Path, dest: &Path) -> Result<(), String> {
     let mut archive = ZipArchive::new(file).map_err(|err| format!("invalid zip: {}", err))?;
     let mut total_bytes: u64 = 0;
 
+    if archive.len() > MULTIPART_IMPORT_MAX_ENTRIES {
+        return Err("zip has too many entries".to_string());
+    }
+
     for i in 0..archive.len() {
         let mut entry = archive
             .by_index(i)
@@ -2192,10 +2201,38 @@ fn extract_zip(path: &Path, dest: &Path) -> Result<(), String> {
             .create_new(true)
             .open(&out_path)
             .map_err(|err| format!("failed to create file: {}", err))?;
-        std::io::copy(&mut entry, &mut outfile)
-            .map_err(|err| format!("failed to write file: {}", err))?;
+        let copied =
+            copy_zip_entry_bounded(&mut entry, &mut outfile, MULTIPART_IMPORT_MAX_FILE_BYTES)
+                .map_err(|err| format!("failed to write file: {}", err))?;
+        total_bytes = total_bytes.saturating_sub(size).saturating_add(copied);
+        if copied > MULTIPART_IMPORT_MAX_FILE_BYTES {
+            return Err(format!("zip entry too large: {}", name));
+        }
+        if total_bytes > MULTIPART_IMPORT_MAX_TOTAL_BYTES {
+            return Err("zip exceeds max total bytes".to_string());
+        }
     }
     Ok(())
+}
+
+fn copy_zip_entry_bounded<R: Read, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    max_bytes: u64,
+) -> std::io::Result<u64> {
+    let mut copied = 0u64;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(copied);
+        }
+        copied = copied.saturating_add(read as u64);
+        if copied > max_bytes {
+            return Ok(copied);
+        }
+        writer.write_all(&buffer[..read])?;
+    }
 }
 
 fn resolve_bundle_root(base: &Path) -> Result<PathBuf, EndpointError> {
@@ -4082,6 +4119,35 @@ mod tests {
     }
 
     #[test]
+    fn zip_copy_stops_after_file_limit() {
+        let mut input = std::io::Cursor::new(vec![b'x'; 12]);
+        let mut output = Vec::new();
+        let copied = copy_zip_entry_bounded(&mut input, &mut output, 8).expect("copy");
+        assert_eq!(copied, 12);
+        assert!(output.len() <= 8);
+    }
+
+    #[test]
+    fn zip_extract_rejects_too_many_entries() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let zip_path = temp.path().join("bundle.zip");
+        let file = File::create(&zip_path).expect("create zip");
+        let mut zip_writer = zip::ZipWriter::new(file);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        for index in 0..=MULTIPART_IMPORT_MAX_ENTRIES {
+            zip_writer
+                .start_file(format!("rules/{index}.yaml"), options)
+                .expect("start file");
+        }
+        zip_writer.finish().expect("finish zip");
+
+        let err = extract_zip(&zip_path, temp.path().join("out").as_path())
+            .expect_err("zip should be rejected");
+        assert!(err.contains("too many entries"));
+    }
+
+    #[test]
     fn compile_retry_defaults_to_none() {
         let retry = compile_retry(None).unwrap();
         assert!(retry.is_none());
@@ -5542,6 +5608,48 @@ endpoints:
             .await
             .expect_err("handle request should fail");
         assert!(err.to_string().contains("missing bundle file"));
+    }
+
+    #[tokio::test]
+    async fn multipart_body_is_only_import_special_case() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let rules_dir = temp.path();
+        std::fs::write(
+            rules_dir.join("endpoint.yaml"),
+            r#"
+version: 2
+type: endpoint
+endpoints:
+  - method: GET
+    path: /api/traces
+    steps: []
+    reply:
+      status: 200
+      body: "@input"
+"#,
+        )
+        .expect("write endpoint.yaml");
+        let engine = EndpointEngine::load(
+            rules_dir.to_path_buf(),
+            EngineConfig::new("http://127.0.0.1:8080".to_string(), rules_dir.join(".data")),
+        )
+        .expect("load engine");
+        let (boundary, body) = build_multipart_zip_body();
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/traces")
+            .header(
+                axum::http::header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(axum::body::Body::from(body))
+            .expect("request");
+
+        let err = engine
+            .handle_request(request)
+            .await
+            .expect_err("multipart should not be parsed on non-import endpoints");
+        assert!(!err.to_string().contains("missing bundle file"));
     }
 
     fn build_multipart_zip_body() -> (String, Vec<u8>) {

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -2055,7 +2055,7 @@ fn absolute_clean_path(path: &Path) -> Result<PathBuf, String> {
         match component {
             std::path::Component::Prefix(prefix) => clean.push(prefix.as_os_str()),
             std::path::Component::RootDir => {
-                clean.push(std::path::MAIN_SEPARATOR.to_string());
+                push_root_dir(&mut clean);
             }
             std::path::Component::CurDir => {}
             std::path::Component::ParentDir => {
@@ -2067,6 +2067,22 @@ fn absolute_clean_path(path: &Path) -> Result<PathBuf, String> {
         }
     }
     Ok(clean)
+}
+
+fn push_root_dir(clean: &mut PathBuf) {
+    #[cfg(windows)]
+    {
+        if matches!(
+            clean.components().next(),
+            Some(std::path::Component::Prefix(_))
+        ) {
+            let mut rooted = clean.as_os_str().to_os_string();
+            rooted.push(std::path::MAIN_SEPARATOR.to_string());
+            *clean = PathBuf::from(rooted);
+            return;
+        }
+    }
+    clean.push(std::path::MAIN_SEPARATOR.to_string());
 }
 
 fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf, String> {
@@ -2112,9 +2128,11 @@ fn allowed_roots() -> Result<Vec<PathBuf>, String> {
             return Ok(roots);
         }
     }
-    std::env::current_dir()
-        .map(|path| vec![path])
-        .map_err(|err| format!("failed to resolve current directory: {}", err))
+    let cwd = std::env::current_dir()
+        .map_err(|err| format!("failed to read current directory: {}", err))?
+        .canonicalize()
+        .map_err(|err| format!("failed to resolve current directory: {}", err))?;
+    Ok(vec![cwd])
 }
 
 fn allow_any_path() -> bool {
@@ -4956,5 +4974,58 @@ fn transform_kind_to_str(kind: &TransformErrorKind) -> &'static str {
         TransformErrorKind::TypeCastFailed => "TypeCastFailed",
         TransformErrorKind::ExprError => "ExprError",
         TransformErrorKind::AssertionFailed => "AssertionFailed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn allowed_roots_fallback_uses_canonical_current_dir() {
+        let _guard = env_lock();
+        let previous_cwd = std::env::current_dir().expect("current dir");
+        let previous_allowed_roots = std::env::var_os("RULEMORPH_MCP_ALLOWED_ROOTS");
+        let previous_allow_any = std::env::var_os("RULEMORPH_MCP_ALLOW_ANY_PATH");
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        unsafe {
+            std::env::remove_var("RULEMORPH_MCP_ALLOWED_ROOTS");
+            std::env::remove_var("RULEMORPH_MCP_ALLOW_ANY_PATH");
+        }
+        std::env::set_current_dir(temp.path()).expect("set current dir");
+
+        let roots = allowed_roots().expect("allowed roots");
+        assert_eq!(
+            roots,
+            vec![temp.path().canonicalize().expect("canonical temp")]
+        );
+
+        std::env::set_current_dir(previous_cwd).expect("restore current dir");
+        unsafe {
+            match previous_allowed_roots {
+                Some(value) => std::env::set_var("RULEMORPH_MCP_ALLOWED_ROOTS", value),
+                None => std::env::remove_var("RULEMORPH_MCP_ALLOWED_ROOTS"),
+            }
+            match previous_allow_any {
+                Some(value) => std::env::set_var("RULEMORPH_MCP_ALLOW_ANY_PATH", value),
+                None => std::env::remove_var("RULEMORPH_MCP_ALLOW_ANY_PATH"),
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn absolute_clean_path_preserves_windows_drive_root() {
+        let path = Path::new(r"C:\work\..\allowed\out.json");
+        let clean = absolute_clean_path(path).expect("clean path");
+
+        assert_eq!(clean, PathBuf::from(r"C:\allowed\out.json"));
     }
 }

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use csv::ReaderBuilder;
 use rulemorph::{
@@ -820,28 +820,21 @@ fn run_transform_tool(args: &Map<String, Value>) -> Result<Value, CallError> {
         ));
     }
 
-    let (mut rule, yaml) = load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
-    let base_dir = rules_path.as_deref().and_then(|path| {
-        let parent = Path::new(path).parent()?;
-        if parent.as_os_str().is_empty() {
-            None
-        } else {
-            Some(parent.to_path_buf())
-        }
-    });
+    let (mut rule, yaml, base_dir) =
+        load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
+    if rules_text.is_some() && rule_has_file_branch(&rule) {
+        return Err(CallError::InvalidParams(
+            "rules_text cannot use branch file references; use rules_path under an allowed root"
+                .to_string(),
+        ));
+    }
 
     let input = match (
         input_path.as_deref(),
         input_text.as_deref(),
         input_json.as_ref(),
     ) {
-        (Some(path), None, None) => fs::read_to_string(path).map_err(|err| {
-            let message = format!("failed to read input: {}", err);
-            CallError::Tool {
-                message: message.clone(),
-                errors: Some(vec![io_error_json(&message, Some(path))]),
-            }
-        })?,
+        (Some(path), None, None) => read_allowed_to_string(path, "input")?,
         (None, Some(text), None) => text.to_string(),
         (None, None, Some(value)) => serde_json::to_string(value).map_err(|err| {
             let message = format!("failed to serialize input JSON: {}", err);
@@ -859,13 +852,7 @@ fn run_transform_tool(args: &Map<String, Value>) -> Result<Value, CallError> {
 
     let context_value = match (context_path.as_deref(), context_json.as_ref()) {
         (Some(path), None) => {
-            let data = fs::read_to_string(path).map_err(|err| {
-                let message = format!("failed to read context: {}", err);
-                CallError::Tool {
-                    message: message.clone(),
-                    errors: Some(vec![io_error_json(&message, Some(path))]),
-                }
-            })?;
+            let data = read_allowed_to_string(path, "context")?;
             Some(serde_json::from_str(&data).map_err(|err| {
                 let message = format!("failed to parse context JSON: {}", err);
                 CallError::Tool {
@@ -927,7 +914,7 @@ fn run_transform_tool(args: &Map<String, Value>) -> Result<Value, CallError> {
     };
 
     if let Some(path) = output_path.as_deref() {
-        write_output(path, &output_text).map_err(|err| {
+        write_allowed_output(path, &output_text).map_err(|err| {
             let message = err;
             CallError::Tool {
                 message: message.clone(),
@@ -1009,7 +996,7 @@ fn run_validate_rules_tool(args: &Map<String, Value>) -> Result<Value, CallError
         ));
     }
 
-    let (rule, yaml) = load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
+    let (rule, yaml, _) = load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
     match validate_rule_file_with_source(&rule, &yaml) {
         Ok(_) => {
             let warnings = collect_rule_warnings(&rule);
@@ -1068,7 +1055,7 @@ fn run_generate_dto_tool(args: &Map<String, Value>) -> Result<Value, CallError> 
         language.ok_or_else(|| CallError::InvalidParams("language is required".to_string()))?;
     let language = parse_dto_language(&language).map_err(CallError::InvalidParams)?;
 
-    let (rule, _) = load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
+    let (rule, _, _) = load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
     let dto = generate_dto(&rule, language, name.as_deref()).map_err(|err| {
         let message = format!("failed to generate dto: {}", err);
         CallError::Tool {
@@ -1346,13 +1333,7 @@ fn run_analyze_input_tool(args: &Map<String, Value>) -> Result<Value, CallError>
     }
 
     let input_text = match (input_path.as_deref(), input_text.as_deref()) {
-        (Some(path), None) => fs::read_to_string(path).map_err(|err| {
-            let message = format!("failed to read input: {}", err);
-            CallError::Tool {
-                message: message.clone(),
-                errors: Some(vec![io_error_json(&message, Some(path))]),
-            }
-        })?,
+        (Some(path), None) => read_allowed_to_string(path, "input")?,
         (None, Some(text)) => text.to_string(),
         (None, None) => String::new(),
         _ => {
@@ -1467,7 +1448,7 @@ fn run_generate_rules_from_base_tool(args: &Map<String, Value>) -> Result<Value,
         ));
     }
 
-    let (rule, yaml) = load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
+    let (rule, yaml, _) = load_rule_from_source(rules_path.as_deref(), rules_text.as_deref())?;
     let mut yaml_value: YamlValue = serde_yaml::from_str(&yaml).map_err(|err| {
         let message = format!("failed to parse rules yaml: {}", err);
         CallError::Tool {
@@ -1477,13 +1458,7 @@ fn run_generate_rules_from_base_tool(args: &Map<String, Value>) -> Result<Value,
     })?;
 
     let input_text = match (input_path.as_deref(), input_text.as_deref()) {
-        (Some(path), None) => fs::read_to_string(path).map_err(|err| {
-            let message = format!("failed to read input: {}", err);
-            CallError::Tool {
-                message: message.clone(),
-                errors: Some(vec![io_error_json(&message, Some(path))]),
-            }
-        })?,
+        (Some(path), None) => read_allowed_to_string(path, "input")?,
         (None, Some(text)) => text.to_string(),
         (None, None) => String::new(),
         _ => {
@@ -1717,13 +1692,7 @@ fn run_generate_rules_from_dto_tool(args: &Map<String, Value>) -> Result<Value, 
     }
 
     let input_text = match (input_path.as_deref(), input_text.as_deref()) {
-        (Some(path), None) => fs::read_to_string(path).map_err(|err| {
-            let message = format!("failed to read input: {}", err);
-            CallError::Tool {
-                message: message.clone(),
-                errors: Some(vec![io_error_json(&message, Some(path))]),
-            }
-        })?,
+        (Some(path), None) => read_allowed_to_string(path, "input")?,
         (None, Some(text)) => text.to_string(),
         (None, None) => String::new(),
         _ => {
@@ -1974,16 +1943,10 @@ fn get_optional_object(args: &Map<String, Value>, key: &str) -> Result<Option<Va
 fn load_rule_from_source(
     rules_path: Option<&str>,
     rules_text: Option<&str>,
-) -> Result<(RuleFile, String), CallError> {
+) -> Result<(RuleFile, String, Option<PathBuf>), CallError> {
     match (rules_path, rules_text) {
         (Some(path), None) => {
-            let yaml = fs::read_to_string(path).map_err(|err| {
-                let message = format!("failed to read rules: {}", err);
-                CallError::Tool {
-                    message: message.clone(),
-                    errors: Some(vec![io_error_json(&message, Some(path))]),
-                }
-            })?;
+            let (resolved_path, yaml) = read_allowed_file(path, "rules")?;
             let rule = parse_rule_file(&yaml).map_err(|err| {
                 let message = format!("failed to parse rules: {}", err);
                 CallError::Tool {
@@ -1991,7 +1954,8 @@ fn load_rule_from_source(
                     errors: Some(vec![parse_error_json(&message, Some(path))]),
                 }
             })?;
-            Ok((rule, yaml))
+            let base_dir = resolved_path.parent().map(Path::to_path_buf);
+            Ok((rule, yaml, base_dir))
         }
         (None, Some(text)) => {
             let rule = parse_rule_file(text).map_err(|err| {
@@ -2001,12 +1965,161 @@ fn load_rule_from_source(
                     errors: Some(vec![parse_error_json(&message, None)]),
                 }
             })?;
-            Ok((rule, text.to_string()))
+            Ok((rule, text.to_string(), None))
         }
         _ => Err(CallError::InvalidParams(
             "rules_path or rules_text is required".to_string(),
         )),
     }
+}
+
+fn read_allowed_to_string(path: &str, label: &str) -> Result<String, CallError> {
+    read_allowed_file(path, label).map(|(_, data)| data)
+}
+
+fn read_allowed_file(path: &str, label: &str) -> Result<(PathBuf, String), CallError> {
+    let path = allowed_existing_path(path).map_err(|err| {
+        let message = format!("failed to read {}: {}", label, err);
+        CallError::Tool {
+            message: message.clone(),
+            errors: Some(vec![io_error_json(&message, Some(path))]),
+        }
+    })?;
+    let data = fs::read_to_string(&path).map_err(|err| {
+        let message = format!("failed to read {}: {}", label, err);
+        CallError::Tool {
+            message: message.clone(),
+            errors: Some(vec![io_error_json(
+                &message,
+                Some(path.to_string_lossy().as_ref()),
+            )]),
+        }
+    })?;
+    Ok((path, data))
+}
+
+fn rule_has_file_branch(rule: &RuleFile) -> bool {
+    rule.steps
+        .as_ref()
+        .is_some_and(|steps| steps.iter().any(|step| step.branch.is_some()))
+}
+
+fn write_allowed_output(path: &str, output: &str) -> Result<(), String> {
+    let path = Path::new(path);
+    ensure_allowed_output_path(path)?;
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|err| format!("failed to create output directory: {}", err))?;
+        }
+    }
+    fs::write(path, output.as_bytes()).map_err(|err| format!("failed to write output: {}", err))
+}
+
+fn allowed_existing_path(path: &str) -> Result<PathBuf, String> {
+    let path = Path::new(path);
+    let canonical = path
+        .canonicalize()
+        .map_err(|err| format!("failed to resolve path: {}", err))?;
+    ensure_allowed_canonical_path(&canonical)?;
+    Ok(canonical)
+}
+
+fn ensure_allowed_output_path(path: &Path) -> Result<(), String> {
+    let path = absolute_clean_path(path)?;
+    if path.exists() {
+        let check_path = path
+            .canonicalize()
+            .map_err(|err| format!("failed to resolve output path: {}", err))?;
+        ensure_allowed_canonical_path(&check_path)
+    } else {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let ancestor = nearest_existing_ancestor(parent)?;
+        let check_path = ancestor
+            .canonicalize()
+            .map_err(|err| format!("failed to resolve output directory: {}", err))?;
+        ensure_allowed_canonical_path(&check_path)
+    }
+}
+
+fn absolute_clean_path(path: &Path) -> Result<PathBuf, String> {
+    let mut clean = if path.is_absolute() {
+        PathBuf::new()
+    } else {
+        std::env::current_dir()
+            .map_err(|err| format!("failed to read current directory: {}", err))?
+            .canonicalize()
+            .map_err(|err| format!("failed to resolve current directory: {}", err))?
+    };
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => clean.push(prefix.as_os_str()),
+            std::path::Component::RootDir => {
+                clean.push(std::path::MAIN_SEPARATOR.to_string());
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !clean.pop() {
+                    return Err("output path escapes filesystem root".to_string());
+                }
+            }
+            std::path::Component::Normal(value) => clean.push(value),
+        }
+    }
+    Ok(clean)
+}
+
+fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf, String> {
+    let mut ancestor = path.to_path_buf();
+    loop {
+        if ancestor.exists() {
+            return Ok(ancestor);
+        }
+        if !ancestor.pop() {
+            return Err("failed to find existing output directory ancestor".to_string());
+        }
+    }
+}
+
+fn ensure_allowed_canonical_path(path: &Path) -> Result<(), String> {
+    if allow_any_path() {
+        return Ok(());
+    }
+    let roots = allowed_roots()?;
+    if roots.iter().any(|root| path.starts_with(root)) {
+        return Ok(());
+    }
+    Err(format!(
+        "path is outside MCP allowed roots: {}",
+        path.display()
+    ))
+}
+
+fn allowed_roots() -> Result<Vec<PathBuf>, String> {
+    if let Some(raw) = std::env::var_os("RULEMORPH_MCP_ALLOWED_ROOTS") {
+        let roots = std::env::split_paths(&raw)
+            .map(|path| {
+                path.canonicalize().map_err(|err| {
+                    format!(
+                        "failed to resolve MCP allowed root {}: {}",
+                        path.display(),
+                        err
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if !roots.is_empty() {
+            return Ok(roots);
+        }
+    }
+    std::env::current_dir()
+        .map(|path| vec![path])
+        .map_err(|err| format!("failed to resolve current directory: {}", err))
+}
+
+fn allow_any_path() -> bool {
+    std::env::var("RULEMORPH_MCP_ALLOW_ANY_PATH")
+        .is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
 }
 
 fn parse_dto_language(value: &str) -> Result<DtoLanguage, String> {
@@ -4560,17 +4673,6 @@ fn apply_format_override(rule: &mut RuleFile, format: Option<&str>) -> Result<()
         _ => return Err(format!("unknown format: {}", format)),
     };
     Ok(())
-}
-
-fn write_output(path: &str, output: &str) -> Result<(), String> {
-    let path = std::path::Path::new(path);
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent)
-                .map_err(|err| format!("failed to create output directory: {}", err))?;
-        }
-    }
-    fs::write(path, output.as_bytes()).map_err(|err| format!("failed to write output: {}", err))
 }
 
 fn transform_to_ndjson(

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -16,6 +16,27 @@ impl McpServer {
     fn start() -> Self {
         let bin = env!("CARGO_BIN_EXE_rulemorph-mcp");
         let mut child = Command::new(bin)
+            .env("RULEMORPH_MCP_ALLOW_ANY_PATH", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn mcp server");
+
+        let stdin = child.stdin.take().expect("take stdin");
+        let stdout = child.stdout.take().expect("take stdout");
+
+        Self {
+            child,
+            stdin: Some(stdin),
+            stdout: BufReader::new(stdout),
+        }
+    }
+
+    fn start_with_allowed_root(root: &std::path::Path) -> Self {
+        let bin = env!("CARGO_BIN_EXE_rulemorph-mcp");
+        let mut child = Command::new(bin)
+            .env("RULEMORPH_MCP_ALLOWED_ROOTS", root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
@@ -142,6 +163,123 @@ mappings:
     assert_eq!(output, json!([{ "id": 1 }]));
     assert!(response["result"]["isError"].is_null() || response["result"]["isError"] == false);
 
+    server.shutdown();
+}
+
+#[test]
+fn transform_rejects_paths_outside_allowed_root() {
+    let allowed = tempdir().expect("allowed temp dir");
+    let outside = tempdir().expect("outside temp dir");
+    let rules_path = outside.path().join("rules.yaml");
+    let input_path = outside.path().join("input.json");
+
+    fs::write(
+        &rules_path,
+        r#"version: 1
+input:
+  format: json
+  json: {}
+mappings: []
+"#,
+    )
+    .expect("write rules");
+    fs::write(&input_path, r#"{"id": 1}"#).expect("write input");
+
+    let mut server = McpServer::start_with_allowed_root(allowed.path());
+    initialize(&mut server);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 30,
+        "method": "tools/call",
+        "params": {
+            "name": "transform",
+            "arguments": {
+                "rules_path": rules_path.to_string_lossy(),
+                "input_path": input_path.to_string_lossy()
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    let message = response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("error text");
+    assert!(message.contains("outside MCP allowed roots"));
+    server.shutdown();
+}
+
+#[test]
+fn transform_allows_new_output_directory_inside_allowed_root() {
+    let dir = tempdir().expect("allowed temp dir");
+    let rules_path = dir.path().join("rules.yaml");
+    let input_path = dir.path().join("input.json");
+    let output_path = dir.path().join("new").join("out.json");
+
+    fs::write(
+        &rules_path,
+        r#"version: 1
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "id"
+    source: "id"
+"#,
+    )
+    .expect("write rules");
+    fs::write(&input_path, r#"{"id": 1}"#).expect("write input");
+
+    let mut server = McpServer::start_with_allowed_root(dir.path());
+    initialize(&mut server);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 31,
+        "method": "tools/call",
+        "params": {
+            "name": "transform",
+            "arguments": {
+                "rules_path": rules_path.to_string_lossy(),
+                "input_path": input_path.to_string_lossy(),
+                "output_path": output_path.to_string_lossy()
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    assert!(response["result"]["isError"].is_null() || response["result"]["isError"] == false);
+    let output_file = fs::read_to_string(&output_path).expect("read output file");
+    let output: Value = serde_json::from_str(&output_file).expect("output json");
+    assert_eq!(output, json!([{ "id": 1 }]));
+    server.shutdown();
+}
+
+#[test]
+fn transform_rejects_rules_text_file_branch() {
+    let dir = tempdir().expect("allowed temp dir");
+    let mut server = McpServer::start_with_allowed_root(dir.path());
+    initialize(&mut server);
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 32,
+        "method": "tools/call",
+        "params": {
+            "name": "transform",
+            "arguments": {
+                "rules_text": "version: 2\ninput:\n  format: json\n  json: {}\nsteps:\n  - branch:\n      when: { eq: [1, 1] }\n      then: /tmp/outside.yaml\n",
+                "input_json": { "id": 1 }
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    assert_eq!(response["error"]["code"], -32602);
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("rules_text cannot use branch")
+    );
     server.shutdown();
 }
 

--- a/crates/rulemorph_server/src/api_keys.rs
+++ b/crates/rulemorph_server/src/api_keys.rs
@@ -1,6 +1,8 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -19,6 +21,12 @@ const SECRET_BYTES: usize = 32;
 const SALT_BYTES: usize = 16;
 const ID_BYTES: usize = 12;
 const PREFIX_VISIBLE_CHARS: usize = 8;
+const API_KEY_LOCK_STALE_AFTER: Duration = Duration::from_secs(300);
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ApiKeyRecord {
@@ -140,6 +148,12 @@ impl ApiKeyStore {
     }
 
     pub fn issue(&mut self, label: Option<String>) -> Result<ApiKeyIssueResult> {
+        let _lock = ApiKeyFileLock::acquire(&self.path)?;
+        self.reload_or_keep()?;
+        self.issue_unlocked(label)
+    }
+
+    fn issue_unlocked(&mut self, label: Option<String>) -> Result<ApiKeyIssueResult> {
         let secret = random_base64(SECRET_BYTES);
         let key = format!("{}{}.{}", API_KEY_PREFIX, self.tenant_id, secret);
         let created_at = now_rfc3339();
@@ -162,7 +176,7 @@ impl ApiKeyStore {
             revoked_at: None,
             label: label.clone(),
         });
-        self.save()?;
+        self.save_unlocked()?;
         Ok(ApiKeyIssueResult {
             id,
             key,
@@ -186,6 +200,12 @@ impl ApiKeyStore {
     }
 
     pub fn revoke(&mut self, id: &str) -> Result<bool> {
+        let _lock = ApiKeyFileLock::acquire(&self.path)?;
+        self.reload_or_keep()?;
+        self.revoke_unlocked(id)
+    }
+
+    fn revoke_unlocked(&mut self, id: &str) -> Result<bool> {
         let mut updated = false;
         let now = now_rfc3339();
         for record in &mut self.keys {
@@ -195,17 +215,19 @@ impl ApiKeyStore {
             }
         }
         if updated {
-            self.save()?;
+            self.save_unlocked()?;
         }
         Ok(updated)
     }
 
     pub fn rotate(&mut self, id: &str, label: Option<String>) -> Result<Option<ApiKeyIssueResult>> {
-        let revoked = self.revoke(id)?;
+        let _lock = ApiKeyFileLock::acquire(&self.path)?;
+        self.reload_or_keep()?;
+        let revoked = self.revoke_unlocked(id)?;
         if !revoked {
             return Ok(None);
         }
-        let issued = self.issue(label)?;
+        let issued = self.issue_unlocked(label)?;
         Ok(Some(issued))
     }
 
@@ -224,7 +246,16 @@ impl ApiKeyStore {
             .any(|record| record.hash == hash && record.revoked_at.is_none()))
     }
 
-    fn save(&self) -> Result<()> {
+    fn reload_or_keep(&mut self) -> Result<()> {
+        let Some(existing) = Self::load(self.path.clone(), &self.tenant_id)? else {
+            return Ok(());
+        };
+        self.salt = existing.salt;
+        self.keys = existing.keys;
+        Ok(())
+    }
+
+    fn save_unlocked(&self) -> Result<()> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("failed to create api key dir: {}", parent.display()))?;
@@ -249,6 +280,118 @@ impl ApiKeyStore {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+}
+
+struct ApiKeyFileLock {
+    path: PathBuf,
+}
+
+impl ApiKeyFileLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        let lock_path = lock_path(path);
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create api key lock dir: {}", parent.display())
+            })?;
+        }
+        let mut last_err = None;
+        for _ in 0..250 {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path)
+            {
+                Ok(mut handle) => {
+                    writeln!(handle, "{}", std::process::id()).ok();
+                    return Ok(Self { path: lock_path });
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if remove_stale_lock_if_needed(&lock_path)? {
+                        continue;
+                    }
+                    last_err = Some(err);
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(err) => {
+                    return Err(err).with_context(|| {
+                        format!("failed to create api key lock: {}", lock_path.display())
+                    });
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "api key lock timeout")
+        }))
+        .with_context(|| {
+            format!(
+                "timed out waiting for api key lock: {}",
+                lock_path.display()
+            )
+        })
+    }
+}
+
+fn remove_stale_lock_if_needed(path: &Path) -> Result<bool> {
+    match fs::read_to_string(path) {
+        Ok(contents) => {
+            if let Ok(pid) = contents.trim().parse::<u32>() {
+                if pid != std::process::id() && !process_is_running(pid) {
+                    remove_lock_file(path)?;
+                    return Ok(true);
+                }
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(_) => {}
+    }
+
+    let is_old = fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|age| age >= API_KEY_LOCK_STALE_AFTER);
+    if is_old {
+        remove_lock_file(path)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn remove_lock_file(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => {
+            Err(err).with_context(|| format!("failed to remove stale lock: {}", path.display()))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    let rc = unsafe { kill(pid, 0) };
+    if rc == 0 {
+        return true;
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(1) => true,
+        Some(3) => false,
+        _ => true,
+    }
+}
+
+#[cfg(not(unix))]
+fn process_is_running(_pid: u32) -> bool {
+    true
+}
+
+impl Drop for ApiKeyFileLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
     }
 }
 
@@ -279,6 +422,14 @@ fn tmp_path(path: &Path) -> PathBuf {
     let suffix = random_base64(6);
     let tmp_name = format!("{}.tmp-{}", file_name, suffix);
     path.with_file_name(tmp_name)
+}
+
+fn lock_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("api_keys.json");
+    path.with_file_name(format!("{}.lock", file_name))
 }
 
 fn replace_file(temp_path: &Path, target_path: &Path) -> Result<()> {
@@ -341,10 +492,12 @@ fn hex_encode(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use anyhow::Result;
     use tempfile::tempdir;
 
-    use super::ApiKeyStore;
+    use super::{ApiKeyStore, lock_path};
 
     #[test]
     fn api_key_store_persists_multiple_updates() -> Result<()> {
@@ -370,6 +523,44 @@ mod tests {
         assert!(!final_store.verify(&first.key)?);
         assert!(!final_store.verify(&second.key)?);
         assert!(final_store.verify(&rotated.key)?);
+        Ok(())
+    }
+
+    #[test]
+    fn stale_store_save_does_not_resurrect_revoked_key() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("api_keys.json");
+        let tenant_id = "tenant-a";
+
+        let mut first_writer = ApiKeyStore::load_or_init(path.clone(), tenant_id)?;
+        let first = first_writer.issue(Some("first".to_string()))?;
+
+        let mut stale_writer =
+            ApiKeyStore::load(path.clone(), tenant_id)?.expect("api key store should exist");
+        let mut revoker =
+            ApiKeyStore::load(path.clone(), tenant_id)?.expect("api key store should exist");
+        assert!(revoker.revoke(&first.id)?);
+
+        let second = stale_writer.issue(Some("second".to_string()))?;
+        let final_store = ApiKeyStore::load(path, tenant_id)?.expect("api key store should exist");
+        assert!(!final_store.verify(&first.key)?);
+        assert!(final_store.verify(&second.key)?);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dead_process_lock_file_is_recovered() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("api_keys.json");
+        let tenant_id = "tenant-a";
+        fs::write(lock_path(&path), "999999\n")?;
+
+        let mut store = ApiKeyStore::load_or_init(path.clone(), tenant_id)?;
+        let issued = store.issue(Some("first".to_string()))?;
+
+        let final_store = ApiKeyStore::load(path, tenant_id)?.expect("api key store should exist");
+        assert!(final_store.verify(&issued.key)?);
         Ok(())
     }
 }

--- a/crates/rulemorph_server/src/server.rs
+++ b/crates/rulemorph_server/src/server.rs
@@ -1,5 +1,5 @@
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
@@ -18,7 +18,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::hash::{Hash, Hasher};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, OnceCell, broadcast};
 use tokio_stream::{StreamExt, wrappers::BroadcastStream};
@@ -112,6 +111,7 @@ struct RateLimitState {
 
 const IMPORT_ZIP_MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 const IMPORT_ZIP_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+const IMPORT_ZIP_MAX_ENTRIES: usize = 4096;
 static API_KEY_FILE_LOCKS: OnceLock<StdMutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
 
 fn api_key_file_lock(path: &Path) -> Arc<Mutex<()>> {
@@ -718,7 +718,7 @@ fn ensure_internal_auth(
     headers: &HeaderMap,
 ) -> std::result::Result<(), ApiError> {
     let Some(expected) = state.internal_api_key.as_deref() else {
-        if state.allow_unauth_internal {
+        if state.allow_unauth_internal && state.tenant_resolver.is_none() {
             return Ok(());
         }
         return Err(ApiError::service_unavailable(
@@ -830,9 +830,6 @@ async fn pre_auth_rate_limit(
 }
 
 fn pre_auth_rate_limit_key(request: &Request<axum::body::Body>) -> String {
-    if let Some(api_key) = extract_api_key(request.headers()) {
-        return format!("preauth:key:{:x}", hash_string(&api_key));
-    }
     if let Some(ConnectInfo(addr)) = request
         .extensions()
         .get::<ConnectInfo<std::net::SocketAddr>>()
@@ -840,12 +837,6 @@ fn pre_auth_rate_limit_key(request: &Request<axum::body::Body>) -> String {
         return format!("preauth:ip:{}", addr.ip());
     }
     "preauth:anonymous".to_string()
-}
-
-fn hash_string(value: &str) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    value.hash(&mut hasher);
-    hasher.finish()
 }
 
 async fn enforce_api_rate_limit(
@@ -1190,6 +1181,10 @@ fn extract_zip(path: &Path, dest: &Path) -> Result<(), String> {
     let mut archive = ZipArchive::new(file).map_err(|err| format!("invalid zip: {}", err))?;
     let mut total_bytes: u64 = 0;
 
+    if archive.len() > IMPORT_ZIP_MAX_ENTRIES {
+        return Err("zip has too many entries".to_string());
+    }
+
     for i in 0..archive.len() {
         let mut entry = archive
             .by_index(i)
@@ -1232,10 +1227,37 @@ fn extract_zip(path: &Path, dest: &Path) -> Result<(), String> {
             .create_new(true)
             .open(&out_path)
             .map_err(|err| format!("failed to create file: {}", err))?;
-        std::io::copy(&mut entry, &mut outfile)
+        let copied = copy_zip_entry_bounded(&mut entry, &mut outfile, IMPORT_ZIP_MAX_FILE_BYTES)
             .map_err(|err| format!("failed to write file: {}", err))?;
+        total_bytes = total_bytes.saturating_sub(size).saturating_add(copied);
+        if copied > IMPORT_ZIP_MAX_FILE_BYTES {
+            return Err(format!("zip entry too large: {}", name));
+        }
+        if total_bytes > IMPORT_ZIP_MAX_TOTAL_BYTES {
+            return Err("zip exceeds max total bytes".to_string());
+        }
     }
     Ok(())
+}
+
+fn copy_zip_entry_bounded<R: Read, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    max_bytes: u64,
+) -> std::io::Result<u64> {
+    let mut copied = 0u64;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(copied);
+        }
+        copied = copied.saturating_add(read as u64);
+        if copied > max_bytes {
+            return Ok(copied);
+        }
+        writer.write_all(&buffer[..read])?;
+    }
 }
 
 fn resolve_bundle_root(base: &Path) -> std::result::Result<PathBuf, ApiError> {
@@ -1338,14 +1360,30 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
 
+    use async_trait::async_trait;
     use axum::extract::ConnectInfo;
     use axum::http::{HeaderValue, Request, header::AUTHORIZATION};
 
-    use super::pre_auth_rate_limit_key;
+    use crate::{TenantContext, TenantResolver};
+
+    use super::{
+        ApiMode, AppState, IMPORT_ZIP_MAX_ENTRIES, TenantResources, TraceStore, build_router,
+        copy_zip_entry_bounded, extract_zip, pre_auth_rate_limit_key,
+    };
+
+    struct StaticTenantResolver;
+
+    #[async_trait]
+    impl TenantResolver for StaticTenantResolver {
+        async fn resolve(&self, _api_key: &str) -> anyhow::Result<Option<TenantContext>> {
+            Ok(Some(TenantContext::new("tenant-a")))
+        }
+    }
 
     #[test]
-    fn pre_auth_rate_limit_uses_api_key_even_with_connect_info() {
+    fn pre_auth_rate_limit_uses_ip_even_with_api_key() {
         let mut request = Request::builder()
             .uri("/v1/traces")
             .body(axum::body::Body::empty())
@@ -1359,7 +1397,7 @@ mod tests {
             .insert(ConnectInfo(SocketAddr::from((Ipv4Addr::LOCALHOST, 3000))));
 
         let key = pre_auth_rate_limit_key(&request);
-        assert!(key.starts_with("preauth:key:"));
+        assert_eq!(key, "preauth:ip:127.0.0.1");
     }
 
     #[test]
@@ -1374,5 +1412,82 @@ mod tests {
 
         let key = pre_auth_rate_limit_key(&request);
         assert_eq!(key, "preauth:ip:127.0.0.1");
+    }
+
+    #[test]
+    fn zip_copy_stops_after_file_limit() {
+        let mut input = std::io::Cursor::new(vec![b'x'; 12]);
+        let mut output = Vec::new();
+        let copied = copy_zip_entry_bounded(&mut input, &mut output, 8).expect("copy");
+        assert_eq!(copied, 12);
+        assert!(output.len() <= 8);
+    }
+
+    #[test]
+    fn zip_extract_rejects_too_many_entries() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let zip_path = temp.path().join("bundle.zip");
+        let file = std::fs::File::create(&zip_path).expect("create zip");
+        let mut zip_writer = zip::ZipWriter::new(file);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        for index in 0..=IMPORT_ZIP_MAX_ENTRIES {
+            zip_writer
+                .start_file(format!("traces/{index}/trace.json"), options)
+                .expect("start file");
+        }
+        zip_writer.finish().expect("finish zip");
+
+        let err = extract_zip(&zip_path, temp.path().join("out").as_path())
+            .expect_err("zip should be rejected");
+        assert!(err.contains("too many entries"));
+    }
+
+    #[tokio::test]
+    async fn unauth_internal_is_not_allowed_with_tenant_resolver() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp.path().join("data");
+        let store = TraceStore::new(data_dir.clone())
+            .await
+            .expect("trace store");
+        let (trace_events, _) = tokio::sync::broadcast::channel(16);
+        let auth_dir = data_dir.join("auth");
+        tokio::fs::create_dir_all(&auth_dir)
+            .await
+            .expect("create auth dir");
+        let resources = TenantResources {
+            tenant_id: "default".to_string(),
+            data_dir: data_dir.clone(),
+            rules_dir: data_dir.join("api_rules"),
+            auth_dir,
+            store: Arc::new(store),
+            api_engine: None,
+            trace_events,
+        };
+        let state = AppState {
+            default_resources: Arc::new(resources),
+            tenant_registry: None,
+            ui_source: None,
+            api_mode: ApiMode::UiOnly,
+            tenant_resolver: Some(Arc::new(StaticTenantResolver)),
+            internal_api_key: None,
+            allow_unauth_internal: true,
+            rate_limiter: None,
+        };
+        let app = build_router(state, true);
+        let response = tower::ServiceExt::oneshot(
+            app,
+            Request::builder()
+                .uri("/internal/traces")
+                .header("x-tenant-id", "tenant-a")
+                .body(axum::body::Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
     }
 }

--- a/crates/rulemorph_server/src/server.rs
+++ b/crates/rulemorph_server/src/server.rs
@@ -225,21 +225,13 @@ impl TenantRegistry {
                     return Err(errs.into());
                 }
                 let internal_base = format!("http://localhost:{}", self.port);
-                let allow_internal_auth = self
-                    .rules_dir
-                    .as_ref()
-                    .map(|path| path.is_absolute())
-                    .unwrap_or(false);
                 let mut config = EngineConfig::new(internal_base, layout.data_dir())
                     .with_ssrf_allowlist(self.ssrf_allowlist.clone())
                     .with_ssrf_allow_private(self.ssrf_allow_private)
-                    .with_internal_auth_enabled(allow_internal_auth);
-                if allow_internal_auth {
-                    config =
-                        config.with_internal_auth_path_allowlist(internal_auth_path_allowlist());
-                    if let Some(internal_api_key) = self.internal_api_key.clone() {
-                        config = config.with_internal_api_key(internal_api_key);
-                    }
+                    .with_internal_auth_enabled(true)
+                    .with_internal_auth_path_allowlist(internal_auth_path_allowlist());
+                if let Some(internal_api_key) = self.internal_api_key.clone() {
+                    config = config.with_internal_api_key(internal_api_key);
                 }
                 Some(Arc::new(EndpointEngine::load(rules_dir.clone(), config)?))
             }
@@ -291,15 +283,20 @@ pub fn build_router(state: AppState, ui_enabled: bool) -> Router {
                         api_router.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
                 }
             }
-            let mut v1 = Router::new().route("/v1/*path", any(handle_rules_api));
-            if state.rate_limiter.is_some() {
-                v1 = v1.layer(from_fn_with_state(state.clone(), api_rate_limit));
+            let api = Router::new().merge(api_import).merge(api_router);
+            if state.tenant_resolver.is_some() {
+                let mut v1 = Router::new().route("/v1/*path", any(handle_rules_api));
+                if state.rate_limiter.is_some() {
+                    v1 = v1.layer(from_fn_with_state(state.clone(), api_rate_limit));
+                }
+                v1 = v1.layer(from_fn_with_state(state.clone(), v1_auth));
+                if state.rate_limiter.is_some() {
+                    v1 = v1.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
+                }
+                api.merge(v1)
+            } else {
+                api
             }
-            v1 = v1.layer(from_fn_with_state(state.clone(), v1_auth));
-            if state.rate_limiter.is_some() {
-                v1 = v1.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
-            }
-            Router::new().merge(api_import).merge(api_router).merge(v1)
         }
     };
 

--- a/crates/rulemorph_server/tests/cloud_scenarios.rs
+++ b/crates/rulemorph_server/tests/cloud_scenarios.rs
@@ -486,7 +486,7 @@ finalize:
 }
 
 #[tokio::test]
-async fn v1_returns_503_when_resolver_missing() {
+async fn v1_is_not_mounted_when_resolver_missing() {
     let (app, _temp) = build_v1_app(None, None).await;
     let response = app
         .clone()
@@ -498,7 +498,64 @@ async fn v1_returns_503_when_resolver_missing() {
         )
         .await
         .expect("response");
-    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn tenant_api_rules_allow_internal_auth() -> Result<()> {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let rules_dir = data_dir.join("tenants").join("default").join("api_rules");
+    fs::create_dir_all(rules_dir.join("rules")).expect("create rules");
+    fs::write(
+        rules_dir.join("endpoint.yaml"),
+        r#"
+version: 2
+type: endpoint
+endpoints:
+  - method: GET
+    path: /api/test
+    steps:
+      - rule: rules/ok.yaml
+    reply:
+      status: 200
+      body:
+        ok: true
+"#,
+    )
+    .expect("write endpoint.yaml");
+    fs::write(
+        rules_dir.join("rules/ok.yaml"),
+        r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "output.value"
+    value: 1
+finalize:
+  wrap:
+    key: result
+"#,
+    )
+    .expect("write ok.yaml");
+
+    let registry = TenantRegistry::new(
+        data_dir,
+        None,
+        ApiMode::Rules,
+        true,
+        8080,
+        Vec::new(),
+        true,
+        Some("internal-key".to_string()),
+    );
+    let resources = registry.get_or_init("default").await?;
+    let engine = resources.api_engine.as_ref().expect("api engine");
+
+    assert!(engine.allows_internal_auth());
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/rulemorph_trace/src/trace_writer.rs
+++ b/crates/rulemorph_trace/src/trace_writer.rs
@@ -1408,17 +1408,55 @@ fn normalize_masking_rules(rules: &[String]) -> Vec<String> {
 }
 
 fn mask_url_query(value: &str, rules: &[String]) -> Option<String> {
-    if rules.is_empty() || !value.contains('?') {
+    if rules.is_empty() || (!value.contains('?') && !value.contains('#')) {
         return None;
     }
-    let (base, rest) = value.split_once('?')?;
-    let (query, fragment) = match rest.split_once('#') {
-        Some((query, fragment)) => (query, Some(fragment)),
-        None => (rest, None),
+    let (without_fragment, fragment) = match value.split_once('#') {
+        Some((prefix, fragment)) => (prefix, Some(fragment)),
+        None => (value, None),
+    };
+    let (base, query) = match without_fragment.split_once('?') {
+        Some((base, query)) => (base, Some(query)),
+        None => (without_fragment, None),
     };
     let mut masked = false;
+    let masked_query = query.map(|query| {
+        let (value, did_mask) = mask_url_param_pairs(query, rules);
+        masked |= did_mask;
+        value
+    });
+    let masked_fragment = fragment.map(|fragment| {
+        let (value, did_mask) = mask_url_fragment(fragment, rules);
+        masked |= did_mask;
+        value
+    });
+    let mut masked_value = String::with_capacity(value.len());
+    masked_value.push_str(base);
+    if let Some(query) = masked_query {
+        masked_value.push('?');
+        masked_value.push_str(&query);
+    }
+    if let Some(fragment) = masked_fragment {
+        masked_value.push('#');
+        masked_value.push_str(&fragment);
+    }
+    masked.then_some(masked_value)
+}
+
+fn mask_url_fragment(value: &str, rules: &[String]) -> (String, bool) {
+    if let Some((route, query)) = value.split_once('?') {
+        let (masked_query, did_mask) = mask_url_param_pairs(query, rules);
+        if did_mask {
+            return (format!("{route}?{masked_query}"), true);
+        }
+    }
+    mask_url_param_pairs(value, rules)
+}
+
+fn mask_url_param_pairs(value: &str, rules: &[String]) -> (String, bool) {
+    let mut masked = false;
     let mut parts = Vec::new();
-    for pair in query.split('&') {
+    for pair in value.split('&') {
         if pair.is_empty() {
             parts.push(String::new());
             continue;
@@ -1437,18 +1475,7 @@ fn mask_url_query(value: &str, rules: &[String]) -> Option<String> {
             parts.push(pair.to_string());
         }
     }
-    if !masked {
-        return None;
-    }
-    let mut masked_value = String::with_capacity(value.len());
-    masked_value.push_str(base);
-    masked_value.push('?');
-    masked_value.push_str(&parts.join("&"));
-    if let Some(fragment) = fragment {
-        masked_value.push('#');
-        masked_value.push_str(fragment);
-    }
-    Some(masked_value)
+    (parts.join("&"), masked)
 }
 
 fn apply_masking(value: &mut JsonValue, rules: &[String]) {

--- a/crates/rulemorph_trace/tests/trace_writer.rs
+++ b/crates/rulemorph_trace/tests/trace_writer.rs
@@ -3835,6 +3835,64 @@ async fn write_trace_bundle_masks_url_query_params() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn write_trace_bundle_masks_url_fragment_params() -> anyhow::Result<()> {
+    let temp_dir = unique_temp_dir();
+    fs::create_dir_all(&temp_dir)?;
+
+    let trace = json!({
+        "trace_id": "trace-mask-url-fragment",
+        "records": [
+            {
+                "index": 0,
+                "input": {
+                    "fragment_only": "https://example.com/callback#access_token=abc&ok=1",
+                    "query_and_fragment": "https://example.com/path?ok=1#token=abc",
+                    "hash_route": "https://example.com/#/callback?token=abc&ok=1"
+                }
+            }
+        ]
+    });
+
+    let options = TraceWriteOptions {
+        compression: TraceCompression::None,
+        ..Default::default()
+    };
+
+    let _manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let loaded = store
+        .get("trace-mask-url-fragment")
+        .await?
+        .expect("trace should load");
+
+    let input = loaded
+        .get("records")
+        .and_then(|value| value.as_array())
+        .and_then(|records| records.first())
+        .and_then(|value| value.as_object())
+        .and_then(|record| record.get("input"))
+        .and_then(|value| value.as_object())
+        .expect("input object");
+
+    assert_eq!(
+        input.get("fragment_only").and_then(|value| value.as_str()),
+        Some("https://example.com/callback#access_token=[masked]&ok=1")
+    );
+    assert_eq!(
+        input
+            .get("query_and_fragment")
+            .and_then(|value| value.as_str()),
+        Some("https://example.com/path?ok=1#token=[masked]")
+    );
+    assert_eq!(
+        input.get("hash_route").and_then(|value| value.as_str()),
+        Some("https://example.com/#/callback?token=[masked]&ok=1")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn write_trace_bundle_drops_oversized_rule_source() -> anyhow::Result<()> {
     let temp_dir = unique_temp_dir();
     fs::create_dir_all(&temp_dir)?;

--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -372,6 +372,7 @@ export function getInternalKey(): string | null {
 export function __resetAuthCachesForTest(): void {
   cachedApiKey = undefined;
   cachedInternalKey = undefined;
+  cachedTenantId = undefined;
   pendingApiKeyFromUrl = undefined;
   pendingInternalKeyFromUrl = undefined;
   capturedAuthLocation = undefined;
@@ -400,9 +401,6 @@ function getTenantIdFromApiKey(apiKey: string | null): string | null {
 }
 
 function getTenantIdFromQueryOrStorage(): string | null {
-  if (cachedTenantId !== undefined) {
-    return cachedTenantId;
-  }
   if (typeof window === "undefined") {
     cachedTenantId = null;
     return cachedTenantId;
@@ -427,6 +425,10 @@ function getTenantIdFromQueryOrStorage(): string | null {
     }
     cachedTenantId = tenantParam;
     return tenantParam;
+  }
+
+  if (cachedTenantId !== undefined) {
+    return cachedTenantId;
   }
 
   try {
@@ -458,6 +460,10 @@ export function resolveTenantId(
     return "default";
   }
   return null;
+}
+
+export function __getTenantIdFromQueryOrStorageForTest(): string | null {
+  return getTenantIdFromQueryOrStorage();
 }
 
 function getTenantId(): string | null {

--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -187,8 +187,134 @@ const TENANT_ID_STORAGE = "rulemorph_tenant_id";
 let cachedApiKey: string | null | undefined;
 let cachedInternalKey: string | null | undefined;
 let cachedTenantId: string | null | undefined;
+let pendingApiKeyFromUrl: string | null | undefined;
+let pendingInternalKeyFromUrl: string | null | undefined;
+let capturedAuthLocation: string | undefined;
 
-function getApiKey(): string | null {
+function captureAuthSecretsFromLocation(): void {
+  if (typeof window === "undefined") return;
+  const currentLocation = window.location.href;
+  if (capturedAuthLocation === currentLocation) {
+    return;
+  }
+  capturedAuthLocation = currentLocation;
+
+  const apiKey = getSecretParam(["api_key"]);
+  const internalKey = getSecretParam(["internal_key", "internal_api_key"]);
+  if (apiKey) {
+    pendingApiKeyFromUrl = apiKey;
+    cachedApiKey = apiKey;
+  } else if (pendingApiKeyFromUrl === undefined) {
+    pendingApiKeyFromUrl = null;
+  }
+  if (internalKey) {
+    pendingInternalKeyFromUrl = internalKey;
+    cachedInternalKey = internalKey;
+  } else if (pendingInternalKeyFromUrl === undefined) {
+    pendingInternalKeyFromUrl = null;
+  }
+
+  if (apiKey || internalKey) {
+    removeSecretParams(["api_key", "internal_key", "internal_api_key"]);
+  }
+}
+
+function getSecretParam(names: string[]): string | null {
+  if (typeof window === "undefined") return null;
+  const sources = [
+    ...secretParamSourcesFromHash(window.location.hash),
+    window.location.search
+  ];
+  for (const source of sources) {
+    const params = new URLSearchParams(source.startsWith("?") ? source : `?${source}`);
+    for (const name of names) {
+      const trimmed = params.get(name)?.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return null;
+}
+
+function secretParamSourcesFromHash(hash: string): string[] {
+  if (!hash) return [];
+  const raw = hash.replace(/^#/, "");
+  if (!raw) return [];
+  if (raw.startsWith("/")) {
+    const queryIndex = raw.indexOf("?");
+    return queryIndex === -1 ? [] : [raw.slice(queryIndex + 1)];
+  }
+  if (raw.startsWith("?")) {
+    return [raw.slice(1)];
+  }
+  return raw.includes("=") ? [raw] : [];
+}
+
+function removeSecretParams(names: string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    const url = new URL(window.location.href);
+    let changed = false;
+    for (const name of names) {
+      if (url.searchParams.has(name)) {
+        url.searchParams.delete(name);
+        changed = true;
+      }
+    }
+    const hashResult = removeSecretParamsFromHash(url.hash, names);
+    if (hashResult.changed) {
+      url.hash = hashResult.hash;
+      changed = true;
+    }
+    if (changed) {
+      window.history.replaceState(null, "", url.toString());
+    }
+  } catch {
+    // ignore history failures
+  }
+}
+
+function removeSecretParamsFromHash(hash: string, names: string[]): { hash: string; changed: boolean } {
+  if (!hash) return { hash, changed: false };
+  const raw = hash.replace(/^#/, "");
+  if (!raw) return { hash, changed: false };
+
+  if (raw.startsWith("/")) {
+    const queryIndex = raw.indexOf("?");
+    if (queryIndex === -1) return { hash, changed: false };
+    const route = raw.slice(0, queryIndex);
+    const query = raw.slice(queryIndex + 1);
+    const params = new URLSearchParams(query);
+    if (!deleteNamedParams(params, names)) return { hash, changed: false };
+    const nextQuery = params.toString();
+    return { hash: nextQuery ? `#${route}?${nextQuery}` : `#${route}`, changed: true };
+  }
+
+  const source = raw.startsWith("?") ? raw.slice(1) : raw;
+  if (!source.includes("=")) return { hash, changed: false };
+  const params = new URLSearchParams(source);
+  if (!deleteNamedParams(params, names)) return { hash, changed: false };
+  const next = params.toString();
+  if (raw.startsWith("?")) {
+    return { hash: next ? `#?${next}` : "", changed: true };
+  }
+  return { hash: next ? `#${next}` : "", changed: true };
+}
+
+function deleteNamedParams(params: URLSearchParams, names: string[]): boolean {
+  let changed = false;
+  for (const name of names) {
+    if (params.has(name)) {
+      params.delete(name);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+export function getApiKey(): string | null {
+  if (typeof window !== "undefined") {
+    captureAuthSecretsFromLocation();
+  }
   if (cachedApiKey !== undefined) {
     return cachedApiKey;
   }
@@ -196,24 +322,8 @@ function getApiKey(): string | null {
     cachedApiKey = null;
     return cachedApiKey;
   }
-  const params = new URLSearchParams(window.location.search);
-  const paramKey = params.get("api_key");
-  const trimmed = paramKey?.trim();
+  const trimmed = pendingApiKeyFromUrl?.trim();
   if (trimmed) {
-    try {
-      window.localStorage.setItem(API_KEY_STORAGE, trimmed);
-    } catch {
-      // ignore storage failures
-    }
-    try {
-      const url = new URL(window.location.href);
-      url.searchParams.delete("api_key");
-      if (url.toString() !== window.location.href) {
-        window.history.replaceState(null, "", url.toString());
-      }
-    } catch {
-      // ignore history failures
-    }
     cachedApiKey = trimmed;
     return trimmed;
   }
@@ -230,7 +340,10 @@ function getApiKey(): string | null {
   return cachedApiKey;
 }
 
-function getInternalKey(): string | null {
+export function getInternalKey(): string | null {
+  if (typeof window !== "undefined") {
+    captureAuthSecretsFromLocation();
+  }
   if (cachedInternalKey !== undefined) {
     return cachedInternalKey;
   }
@@ -238,26 +351,8 @@ function getInternalKey(): string | null {
     cachedInternalKey = null;
     return cachedInternalKey;
   }
-  const params = new URLSearchParams(window.location.search);
-  const paramKey =
-    params.get("internal_key") ?? params.get("internal_api_key");
-  const trimmed = paramKey?.trim();
+  const trimmed = pendingInternalKeyFromUrl?.trim();
   if (trimmed) {
-    try {
-      window.localStorage.setItem(INTERNAL_KEY_STORAGE, trimmed);
-    } catch {
-      // ignore storage failures
-    }
-    try {
-      const url = new URL(window.location.href);
-      url.searchParams.delete("internal_key");
-      url.searchParams.delete("internal_api_key");
-      if (url.toString() !== window.location.href) {
-        window.history.replaceState(null, "", url.toString());
-      }
-    } catch {
-      // ignore history failures
-    }
     cachedInternalKey = trimmed;
     return trimmed;
   }
@@ -272,6 +367,14 @@ function getInternalKey(): string | null {
   }
   cachedInternalKey = null;
   return cachedInternalKey;
+}
+
+export function __resetAuthCachesForTest(): void {
+  cachedApiKey = undefined;
+  cachedInternalKey = undefined;
+  pendingApiKeyFromUrl = undefined;
+  pendingInternalKeyFromUrl = undefined;
+  capturedAuthLocation = undefined;
 }
 
 function normalizeTenantId(value: string | null | undefined): string | null {
@@ -1476,6 +1579,17 @@ function buildMergedApiGraph(
 }
 
 export default function App() {
+  captureAuthSecretsFromLocation();
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const capture = () => captureAuthSecretsFromLocation();
+    window.addEventListener("hashchange", capture);
+    window.addEventListener("popstate", capture);
+    return () => {
+      window.removeEventListener("hashchange", capture);
+      window.removeEventListener("popstate", capture);
+    };
+  }, []);
   const [viewMode, setViewMode] = useState<"trace" | "api">("trace");
   const [durationUnit, setDurationUnit] = useState<DurationUnit>(() => {
     if (typeof window === "undefined") return "us";

--- a/crates/rulemorph_ui/ui/src/__tests__/auth_secret_params.test.ts
+++ b/crates/rulemorph_ui/ui/src/__tests__/auth_secret_params.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetAuthCachesForTest,
+  getApiKey,
+  getInternalKey,
+} from "../App";
+
+function setUrl(url: string) {
+  installLocalStorageMock();
+  window.history.replaceState(null, "", url);
+  __resetAuthCachesForTest();
+}
+
+afterEach(() => {
+  __resetAuthCachesForTest();
+  vi.restoreAllMocks();
+});
+
+function installLocalStorageMock() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key);
+      }),
+    },
+  });
+}
+
+describe("auth secret URL params", () => {
+  it("uses query api_key for the current page without persisting it", () => {
+    setUrl("/?api_key=query-secret");
+
+    expect(getApiKey()).toBe("query-secret");
+    expect(window.location.search).toBe("");
+    expect(window.localStorage.setItem).not.toHaveBeenCalledWith(
+      "rulemorph_api_key",
+      "query-secret",
+    );
+  });
+
+  it("uses fragment internal_key without persisting it", () => {
+    setUrl("/#internal_key=fragment-secret");
+
+    expect(getInternalKey()).toBe("fragment-secret");
+    expect(window.location.hash).toBe("");
+    expect(window.localStorage.setItem).not.toHaveBeenCalledWith(
+      "rulemorph_internal_key",
+      "fragment-secret",
+    );
+  });
+
+  it("preserves regular hash fragments when removing query secrets", () => {
+    setUrl("/?api_key=query-secret#section");
+
+    expect(getApiKey()).toBe("query-secret");
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("#section");
+  });
+
+  it("preserves hash routes when removing query secrets", () => {
+    setUrl("/?api_key=query-secret#/route?x=1");
+
+    expect(getApiKey()).toBe("query-secret");
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("#/route?x=1");
+  });
+
+  it("uses and removes auth params from hash route queries", () => {
+    setUrl("/#/route?internal_key=fragment-secret&x=1");
+
+    expect(getInternalKey()).toBe("fragment-secret");
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("#/route?x=1");
+  });
+
+  it("captures new auth params after the URL changes in the same tab", () => {
+    setUrl("/?api_key=query-secret");
+    expect(getApiKey()).toBe("query-secret");
+
+    window.history.replaceState(null, "", "/#/route?internal_key=fragment-secret&x=1");
+
+    expect(getInternalKey()).toBe("fragment-secret");
+    expect(window.location.hash).toBe("#/route?x=1");
+  });
+
+  it("captures new hash auth params after a cached miss", () => {
+    setUrl("/#plain-section");
+    expect(getInternalKey()).toBeNull();
+
+    window.history.replaceState(null, "", "/#/route?internal_key=fragment-secret&x=1");
+
+    expect(getInternalKey()).toBe("fragment-secret");
+    expect(window.location.hash).toBe("#/route?x=1");
+  });
+});

--- a/crates/rulemorph_ui/ui/src/__tests__/tenant_id_resolution.test.ts
+++ b/crates/rulemorph_ui/ui/src/__tests__/tenant_id_resolution.test.ts
@@ -1,5 +1,30 @@
-import { describe, expect, it } from "vitest";
-import { resolveTenantId } from "../App";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __getTenantIdFromQueryOrStorageForTest,
+  __resetAuthCachesForTest,
+  resolveTenantId,
+} from "../App";
+
+function installLocalStorageMock(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key);
+      }),
+    },
+  });
+}
+
+afterEach(() => {
+  __resetAuthCachesForTest();
+  vi.restoreAllMocks();
+});
 
 describe("resolveTenantId", () => {
   it("prefers tenant from API key over stored tenant_id", () => {
@@ -16,5 +41,23 @@ describe("resolveTenantId", () => {
 
   it("returns null when neither api key nor tenant_id is available", () => {
     expect(resolveTenantId(null, null)).toBeNull();
+  });
+});
+
+describe("tenant id query/storage resolution", () => {
+  it("captures a new tenant_id after the URL changes in the same tab", () => {
+    installLocalStorageMock({ rulemorph_tenant_id: "tenant-a" });
+    window.history.replaceState(null, "", "/");
+
+    expect(__getTenantIdFromQueryOrStorageForTest()).toBe("tenant-a");
+
+    window.history.replaceState(null, "", "/?tenant_id=tenant-b");
+
+    expect(__getTenantIdFromQueryOrStorageForTest()).toBe("tenant-b");
+    expect(window.location.search).toBe("");
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      "rulemorph_tenant_id",
+      "tenant-b",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- harden release workflow permissions, action pinning, publisher checksum verification, and Homebrew dispatch handling
- add security boundaries for MCP file access, branch recursion/path handling, ZIP import limits, API key store locking, DTO escaping, trace masking, and UI URL auth secret handling
- add regression coverage for branch traversal/cycles, DTO escaping, MCP path controls, ZIP limits, trace masking, and URL secret cleanup

## Validation
- cargo fmt
- cargo test
- cargo clippy --workspace (exit 0; existing style warnings remain)
- npm test -- --run
- npm run build
- actionlint .github/workflows/release-cli.yml
- zizmor .github/workflows/release-cli.yml (high/medium/low 0; trusted publishing info remains)
- @ブラウザ smoke for URL auth secret cleanup

## Notes
- Target branch: main
- MCP publisher tool is pinned in the workflow as v1.7.8 with SHA256 verification; Rulemorph release tags remain auto-derived from github.ref_name.