### PR TITLE
Fix Windows release asset upload

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -226,11 +226,22 @@ jobs:
           Copy-Item "target\$env:TARGET\release\$BinMcp" "$McpbDir\$BinMcp"
           Compress-Archive -Path "$McpbDir\*" -DestinationPath "$OutDir\rulemorph-mcp-$env:VERSION-$env:TARGET.mcpb"
 
-      - name: Upload Release Assets
+      - name: Upload Release Assets (Unix)
+        if: runner.os != 'Windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: gh release upload "${RELEASE_TAG}" dist/* --clobber
+
+      - name: Upload Release Assets (Windows)
+        if: runner.os == 'Windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: pwsh
+        run: |
+          $Assets = Get-ChildItem -Path dist -File | ForEach-Object { $_.FullName }
+          gh release upload $env:RELEASE_TAG @Assets --clobber
 
   publish-mcp-registry:
     needs: build-and-upload


### PR DESCRIPTION
## Summary
- Split release asset upload into Unix and Windows steps.
- Keep the existing bash-style upload for Unix runners.
- Use PowerShell environment variable syntax and array splatting for Windows assets so gh release upload receives the correct release tag and asset paths.

## Verification
- YAML parse succeeded.
- scripts/verify-release-build.sh succeeded.

## Notes
- Local pwsh is not installed in this environment, so the PowerShell snippet was not executed locally.
- The failed release run built and packaged Windows successfully; only the Windows upload step failed with release not found because bash-style RELEASE_TAG expansion was used under PowerShell.