### PR TITLE
Fix v0.2.3 release asset build

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -71,7 +71,32 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Check crates.io version
+        id: crates_io_version
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          STATUS="$(
+            curl -sS \
+              -A "rulemorph-release-workflow/${VERSION}" \
+              -o crates-io-version.json \
+              -w "%{http_code}" \
+              "https://crates.io/api/v1/crates/rulemorph/${VERSION}"
+          )"
+          if [ "${STATUS}" = "200" ]; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "rulemorph ${VERSION} is already published on crates.io"
+          elif [ "${STATUS}" = "404" ]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "rulemorph ${VERSION} is not published on crates.io"
+          else
+            cat crates-io-version.json
+            echo "::error::Unexpected crates.io API status: ${STATUS}"
+            exit 1
+          fi
+
       - name: Publish to crates.io
+        if: steps.crates_io_version.outputs.published != 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish -p rulemorph

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -78,6 +78,11 @@ jobs:
         run: |
           STATUS="$(
             curl -sS \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --retry 3 \
+              --retry-delay 2 \
+              --retry-all-errors \
               -A "rulemorph-release-workflow/${VERSION}" \
               -o crates-io-version.json \
               -w "%{http_code}" \

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -15,8 +15,8 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      # actions/checkout@v4 pinned 2026-05-09.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2 pinned 2026-05-09. Uses Node.js 24 runtime.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ github.event.release.tag_name }}
           persist-credentials: false
@@ -59,8 +59,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      # actions/checkout@v4 pinned 2026-05-09.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2 pinned 2026-05-09. Uses Node.js 24 runtime.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ github.event.release.tag_name }}
           persist-credentials: false
@@ -120,8 +120,8 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
-      # actions/checkout@v4 pinned 2026-05-09.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2 pinned 2026-05-09. Uses Node.js 24 runtime.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ github.event.release.tag_name }}
           persist-credentials: false
@@ -134,10 +134,10 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Setup Node
-        # actions/setup-node@v4 pinned 2026-05-09.
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        # actions/setup-node@v6.4.0 pinned 2026-05-09. Uses Node.js 24 runtime.
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: crates/rulemorph_ui/ui/package-lock.json
 
@@ -239,8 +239,8 @@ jobs:
       MCP_PUBLISHER_VERSION: v1.7.8
       MCP_PUBLISHER_SHA256: 48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c
     steps:
-      # actions/checkout@v4 pinned 2026-05-09.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2 pinned 2026-05-09. Uses Node.js 24 runtime.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Repository Guidelines
+
+## Language
+- Japanese-first for docs, plans, and communication. Provide English only when explicitly requested.
+- 用語集は `docs/glossary.md` を参照。
+
+## Project Structure & Module Organization
+- `crates/rulemorph`: core library (rule parsing, validation, transform engine).
+- `crates/rulemorph_cli`: CLI binary wrapping the core library.
+- `crates/rulemorph_mcp`: MCP stdio server with tools/resources/prompts.
+- `docs/`: rule specifications and documentation (`rules_spec_en.md`, `rules_spec_ja.md`).
+- `docs/roadmap/roadmap.md`: product roadmap (YAML API platform).
+- Tests live under each crate (for example, `crates/rulemorph/tests` with fixtures in `crates/rulemorph/tests/fixtures` and MCP tests in `crates/rulemorph_mcp/tests/stdio.rs`).
+
+## Build, Test, and Development Commands
+- `cargo build -p rulemorph_cli --release`: build the CLI binary.
+- `cargo build -p rulemorph_mcp --release`: build the MCP server binary.
+- `cargo test`: run the full workspace test suite.
+- `cargo test -p rulemorph_mcp`: run MCP-specific tests.
+- `cargo run -p rulemorph_cli -- --help`: run the CLI in dev mode.
+- `scripts/verify-release-build.sh`: run the release preflight that mirrors the release workflow on the host target, including `cargo fmt --check`, `cargo metadata --locked`, `cargo test`, UI asset build, and release builds for CLI/MCP/server with `embedded-ui`.
+- `scripts/verify-release-build.sh <target> [...]`: run the same release preflight for explicit Rust targets when checking release matrix compatibility.
+- `cargo fmt` and `cargo clippy --workspace`: format and lint (recommended before PRs).
+- ** Rustのソースを実装/修正後 ** は必ず `cargo fmt` と `cargo test` を実行すること。
+- ** release workflow / release packaging / version bump / embedded-ui 周辺を修正した場合 ** は必ず `scripts/verify-release-build.sh` を実行すること。`cargo test` だけでは `rulemorph_server --features embedded-ui` の release build 不具合を検知できない。
+- UIを修正した場合は必ずブラウザ上で挙動を確認すること。
+
+## Coding Style & Naming Conventions
+- Use standard Rust formatting (rustfmt defaults, 4-space indentation).
+- Naming: `snake_case` for functions/modules, `CamelCase` for types, `SCREAMING_SNAKE_CASE` for constants.
+- Keep rule specs and examples consistent with the docs in `docs/`.
+
+## Testing Guidelines
+- Add unit/integration tests alongside the relevant crate.
+- For new rule behavior, add or extend fixtures in `crates/rulemorph/tests/fixtures`.
+- MCP behavior should include stdio JSON-RPC tests in `crates/rulemorph_mcp/tests/stdio.rs`.
+
+## Commit & Pull Request Guidelines
+- Commit messages are short, imperative, and sentence case (examples: "Add DTO parsing for additional languages", "Fix single-line TypeScript DTO parsing").
+- Keep commits focused on one logical change.
+- PRs should include: a brief summary, tests run, and any doc updates (especially when CLI/MCP behavior changes).
+
+## Configuration Tips
+- MCP server runs over stdio; see the README for client config examples.

--- a/crates/rulemorph_server/src/server.rs
+++ b/crates/rulemorph_server/src/server.rs
@@ -38,7 +38,7 @@ use rulemorph_trace::{
 };
 
 #[cfg(feature = "embedded-ui")]
-use axum::{extract::OriginalUri, http::HeaderMap};
+use axum::extract::OriginalUri;
 #[cfg(feature = "embedded-ui")]
 use include_dir::{Dir, include_dir};
 

--- a/scripts/verify-release-build.sh
+++ b/scripts/verify-release-build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ "$#" -gt 0 ]; then
+  TARGETS=("$@")
+else
+  TARGETS=("$(rustc -vV | awk '/^host:/ { print $2 }')")
+fi
+
+echo "==> cargo fmt --check"
+cargo fmt --check
+
+echo "==> cargo metadata --locked"
+cargo metadata --locked --format-version 1 --no-deps > /tmp/rulemorph-release-metadata.json
+
+echo "==> cargo test"
+cargo test
+
+echo "==> npm build for embedded UI"
+(
+  cd crates/rulemorph_ui/ui
+  npm ci
+  npm run build
+)
+
+for TARGET in "${TARGETS[@]}"; do
+  echo "==> release builds for ${TARGET}"
+  cargo build -p rulemorph_cli --release --locked --target "$TARGET"
+  cargo build -p rulemorph_mcp --release --locked --target "$TARGET"
+  cargo build -p rulemorph_server --features embedded-ui --release --locked --target "$TARGET"
+done

--- a/scripts/verify-release-build.sh
+++ b/scripts/verify-release-build.sh
@@ -10,11 +10,14 @@ else
   TARGETS=("$(rustc -vV | awk '/^host:/ { print $2 }')")
 fi
 
+METADATA_FILE="$(mktemp "${TMPDIR:-/tmp}/rulemorph-release-metadata.XXXXXX.json")"
+trap 'rm -f "$METADATA_FILE"' EXIT
+
 echo "==> cargo fmt --check"
 cargo fmt --check
 
 echo "==> cargo metadata --locked"
-cargo metadata --locked --format-version 1 --no-deps > /tmp/rulemorph-release-metadata.json
+cargo metadata --locked --format-version 1 --no-deps > "$METADATA_FILE"
 
 echo "==> cargo test"
 cargo test


### PR DESCRIPTION
## Summary
- Add a release preflight script and document it in AGENTS.md so release/embedded-ui changes run the same local checks.
- Fix the duplicate HeaderMap import that broke the embedded-ui release build.
- Skip crates.io publish when the target version is already published, so recreating v0.2.3 can continue to asset builds.
- Update release workflow actions to Node.js 24-compatible stable releases: actions/checkout v6.0.2 and actions/setup-node v6.4.0, both pinned by commit SHA. Use Node.js 24 for the UI asset build.

## Tests
- scripts/verify-release-build.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cli.yml"); puts "YAML ok"'
- curl crates.io version check for rulemorph 0.2.3 returned 200
- Verified pinned refs via GitHub API: actions/checkout v6.0.2 and actions/setup-node v6.4.0