### PR TITLE
Prepare v0.2.3 release bump

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -18,13 +18,13 @@ jobs:
       # actions/checkout@v4 pinned 2026-05-09.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.ref_name }}
+          ref: refs/tags/${{ github.event.release.tag_name }}
           persist-credentials: false
 
       - name: Extract version from tag
         id: version
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           VERSION="${TAG#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
@@ -62,7 +62,7 @@ jobs:
       # actions/checkout@v4 pinned 2026-05-09.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.ref_name }}
+          ref: refs/tags/${{ github.event.release.tag_name }}
           persist-credentials: false
 
       - name: Install Rust
@@ -98,7 +98,7 @@ jobs:
       # actions/checkout@v4 pinned 2026-05-09.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.ref_name }}
+          ref: refs/tags/${{ github.event.release.tag_name }}
           persist-credentials: false
 
       - name: Install Rust

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -8,17 +8,17 @@ permissions:
   contents: read
 
 jobs:
-  update-version:
+  check-version:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
       # actions/checkout@v4 pinned 2026-05-09.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
           persist-credentials: false
 
       - name: Extract version from tag
@@ -30,48 +30,31 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extracted version: ${VERSION}"
 
-      - name: Update Cargo.toml files
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          for TOML in crates/rulemorph/Cargo.toml \
-                      crates/rulemorph_cli/Cargo.toml \
-                      crates/rulemorph_mcp/Cargo.toml \
-                      crates/rulemorph_endpoint/Cargo.toml \
-                      crates/rulemorph_trace/Cargo.toml \
-                      crates/rulemorph_server/Cargo.toml \
-                      crates/rulemorph_ui/Cargo.toml; do
-            sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" "$TOML"
-            echo "Updated $TOML to version ${VERSION}"
-          done
-
       - name: Install Rust
         # dtolnay/rust-toolchain@stable pinned 2026-05-09.
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
 
-      - name: Update Cargo.lock
-        run: cargo update -w
-
-      - name: Commit and push
+      - name: Verify Cargo versions match tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add crates/*/Cargo.toml Cargo.lock
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: bump version to ${VERSION}"
-            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" HEAD:main
+          cargo metadata --locked --format-version 1 --no-deps > metadata.json
+          jq -r '.packages[] | select(.name | startswith("rulemorph")) | "\(.name)=\(.version)"' metadata.json
+          MISMATCHES="$(
+            jq -r --arg version "${VERSION}" \
+              '.packages[] | select((.name | startswith("rulemorph")) and .version != $version) | "\(.name)=\(.version)"' \
+              metadata.json
+          )"
+          if [ -n "${MISMATCHES}" ]; then
+            echo "::error::Release tag v${VERSION} does not match Cargo package versions"
+            echo "${MISMATCHES}"
+            exit 1
           fi
 
   publish-crates-io:
-    needs: update-version
+    needs: check-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +62,7 @@ jobs:
       # actions/checkout@v4 pinned 2026-05-09.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
           persist-credentials: false
 
       - name: Install Rust
@@ -94,7 +77,7 @@ jobs:
         run: cargo publish -p rulemorph
 
   build-and-upload:
-    needs: update-version
+    needs: check-version
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -115,7 +98,7 @@ jobs:
       # actions/checkout@v4 pinned 2026-05-09.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
           persist-credentials: false
 
       - name: Install Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "rulemorph"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "rulemorph_cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "rulemorph_endpoint"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "rulemorph_mcp"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "csv",
  "rulemorph",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "rulemorph_server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "rulemorph_trace"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "rulemorph_ui"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "rustc-hash"

--- a/crates/rulemorph/Cargo.toml
+++ b/crates/rulemorph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rulemorph"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 description = "YAML-based declarative data transformation engine for CSV/JSON to JSON"

--- a/crates/rulemorph_cli/Cargo.toml
+++ b/crates/rulemorph_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rulemorph_cli"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 description = "CLI for YAML-based declarative data transformation"

--- a/crates/rulemorph_endpoint/Cargo.toml
+++ b/crates/rulemorph_endpoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rulemorph_endpoint"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 description = "Endpoint/network rule engine for rulemorph"

--- a/crates/rulemorph_mcp/Cargo.toml
+++ b/crates/rulemorph_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rulemorph_mcp"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 description = "MCP server for YAML-based declarative data transformation"

--- a/crates/rulemorph_server/Cargo.toml
+++ b/crates/rulemorph_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rulemorph_server"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 description = "HTTP server for rulemorph UI and API"

--- a/crates/rulemorph_trace/Cargo.toml
+++ b/crates/rulemorph_trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rulemorph_trace"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 description = "Trace storage and watcher utilities for rulemorph"

--- a/crates/rulemorph_ui/Cargo.toml
+++ b/crates/rulemorph_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rulemorph_ui"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 description = "UI assets for rulemorph trace viewer"


### PR DESCRIPTION
## Summary
- Bump workspace crates and Cargo.lock to 0.2.3 before release
- Change release workflow from direct main version push to tag/version validation
- Build and publish release jobs now check out the release tag

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cli.yml"); puts "YAML ok"'
- git diff --check -- .github/workflows/release-cli.yml Cargo.lock crates
- cargo metadata --locked --format-version 1 --no-deps
- cargo test

## Release note
After this PR is merged, recreate or update the v0.2.3 tag/release to point at the merge commit, then publish the GitHub Release again.