### PR TITLE
Fix traced v2 evaluation semantics

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -143,8 +143,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: crates/rulemorph_ui/ui/package-lock.json
 
       - name: Build UI assets
         working-directory: crates/rulemorph_ui/ui

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .DS_Store
 /docs/plans
 /docs/roadmap
-AGENTS.md
 CLAUDE.md
 **/node_modules/
 .rulemorph/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,16 @@
 - Naming: `snake_case` for functions/modules, `CamelCase` for types, `SCREAMING_SNAKE_CASE` for constants.
 - Keep rule specs and examples consistent with the docs in `docs/`.
 
+## Design & Code Organization
+- Keep code simple and direct. Prefer small, readable functions and explicit control flow over clever abstractions.
+- Split responsibilities before files become hard to scan. When a module mixes parsing, validation, execution, tracing, persistence, or presentation concerns, extract focused submodules with clear names.
+- Treat file length as a maintainability signal. Aim to keep ordinary source files around 200-400 lines when practical; when a file exceeds roughly 400 lines, actively look for a responsibility split. Files above 600 lines should be exceptional and justified by cohesive ownership, generated/schema-like content, or tests/fixtures.
+- Keep file hierarchy aligned with domain responsibilities, not implementation accidents. A reader should be able to find the owning module from the feature or concept name.
+- Avoid broad utility modules and catch-all files. Shared helpers should have a narrow purpose and live near their primary caller unless they are truly cross-cutting.
+- Add abstractions only when they reduce real duplication, clarify ownership, or stabilize a public/internal boundary. Do not introduce layers just to make code look generalized.
+- Preserve a small public API surface. Prefer `pub(crate)` for internal seams, and expose only the types/functions that are intended for users or other crates.
+- When refactoring large files, keep behavior changes separate from mechanical moves where practical, and maintain tests that prove the split preserved existing semantics.
+
 ## Testing Guidelines
 - Add unit/integration tests alongside the relevant crate.
 - For new rule behavior, add or extend fixtures in `crates/rulemorph/tests/fixtures`.

--- a/crates/rulemorph/src/error.rs
+++ b/crates/rulemorph/src/error.rs
@@ -181,6 +181,19 @@ impl TransformError {
         self.path = Some(path.into());
         self
     }
+
+    pub fn kind_name(&self) -> &'static str {
+        match &self.kind {
+            TransformErrorKind::InvalidInput => "invalid_input",
+            TransformErrorKind::InvalidRecordsPath => "invalid_records_path",
+            TransformErrorKind::InvalidRef => "invalid_ref",
+            TransformErrorKind::InvalidTarget => "invalid_target",
+            TransformErrorKind::MissingRequired => "missing_required",
+            TransformErrorKind::TypeCastFailed => "type_cast_failed",
+            TransformErrorKind::ExprError => "expr_error",
+            TransformErrorKind::AssertionFailed => "assertion_failed",
+        }
+    }
 }
 
 impl std::fmt::Display for TransformError {

--- a/crates/rulemorph/src/lib.rs
+++ b/crates/rulemorph/src/lib.rs
@@ -6,6 +6,7 @@ mod model;
 pub mod normalization;
 mod path;
 pub mod serde_guard;
+pub mod trace;
 mod transform;
 pub mod v2_eval;
 pub mod v2_model;
@@ -28,6 +29,12 @@ pub use normalization::{
     normalize_records_with_options,
 };
 pub use path::{PathError, PathToken, get_path, parse_path};
+pub use trace::{
+    RecordTrace, TraceAttributeValue, TraceDiagnostic, TraceEvent, TraceEventKind, TraceJsonType,
+    TracePhase, TraceRedactionOptions, TraceTruncation, TraceValueMode, TraceValueModeName,
+    TraceValueSnapshot, TraceValueState, TransformRecordTraceResult, TransformTrace,
+    TransformTraceError, TransformTraceOptions, TransformTraceResult,
+};
 pub use transform::{
     TransformStream, TransformStreamItem, preflight_validate, preflight_validate_input,
     preflight_validate_input_with_base_dir, preflight_validate_input_with_warnings,
@@ -36,17 +43,19 @@ pub use transform::{
     preflight_validate_with_base_dir, preflight_validate_with_warnings,
     preflight_validate_with_warnings_with_base_dir, transform, transform_input,
     transform_input_with_base_dir, transform_input_with_base_dir_and_options,
-    transform_input_with_options, transform_input_with_warnings,
+    transform_input_with_options, transform_input_with_trace,
+    transform_input_with_trace_with_base_dir_and_options, transform_input_with_warnings,
     transform_input_with_warnings_with_base_dir,
     transform_input_with_warnings_with_base_dir_and_options,
     transform_input_with_warnings_with_options, transform_record, transform_record_with_base_dir,
-    transform_record_with_warnings, transform_record_with_warnings_with_base_dir, transform_stream,
-    transform_stream_input, transform_stream_input_with_base_dir,
-    transform_stream_input_with_base_dir_and_options, transform_stream_input_with_options,
-    transform_stream_with_base_dir, transform_stream_with_base_dir_and_options,
-    transform_stream_with_options, transform_with_base_dir, transform_with_options,
-    transform_with_warnings, transform_with_warnings_with_base_dir,
-    transform_with_warnings_with_base_dir_and_options, transform_with_warnings_with_options,
+    transform_record_with_trace, transform_record_with_warnings,
+    transform_record_with_warnings_with_base_dir, transform_stream, transform_stream_input,
+    transform_stream_input_with_base_dir, transform_stream_input_with_base_dir_and_options,
+    transform_stream_input_with_options, transform_stream_with_base_dir,
+    transform_stream_with_base_dir_and_options, transform_stream_with_options,
+    transform_with_base_dir, transform_with_options, transform_with_warnings,
+    transform_with_warnings_with_base_dir, transform_with_warnings_with_base_dir_and_options,
+    transform_with_warnings_with_options,
 };
 pub use validator::{validate_rule_file, validate_rule_file_with_source};
 

--- a/crates/rulemorph/src/trace.rs
+++ b/crates/rulemorph/src/trace.rs
@@ -1,0 +1,1137 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use crate::error::{TransformError, TransformWarning};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransformTraceOptions {
+    pub value_mode: TraceValueMode,
+    pub max_events: Option<usize>,
+    pub max_trace_bytes: Option<usize>,
+    pub max_snapshot_bytes: Option<usize>,
+}
+
+impl TransformTraceOptions {
+    pub fn raw() -> Self {
+        Self {
+            value_mode: TraceValueMode::Raw,
+            max_events: None,
+            max_trace_bytes: None,
+            max_snapshot_bytes: None,
+        }
+    }
+
+    pub fn redacted() -> Self {
+        Self {
+            value_mode: TraceValueMode::Redacted(TraceRedactionOptions::default()),
+            max_events: None,
+            max_trace_bytes: None,
+            max_snapshot_bytes: None,
+        }
+    }
+
+    pub fn metadata_only() -> Self {
+        Self {
+            value_mode: TraceValueMode::MetadataOnly,
+            max_events: None,
+            max_trace_bytes: None,
+            max_snapshot_bytes: None,
+        }
+    }
+}
+
+impl Default for TransformTraceOptions {
+    fn default() -> Self {
+        Self::raw()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceValueMode {
+    Raw,
+    Redacted(TraceRedactionOptions),
+    MetadataOnly,
+}
+
+impl TraceValueMode {
+    pub fn name(&self) -> TraceValueModeName {
+        match self {
+            TraceValueMode::Raw => TraceValueModeName::Raw,
+            TraceValueMode::Redacted(_) => TraceValueModeName::Redacted,
+            TraceValueMode::MetadataOnly => TraceValueModeName::MetadataOnly,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceValueModeName {
+    Raw,
+    Redacted,
+    MetadataOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceRedactionOptions {
+    pub secret_key_fragments: Vec<String>,
+    pub oversized_value_bytes: Option<usize>,
+}
+
+impl Default for TraceRedactionOptions {
+    fn default() -> Self {
+        Self {
+            secret_key_fragments: vec![
+                "password".to_string(),
+                "token".to_string(),
+                "secret".to_string(),
+                "authorization".to_string(),
+                "api_key".to_string(),
+                "api-key".to_string(),
+                "apikey".to_string(),
+                "bearer".to_string(),
+            ],
+            oversized_value_bytes: Some(64 * 1024),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TransformTrace {
+    pub schema_version: u8,
+    pub value_mode: TraceValueModeName,
+    pub contains_raw_values: bool,
+    pub complete: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<TraceTruncation>,
+    pub records: Vec<RecordTrace>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finalize: Option<Vec<TraceEvent>>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RecordTrace {
+    pub record_index: usize,
+    pub events: Vec<TraceEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TraceTruncation {
+    pub reason: String,
+    pub emitted_events: usize,
+    pub emitted_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TraceEvent {
+    pub id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<u64>,
+    pub kind: TraceEventKind,
+    pub phase: TracePhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<TraceDiagnostic>,
+    pub inputs: Vec<TraceValueSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<TraceValueSnapshot>,
+    pub attributes: BTreeMap<String, TraceAttributeValue>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TraceDiagnostic {
+    pub code: &'static str,
+    pub message: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum TraceAttributeValue {
+    Bool(bool),
+    Number(serde_json::Number),
+    String(String),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceEventKind {
+    RecordStart,
+    RecordWhenStart,
+    RecordWhenEnd,
+    RecordDecision,
+    MappingStart,
+    MappingWhenStart,
+    MappingWhenEnd,
+    MappingDecision,
+    MappingEnd,
+    SourceRead,
+    LiteralEval,
+    DefaultApplied,
+    TypeCast,
+    ExprStart,
+    ExprEnd,
+    ChainStart,
+    ChainStep,
+    RefRead,
+    OpStart,
+    ArgEval,
+    OpEnd,
+    OpError,
+    CollectionItemStart,
+    CollectionItemEnd,
+    OutputWrite,
+    StepStart,
+    AssertEval,
+    BranchEval,
+    BranchTaken,
+    BranchMerge,
+    FinalizeStart,
+    FinalizeFilter,
+    FinalizeSort,
+    FinalizeOffset,
+    FinalizeLimit,
+    FinalizeWrap,
+    FinalizeEnd,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TracePhase {
+    Start,
+    End,
+    Instant,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TraceValueSnapshot {
+    pub state: TraceValueState,
+    #[serde(rename = "type")]
+    pub value_type: TraceJsonType,
+    pub contains_raw_value: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redaction_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceValueState {
+    Missing,
+    Null,
+    Present,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceJsonType {
+    Missing,
+    Null,
+    Boolean,
+    Number,
+    String,
+    Array,
+    Object,
+}
+
+impl TraceValueSnapshot {
+    pub fn missing(_options: &TransformTraceOptions, _path_hint: Option<&str>) -> Self {
+        Self {
+            state: TraceValueState::Missing,
+            value_type: TraceJsonType::Missing,
+            contains_raw_value: false,
+            value: None,
+            visibility: None,
+            redaction_reason: None,
+            bytes: None,
+        }
+    }
+
+    pub(crate) fn from_eval_value(
+        value: &crate::transform::EvalValue,
+        options: &TransformTraceOptions,
+        path_hint: Option<&str>,
+    ) -> Self {
+        match value {
+            crate::transform::EvalValue::Missing => Self::missing(options, path_hint),
+            crate::transform::EvalValue::Value(value) => Self::from_json(value, options, path_hint),
+        }
+    }
+
+    pub(crate) fn from_v2_eval_value(
+        value: &crate::v2_eval::EvalValue,
+        options: &TransformTraceOptions,
+        path_hint: Option<&str>,
+    ) -> Self {
+        match value {
+            crate::v2_eval::EvalValue::Missing => Self::missing(options, path_hint),
+            crate::v2_eval::EvalValue::Value(value) => Self::from_json(value, options, path_hint),
+        }
+    }
+
+    pub fn from_json(
+        value: &JsonValue,
+        options: &TransformTraceOptions,
+        path_hint: Option<&str>,
+    ) -> Self {
+        let value_type = json_value_type(value);
+        let state = if value.is_null() {
+            TraceValueState::Null
+        } else {
+            TraceValueState::Present
+        };
+        let bytes = value_size_bytes(value);
+        if options
+            .max_snapshot_bytes
+            .is_some_and(|limit| bytes > limit)
+        {
+            return Self {
+                state,
+                value_type,
+                contains_raw_value: false,
+                value: None,
+                visibility: Some("truncated".to_string()),
+                redaction_reason: Some("max_snapshot_bytes".to_string()),
+                bytes: Some(bytes),
+            };
+        }
+
+        match &options.value_mode {
+            TraceValueMode::Raw => Self {
+                state,
+                value_type,
+                contains_raw_value: true,
+                value: Some(value.clone()),
+                visibility: Some("raw".to_string()),
+                redaction_reason: None,
+                bytes: Some(bytes),
+            },
+            TraceValueMode::MetadataOnly => Self {
+                state,
+                value_type,
+                contains_raw_value: false,
+                value: None,
+                visibility: Some("metadata_only".to_string()),
+                redaction_reason: None,
+                bytes: Some(bytes),
+            },
+            TraceValueMode::Redacted(redaction) => {
+                if value.is_object() || value.is_array() {
+                    return Self {
+                        state,
+                        value_type,
+                        contains_raw_value: false,
+                        value: None,
+                        visibility: Some("metadata_only".to_string()),
+                        redaction_reason: Some("composite_snapshot".to_string()),
+                        bytes: Some(bytes),
+                    };
+                }
+                let reason = redaction_reason(value, path_hint, redaction);
+                Self {
+                    state,
+                    value_type,
+                    contains_raw_value: reason.is_none(),
+                    value: if reason.is_none() {
+                        Some(value.clone())
+                    } else {
+                        None
+                    },
+                    visibility: Some(if reason.is_some() { "redacted" } else { "raw" }.to_string()),
+                    redaction_reason: reason,
+                    bytes: Some(bytes),
+                }
+            }
+        }
+    }
+}
+
+fn json_value_type(value: &JsonValue) -> TraceJsonType {
+    match value {
+        JsonValue::Null => TraceJsonType::Null,
+        JsonValue::Bool(_) => TraceJsonType::Boolean,
+        JsonValue::Number(_) => TraceJsonType::Number,
+        JsonValue::String(_) => TraceJsonType::String,
+        JsonValue::Array(_) => TraceJsonType::Array,
+        JsonValue::Object(_) => TraceJsonType::Object,
+    }
+}
+
+fn value_size_bytes(value: &JsonValue) -> usize {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .unwrap_or(0)
+}
+
+fn redaction_reason(
+    value: &JsonValue,
+    path_hint: Option<&str>,
+    redaction: &TraceRedactionOptions,
+) -> Option<String> {
+    if let Some(path) = path_hint {
+        let path = path.to_ascii_lowercase();
+        if redaction
+            .secret_key_fragments
+            .iter()
+            .any(|fragment| path.contains(fragment))
+        {
+            return Some("secret_like_path".to_string());
+        }
+    }
+    if let Some(limit) = redaction.oversized_value_bytes
+        && value_size_bytes(value) > limit
+    {
+        return Some("oversized_value".to_string());
+    }
+    if let Some(text) = value.as_str()
+        && text.to_ascii_lowercase().starts_with("bearer ")
+    {
+        return Some("bearer_credential".to_string());
+    }
+    None
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransformTraceResult {
+    pub output: JsonValue,
+    pub warnings: Vec<TransformWarning>,
+    pub trace: TransformTrace,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransformRecordTraceResult {
+    pub output: Option<JsonValue>,
+    pub warnings: Vec<TransformWarning>,
+    pub trace: TransformTrace,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct TransformTraceError {
+    pub error: TransformError,
+    pub warnings: Vec<TransformWarning>,
+    pub trace: TransformTrace,
+}
+
+impl fmt::Debug for TransformTraceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransformTraceError")
+            .field("error_kind", &self.error.kind_name())
+            .field("warnings_len", &self.warnings.len())
+            .field("trace_schema_version", &self.trace.schema_version)
+            .field("trace_complete", &self.trace.complete)
+            .field("trace_contains_raw_values", &self.trace.contains_raw_values)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for TransformTraceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "transform trace failed: error_kind={}, warnings_len={}, trace_complete={}, trace_contains_raw_values={}",
+            self.error.kind_name(),
+            self.warnings.len(),
+            self.trace.complete,
+            self.trace.contains_raw_values
+        )
+    }
+}
+
+impl std::error::Error for TransformTraceError {}
+
+pub(crate) struct TraceCollector {
+    options: TransformTraceOptions,
+    next_id: u64,
+    complete: bool,
+    truncation: Option<TraceTruncation>,
+    contains_raw_values: bool,
+    emitted_bytes: usize,
+    frozen: bool,
+    structural_truncated: bool,
+    span_stack: Vec<u64>,
+    records: Vec<RecordTrace>,
+    current_record: Option<RecordTrace>,
+    finalize_events: Vec<TraceEvent>,
+    scope: TraceScope,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpanAction {
+    Push(u64),
+    Pop(Option<u64>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TraceScope {
+    Record,
+    Finalize,
+}
+
+impl TraceCollector {
+    pub(crate) fn new(options: TransformTraceOptions) -> Self {
+        Self {
+            options,
+            next_id: 1,
+            complete: true,
+            truncation: None,
+            contains_raw_values: false,
+            emitted_bytes: 0,
+            frozen: false,
+            structural_truncated: false,
+            span_stack: Vec::new(),
+            records: Vec::new(),
+            current_record: None,
+            finalize_events: Vec::new(),
+            scope: TraceScope::Record,
+        }
+    }
+
+    pub(crate) fn start_record(&mut self, record_index: usize, record: &JsonValue) {
+        if self.frozen {
+            return;
+        }
+        debug_assert!(
+            self.span_stack.is_empty(),
+            "start_record called while a span is open: {:?}",
+            self.span_stack
+        );
+        if let Some(record) = self.current_record.take() {
+            self.records.push(record);
+        }
+        self.current_record = Some(RecordTrace {
+            record_index,
+            events: Vec::new(),
+        });
+        self.emit(TraceEventKind::RecordStart, TracePhase::Instant)
+            .finish_with_output(self, record, None);
+    }
+
+    pub(crate) fn start_finalize(&mut self, output_before_finalize: &JsonValue) {
+        if self.frozen {
+            return;
+        }
+        debug_assert!(
+            self.span_stack.is_empty(),
+            "start_finalize called while a span is open: {:?}",
+            self.span_stack
+        );
+        if let Some(record) = self.current_record.take() {
+            self.records.push(record);
+        }
+        self.scope = TraceScope::Finalize;
+        self.start_span(TraceEventKind::FinalizeStart, TracePhase::Start)
+            .finish_with_output(self, output_before_finalize, None);
+    }
+
+    pub(crate) fn emit(&mut self, kind: TraceEventKind, phase: TracePhase) -> TraceEventBuilder {
+        let id = self.next_id;
+        self.next_id += 1;
+        TraceEventBuilder::new(id, self.span_stack.last().copied(), kind, phase)
+    }
+
+    pub(crate) fn start_span(
+        &mut self,
+        kind: TraceEventKind,
+        phase: TracePhase,
+    ) -> TraceEventBuilder {
+        let id = self.next_id;
+        self.next_id += 1;
+        let parent_id = self.span_stack.last().copied();
+        TraceEventBuilder::new(id, parent_id, kind, phase).span_action(SpanAction::Push(id))
+    }
+
+    pub(crate) fn end_span(
+        &mut self,
+        kind: TraceEventKind,
+        phase: TracePhase,
+    ) -> TraceEventBuilder {
+        let span_id = self.span_stack.last().copied();
+        let id = self.next_id;
+        self.next_id += 1;
+        TraceEventBuilder::new(id, span_id, kind, phase).span_action(SpanAction::Pop(span_id))
+    }
+
+    pub(crate) fn error_span(
+        &mut self,
+        kind: TraceEventKind,
+        code: &'static str,
+        message: &'static str,
+    ) -> TraceEventBuilder {
+        let span_id = self.span_stack.last().copied();
+        let id = self.next_id;
+        self.next_id += 1;
+        TraceEventBuilder::new(id, span_id, kind, TracePhase::Error)
+            .diagnostic(code, message)
+            .span_action(SpanAction::Pop(span_id))
+    }
+
+    pub(crate) fn push(&mut self, event: TraceEvent) -> bool {
+        if self.frozen {
+            return false;
+        }
+        let snapshot_truncated = event.output.as_ref().is_some_and(|snapshot| {
+            snapshot.redaction_reason.as_deref() == Some("max_snapshot_bytes")
+        }) || event
+            .inputs
+            .iter()
+            .any(|snapshot| snapshot.redaction_reason.as_deref() == Some("max_snapshot_bytes"));
+        if let Some(max_events) = self.options.max_events {
+            let emitted = self.emitted_events();
+            if emitted >= max_events {
+                self.complete = false;
+                self.truncation = Some(TraceTruncation {
+                    reason: "max_events".to_string(),
+                    emitted_events: emitted,
+                    emitted_bytes: self.emitted_bytes,
+                });
+                self.frozen = true;
+                self.structural_truncated = true;
+                return false;
+            }
+        }
+        let event_bytes =
+            value_size_bytes(&serde_json::to_value(&event).unwrap_or(JsonValue::Null));
+        if let Some(max_trace_bytes) = self.options.max_trace_bytes
+            && self.emitted_bytes.saturating_add(event_bytes) > max_trace_bytes
+        {
+            self.complete = false;
+            self.truncation = Some(TraceTruncation {
+                reason: "max_trace_bytes".to_string(),
+                emitted_events: self.emitted_events(),
+                emitted_bytes: self.emitted_bytes,
+            });
+            self.frozen = true;
+            self.structural_truncated = true;
+            return false;
+        }
+        self.emitted_bytes = self.emitted_bytes.saturating_add(event_bytes);
+        if snapshot_truncated {
+            self.complete = false;
+            let emitted_events = self.emitted_events();
+            self.truncation.get_or_insert_with(|| TraceTruncation {
+                reason: "max_snapshot_bytes".to_string(),
+                emitted_events,
+                emitted_bytes: self.emitted_bytes,
+            });
+        }
+        self.contains_raw_values |= event
+            .output
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.contains_raw_value)
+            || event
+                .inputs
+                .iter()
+                .any(|snapshot| snapshot.contains_raw_value);
+        match self.scope {
+            TraceScope::Record => {
+                if let Some(record) = &mut self.current_record {
+                    record.events.push(event);
+                }
+            }
+            TraceScope::Finalize => {
+                self.finalize_events.push(event);
+            }
+        }
+        true
+    }
+
+    fn apply_span_action(&mut self, action: Option<SpanAction>) {
+        match action {
+            Some(SpanAction::Push(id)) => self.span_stack.push(id),
+            Some(SpanAction::Pop(Some(expected))) => {
+                if self.span_stack.last().copied() == Some(expected) {
+                    self.span_stack.pop();
+                }
+            }
+            Some(SpanAction::Pop(None)) | None => {}
+        }
+    }
+
+    fn emitted_events(&self) -> usize {
+        self.records
+            .iter()
+            .map(|record| record.events.len())
+            .sum::<usize>()
+            + self
+                .current_record
+                .as_ref()
+                .map(|record| record.events.len())
+                .unwrap_or(0)
+            + self.finalize_events.len()
+    }
+
+    pub(crate) fn finish(mut self) -> TransformTrace {
+        debug_assert!(
+            self.structural_truncated || self.span_stack.is_empty(),
+            "complete trace finished with open spans: {:?}",
+            self.span_stack
+        );
+        if let Some(record) = self.current_record.take() {
+            self.records.push(record);
+        }
+        TransformTrace {
+            schema_version: 1,
+            value_mode: self.options.value_mode.name(),
+            contains_raw_values: self.contains_raw_values,
+            complete: self.complete,
+            truncation: self.truncation,
+            records: self.records,
+            finalize: (!self.finalize_events.is_empty()).then_some(self.finalize_events),
+        }
+    }
+
+    pub(crate) fn options(&self) -> &TransformTraceOptions {
+        &self.options
+    }
+}
+
+pub(crate) fn canonical_input_path(path: &str) -> String {
+    canonical_at_path("@input", &["@input", "input"], path)
+}
+
+pub(crate) fn canonical_item_path(path: &str) -> String {
+    canonical_at_path("@item", &["@item", "item"], path)
+}
+
+pub(crate) fn canonical_acc_path(path: &str) -> String {
+    canonical_at_path("@acc", &["@acc", "acc"], path)
+}
+
+pub(crate) fn canonical_context_path(path: &str) -> String {
+    canonical_at_path("@context", &["@context", "context"], path)
+}
+
+pub(crate) fn canonical_out_path(path: &str) -> String {
+    canonical_at_path("@out", &["@out", "out"], path)
+}
+
+pub(crate) fn canonical_output_path(path: &str) -> String {
+    let trimmed = path.trim();
+    if trimmed == "$" || trimmed.starts_with("$.") || trimmed.starts_with("$[") {
+        return trimmed.to_string();
+    }
+    let stripped = trimmed
+        .strip_prefix("output.")
+        .or_else(|| trimmed.strip_prefix("out."))
+        .unwrap_or(trimmed)
+        .trim_start_matches('.');
+    if stripped.is_empty() {
+        "$".to_string()
+    } else if stripped.starts_with('[') {
+        format!("${stripped}")
+    } else {
+        format!("$.{stripped}")
+    }
+}
+
+fn canonical_at_path(prefix: &'static str, strip_prefixes: &[&str], path: &str) -> String {
+    let trimmed = path.trim();
+    if trimmed == prefix
+        || trimmed.starts_with(&format!("{prefix}."))
+        || trimmed.starts_with(&format!("{prefix}["))
+    {
+        return trimmed.to_string();
+    }
+    for other_prefix in ["@input", "@item", "@acc", "@context", "@out"] {
+        debug_assert!(
+            other_prefix == prefix
+                || !(trimmed == other_prefix
+                    || trimmed.starts_with(&format!("{other_prefix}."))
+                    || trimmed.starts_with(&format!("{other_prefix}["))),
+            "semantic path namespace mismatch: expected {prefix}, got {trimmed}"
+        );
+    }
+    let suffix = strip_prefixes
+        .iter()
+        .find_map(|candidate| {
+            if trimmed == *candidate {
+                Some("")
+            } else if let Some(rest) = trimmed.strip_prefix(candidate) {
+                (rest.starts_with('.') || rest.starts_with('[')).then_some(rest)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(trimmed);
+    if suffix.is_empty() {
+        prefix.to_string()
+    } else if suffix.starts_with('.') || suffix.starts_with('[') {
+        format!("{prefix}{suffix}")
+    } else {
+        format!("{prefix}.{suffix}")
+    }
+}
+
+pub(crate) struct TraceEventBuilder {
+    event: TraceEvent,
+    span_action: Option<SpanAction>,
+}
+
+impl TraceEventBuilder {
+    fn new(id: u64, parent_id: Option<u64>, kind: TraceEventKind, phase: TracePhase) -> Self {
+        Self {
+            event: TraceEvent {
+                id,
+                parent_id,
+                kind,
+                phase,
+                rule_path: None,
+                input_path: None,
+                output_path: None,
+                namespace: None,
+                operator: None,
+                message: None,
+                inputs: Vec::new(),
+                output: None,
+                attributes: BTreeMap::new(),
+            },
+            span_action: None,
+        }
+    }
+
+    fn span_action(mut self, action: SpanAction) -> Self {
+        self.span_action = Some(action);
+        self
+    }
+
+    pub(crate) fn rule_path(mut self, path: impl Into<String>) -> Self {
+        self.event.rule_path = Some(path.into());
+        self
+    }
+
+    pub(crate) fn input_path(mut self, path: impl Into<String>) -> Self {
+        self.event.input_path = Some(path.into());
+        self
+    }
+
+    pub(crate) fn output_path(mut self, path: impl Into<String>) -> Self {
+        self.event.output_path = Some(path.into());
+        self
+    }
+
+    pub(crate) fn operator(mut self, operator: impl Into<String>) -> Self {
+        self.event.operator = Some(operator.into());
+        self
+    }
+
+    fn attr(mut self, key: impl Into<String>, value: TraceAttributeValue) -> Self {
+        self.event.attributes.insert(key.into(), value);
+        self
+    }
+
+    pub(crate) fn attr_bool(self, key: impl Into<String>, value: bool) -> Self {
+        self.attr(key, TraceAttributeValue::Bool(value))
+    }
+
+    pub(crate) fn attr_index(self, key: impl Into<String>, value: usize) -> Self {
+        self.attr(
+            key,
+            TraceAttributeValue::Number(serde_json::Number::from(value as u64)),
+        )
+    }
+
+    pub(crate) fn attr_count(self, key: impl Into<String>, value: usize) -> Self {
+        self.attr_index(key, value)
+    }
+
+    pub(crate) fn attr_enum(self, key: impl Into<String>, value: &'static str) -> Self {
+        self.attr(key, TraceAttributeValue::String(value.to_string()))
+    }
+
+    pub(crate) fn attr_path(self, key: impl Into<String>, path: impl Into<String>) -> Self {
+        self.attr(key, TraceAttributeValue::String(path.into()))
+    }
+
+    pub(crate) fn diagnostic(mut self, code: &'static str, message: &'static str) -> Self {
+        self.event.message = Some(TraceDiagnostic { code, message });
+        self
+    }
+
+    pub(crate) fn input_value(
+        mut self,
+        value: &JsonValue,
+        options: &TransformTraceOptions,
+        path_hint: Option<&str>,
+    ) -> Self {
+        self.event
+            .inputs
+            .push(TraceValueSnapshot::from_json(value, options, path_hint));
+        self
+    }
+
+    pub(crate) fn input_eval_value(
+        mut self,
+        value: &crate::transform::EvalValue,
+        options: &TransformTraceOptions,
+        path_hint: Option<&str>,
+    ) -> Self {
+        self.event.inputs.push(TraceValueSnapshot::from_eval_value(
+            value, options, path_hint,
+        ));
+        self
+    }
+
+    pub(crate) fn input_v2_eval_value(
+        mut self,
+        value: &crate::v2_eval::EvalValue,
+        options: &TransformTraceOptions,
+        path_hint: Option<&str>,
+    ) -> Self {
+        self.event
+            .inputs
+            .push(TraceValueSnapshot::from_v2_eval_value(
+                value, options, path_hint,
+            ));
+        self
+    }
+
+    pub(crate) fn finish_with_eval_output(
+        mut self,
+        collector: &mut TraceCollector,
+        output: &crate::transform::EvalValue,
+        path_hint: Option<&str>,
+    ) -> bool {
+        self.event.output = Some(TraceValueSnapshot::from_eval_value(
+            output,
+            collector.options(),
+            path_hint,
+        ));
+        self.finish(collector)
+    }
+
+    pub(crate) fn finish_with_v2_eval_output(
+        mut self,
+        collector: &mut TraceCollector,
+        output: &crate::v2_eval::EvalValue,
+        path_hint: Option<&str>,
+    ) -> bool {
+        self.event.output = Some(TraceValueSnapshot::from_v2_eval_value(
+            output,
+            collector.options(),
+            path_hint,
+        ));
+        self.finish(collector)
+    }
+
+    pub(crate) fn finish(self, collector: &mut TraceCollector) -> bool {
+        let TraceEventBuilder { event, span_action } = self;
+        let emitted = collector.push(event);
+        if emitted {
+            collector.apply_span_action(span_action);
+        }
+        emitted
+    }
+
+    pub(crate) fn finish_with_output(
+        mut self,
+        collector: &mut TraceCollector,
+        output: &JsonValue,
+        path_hint: Option<&str>,
+    ) -> bool {
+        self.event.output = Some(TraceValueSnapshot::from_json(
+            output,
+            collector.options(),
+            path_hint,
+        ));
+        self.finish(collector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn collector_assigns_parent_ids_from_span_stack() {
+        let mut collector = TraceCollector::new(TransformTraceOptions::metadata_only());
+        collector.start_record(0, &json!({"name":"alice"}));
+
+        collector
+            .start_span(TraceEventKind::MappingStart, TracePhase::Start)
+            .rule_path("mappings[0]")
+            .finish(&mut collector);
+        collector
+            .start_span(TraceEventKind::OpStart, TracePhase::Start)
+            .operator("uppercase")
+            .finish(&mut collector);
+        collector
+            .end_span(TraceEventKind::OpEnd, TracePhase::End)
+            .operator("uppercase")
+            .finish(&mut collector);
+        collector
+            .end_span(TraceEventKind::MappingEnd, TracePhase::End)
+            .rule_path("mappings[0]")
+            .finish(&mut collector);
+
+        let trace = collector.finish();
+        let events = &trace.records[0].events;
+        let mapping_start = events
+            .iter()
+            .find(|event| event.kind == TraceEventKind::MappingStart)
+            .unwrap();
+        let op_start = events
+            .iter()
+            .find(|event| event.kind == TraceEventKind::OpStart)
+            .unwrap();
+        let op_end = events
+            .iter()
+            .find(|event| event.kind == TraceEventKind::OpEnd)
+            .unwrap();
+        let mapping_end = events
+            .iter()
+            .find(|event| event.kind == TraceEventKind::MappingEnd)
+            .unwrap();
+        assert_eq!(op_start.parent_id, Some(mapping_start.id));
+        assert_eq!(op_end.parent_id, Some(op_start.id));
+        assert_eq!(mapping_end.parent_id, Some(mapping_start.id));
+    }
+
+    #[test]
+    fn collector_freezes_before_unemitted_span_enters_stack() {
+        let mut options = TransformTraceOptions::metadata_only();
+        options.max_events = Some(2);
+        let mut collector = TraceCollector::new(options);
+        collector.start_record(0, &json!({"name":"alice"}));
+
+        assert!(
+            collector
+                .start_span(TraceEventKind::MappingStart, TracePhase::Start)
+                .rule_path("mappings[0]")
+                .finish(&mut collector)
+        );
+        assert!(
+            !collector
+                .start_span(TraceEventKind::OpStart, TracePhase::Start)
+                .operator("uppercase")
+                .finish(&mut collector)
+        );
+        collector
+            .emit(TraceEventKind::SourceRead, TracePhase::Instant)
+            .input_path("@input.name")
+            .finish(&mut collector);
+
+        let trace = collector.finish();
+        assert!(!trace.complete);
+        let ids = trace.records[0]
+            .events
+            .iter()
+            .map(|event| event.id)
+            .collect::<std::collections::BTreeSet<_>>();
+        for event in &trace.records[0].events {
+            if let Some(parent_id) = event.parent_id {
+                assert!(
+                    ids.contains(&parent_id),
+                    "parent_id points to a non-emitted event"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn collector_error_span_records_error_and_closes_span() {
+        let mut collector = TraceCollector::new(TransformTraceOptions::metadata_only());
+        collector.start_record(0, &json!({"name":"alice"}));
+
+        collector
+            .start_span(TraceEventKind::OpStart, TracePhase::Start)
+            .operator("uppercase")
+            .finish(&mut collector);
+        collector
+            .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+            .operator("uppercase")
+            .finish(&mut collector);
+        collector
+            .emit(TraceEventKind::SourceRead, TracePhase::Instant)
+            .input_path("@input.name")
+            .finish(&mut collector);
+
+        let trace = collector.finish();
+        let events = &trace.records[0].events;
+        let op_start = events
+            .iter()
+            .find(|event| event.kind == TraceEventKind::OpStart)
+            .unwrap();
+        let op_error = events
+            .iter()
+            .find(|event| event.kind == TraceEventKind::OpError)
+            .unwrap();
+        let source_read = events
+            .iter()
+            .find(|event| event.kind == TraceEventKind::SourceRead)
+            .unwrap();
+        assert_eq!(op_error.parent_id, Some(op_start.id));
+        assert_eq!(source_read.parent_id, None);
+    }
+
+    #[test]
+    fn canonical_path_helpers_preserve_bracket_notation() {
+        assert_eq!(canonical_input_path(r#"input["@id"]"#), r#"@input["@id"]"#);
+        assert_eq!(canonical_input_path("input[0].name"), "@input[0].name");
+        assert_eq!(canonical_item_path("@item[0].name"), "@item[0].name");
+        assert_eq!(canonical_output_path("$.items[0].name"), "$.items[0].name");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "semantic path namespace mismatch")]
+    fn canonical_path_helpers_detect_namespace_mismatch() {
+        let _ = canonical_input_path("@item.name");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "complete trace finished with open spans")]
+    fn collector_finish_rejects_open_span_after_snapshot_only_truncation() {
+        let mut options = TransformTraceOptions::raw();
+        options.max_snapshot_bytes = Some(1);
+        let mut collector = TraceCollector::new(options);
+        collector.start_record(0, &json!({"name":"alice"}));
+        collector
+            .start_span(TraceEventKind::MappingStart, TracePhase::Start)
+            .finish_with_output(&mut collector, &json!("oversized"), None);
+        let _ = collector.finish();
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "start_record called while a span is open")]
+    fn collector_start_record_requires_empty_span_stack() {
+        let mut collector = TraceCollector::new(TransformTraceOptions::metadata_only());
+        collector.start_record(0, &json!({"name":"alice"}));
+        collector
+            .start_span(TraceEventKind::MappingStart, TracePhase::Start)
+            .finish(&mut collector);
+        collector.start_record(1, &json!({"name":"bob"}));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "start_finalize called while a span is open")]
+    fn collector_start_finalize_requires_empty_span_stack() {
+        let mut collector = TraceCollector::new(TransformTraceOptions::metadata_only());
+        collector.start_record(0, &json!({"name":"alice"}));
+        collector
+            .start_span(TraceEventKind::MappingStart, TracePhase::Start)
+            .finish(&mut collector);
+        collector.start_finalize(&json!([]));
+    }
+}

--- a/crates/rulemorph/src/trace.rs
+++ b/crates/rulemorph/src/trace.rs
@@ -334,6 +334,17 @@ impl TraceValueSnapshot {
                 bytes: Some(bytes),
             },
             TraceValueMode::Redacted(redaction) => {
+                if path_hint.is_none() {
+                    return Self {
+                        state,
+                        value_type,
+                        contains_raw_value: false,
+                        value: None,
+                        visibility: Some("metadata_only".to_string()),
+                        redaction_reason: Some("unknown_provenance".to_string()),
+                        bytes: Some(bytes),
+                    };
+                }
                 if value.is_object() || value.is_array() {
                     return Self {
                         state,

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -765,10 +765,15 @@ pub fn transform_record_with_trace(
     match result {
         Ok(output) => {
             let output = if let Some(finalize) = &rule.finalize {
+                let Some(value) = output else {
+                    return Ok(TransformRecordTraceResult {
+                        output: None,
+                        warnings,
+                        trace: collector.finish(),
+                    });
+                };
                 let mut records = Vec::new();
-                if let Some(value) = output {
-                    records.push(value);
-                }
+                records.push(value);
                 let array = JsonValue::Array(records);
                 collector.start_finalize(&array);
                 match apply_finalize_traced(finalize, array, context, &mut collector) {
@@ -1243,6 +1248,56 @@ fn apply_rule_to_record_traced(
     Ok(Some(output))
 }
 
+#[allow(clippy::too_many_arguments)]
+fn transform_record_with_warnings_inner_traced(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    base_dir: Option<&Path>,
+    branch_context: &mut BranchContext,
+    collector: &mut TraceCollector,
+) -> Result<(Option<JsonValue>, Vec<TransformWarning>), TransformError> {
+    let mut warnings = Vec::new();
+    let output = apply_rule_to_record_traced(
+        rule,
+        record,
+        context,
+        &mut warnings,
+        base_dir,
+        branch_context,
+        collector,
+    )?;
+    let Some(output) = output else {
+        return Ok((None, warnings));
+    };
+
+    if let Some(finalize) = &rule.finalize {
+        let array = JsonValue::Array(vec![output]);
+        collector
+            .start_span(TraceEventKind::FinalizeStart, TracePhase::Start)
+            .rule_path("finalize")
+            .finish_with_output(collector, &array, None);
+        match apply_finalize_traced(finalize, array, context, collector) {
+            Ok(finalized) => {
+                collector
+                    .end_span(TraceEventKind::FinalizeEnd, TracePhase::End)
+                    .rule_path("finalize")
+                    .finish(collector);
+                return Ok((Some(finalized), warnings));
+            }
+            Err(error) => {
+                collector
+                    .error_span(TraceEventKind::Error, "FINALIZE_ERROR", "finalize failed")
+                    .rule_path("finalize")
+                    .finish(collector);
+                return Err(error);
+            }
+        }
+    }
+
+    Ok((Some(output), warnings))
+}
+
 fn apply_rule_to_record(
     rule: &RuleFile,
     record: &JsonValue,
@@ -1381,6 +1436,12 @@ fn apply_steps(
     Ok(Some(out))
 }
 
+enum TracedStepOutcome {
+    Continue,
+    DropRecord,
+    Return(JsonValue),
+}
+
 #[allow(clippy::too_many_arguments)]
 fn apply_steps_traced(
     steps: &[V2RuleStep],
@@ -1402,7 +1463,7 @@ fn apply_steps_traced(
             .attr_index("step_index", step_index)
             .finish(collector);
 
-        let step_result = (|| -> Result<Option<JsonValue>, TransformError> {
+        let step_result = (|| -> Result<TracedStepOutcome, TransformError> {
             if let Some(mappings) = &step.mappings {
                 apply_mappings_into_traced(
                     mappings,
@@ -1414,7 +1475,7 @@ fn apply_steps_traced(
                     &format!("{}.mappings", base_path),
                     collector,
                 )?;
-                return Ok(None);
+                return Ok(TracedStepOutcome::Continue);
             }
 
             if let Some(expr) = &step.record_when {
@@ -1448,9 +1509,9 @@ fn apply_steps_traced(
                     .attr_bool("kept", keep)
                     .finish(collector);
                 if !keep {
-                    return Ok(Some(JsonValue::Null));
+                    return Ok(TracedStepOutcome::DropRecord);
                 }
-                return Ok(None);
+                return Ok(TracedStepOutcome::Continue);
             }
 
             if let Some(asserts) = &step.asserts {
@@ -1480,7 +1541,7 @@ fn apply_steps_traced(
                         .with_path(assert_path));
                     }
                 }
-                return Ok(None);
+                return Ok(TracedStepOutcome::Continue);
             }
 
             if let Some(branch) = &step.branch {
@@ -1508,10 +1569,16 @@ fn apply_steps_traced(
                         .rule_path(&branch_path)
                         .attr_enum("selected_branch", target_field)
                         .finish(collector);
-                    let branch_path_guard =
-                        branch_context.enter(base_dir, target).map_err(|err| {
-                            err.with_path(format!("{}.{}", branch_path, target_field))
-                        })?;
+                    let branch_path_guard = match branch_context.enter(base_dir, target) {
+                        Ok(guard) => guard,
+                        Err(err) => {
+                            collector
+                                .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
+                                .rule_path(&branch_path)
+                                .finish(collector);
+                            return Err(err.with_path(format!("{}.{}", branch_path, target_field)));
+                        }
+                    };
                     let branch_result = (|| {
                         let (branch_rule, branch_base_dir) =
                             load_rule_from_path(base_dir, target, branch_context.allowed_root())
@@ -1519,18 +1586,17 @@ fn apply_steps_traced(
                                     err.with_path(format!("{}.{}", branch_path, target_field))
                                 })?;
                         let branch_input = out.clone();
-                        apply_rule_to_record_traced(
+                        transform_record_with_warnings_inner_traced(
                             &branch_rule,
                             &branch_input,
                             context,
-                            warnings,
                             Some(&branch_base_dir),
                             branch_context,
                             collector,
                         )
                     })();
                     branch_context.exit(branch_path_guard);
-                    let branch_output = match branch_result {
+                    let (branch_output, branch_warnings) = match branch_result {
                         Ok(output) => output,
                         Err(error) => {
                             collector
@@ -1540,12 +1606,13 @@ fn apply_steps_traced(
                             return Err(error);
                         }
                     };
+                    warnings.extend(branch_warnings);
                     let Some(branch_output) = branch_output else {
                         collector
                             .end_span(TraceEventKind::BranchTaken, TracePhase::End)
                             .rule_path(&branch_path)
                             .finish(collector);
-                        return Ok(Some(JsonValue::Null));
+                        return Ok(TracedStepOutcome::DropRecord);
                     };
 
                     if branch.return_ {
@@ -1553,9 +1620,16 @@ fn apply_steps_traced(
                             .end_span(TraceEventKind::BranchTaken, TracePhase::End)
                             .rule_path(&branch_path)
                             .finish_with_output(collector, &branch_output, None);
-                        return Ok(Some(branch_output));
+                        return Ok(TracedStepOutcome::Return(branch_output));
                     }
-                    merge_branch_output(&mut out, &branch_output, &branch_path)?;
+                    if let Err(error) = merge_branch_output(&mut out, &branch_output, &branch_path)
+                    {
+                        collector
+                            .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
+                            .rule_path(&branch_path)
+                            .finish(collector);
+                        return Err(error);
+                    }
                     collector
                         .emit(TraceEventKind::BranchMerge, TracePhase::Instant)
                         .rule_path(&branch_path)
@@ -1565,28 +1639,28 @@ fn apply_steps_traced(
                         .rule_path(&branch_path)
                         .finish(collector);
                 }
-                return Ok(None);
+                return Ok(TracedStepOutcome::Continue);
             }
 
-            Ok(None)
+            Ok(TracedStepOutcome::Continue)
         })();
 
         match step_result {
-            Ok(Some(value)) if value.is_null() => {
+            Ok(TracedStepOutcome::DropRecord) => {
                 collector
                     .end_span(TraceEventKind::StepStart, TracePhase::End)
                     .rule_path(&base_path)
                     .finish(collector);
                 return Ok(None);
             }
-            Ok(Some(value)) => {
+            Ok(TracedStepOutcome::Return(value)) => {
                 collector
                     .end_span(TraceEventKind::StepStart, TracePhase::End)
                     .rule_path(&base_path)
                     .finish_with_output(collector, &value, None);
                 return Ok(Some(value));
             }
-            Ok(None) => {
+            Ok(TracedStepOutcome::Continue) => {
                 collector
                     .end_span(TraceEventKind::StepStart, TracePhase::End)
                     .rule_path(&base_path)
@@ -2812,50 +2886,60 @@ fn eval_expr_traced(
                 .rule_path(base_path)
                 .operator(&expr_op.op)
                 .finish(collector);
-            let mut arg_error = None;
-            for (arg_index, arg) in expr_op.args.iter().enumerate() {
-                let arg_path = format!("{}.args[{}]", base_path, arg_index);
-                let arg_value =
-                    match eval_expr_traced(arg, record, context, out, &arg_path, locals, collector)
-                    {
-                        Ok(value) => value,
-                        Err(error) => {
-                            arg_error = Some(error);
-                            break;
-                        }
-                    };
-                collector
-                    .emit(TraceEventKind::ArgEval, TracePhase::Instant)
-                    .rule_path(&arg_path)
-                    .attr_index("arg_index", arg_index)
-                    .input_eval_value(&arg_value, collector.options(), None)
-                    .finish(collector);
-            }
-            if let Some(error) = arg_error {
-                collector
-                    .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
-                    .rule_path(base_path)
-                    .operator(&expr_op.op)
-                    .finish(collector);
-                Err(error)
-            } else {
-                match eval_op(expr_op, record, context, out, base_path, None, locals) {
-                    Ok(value) => {
-                        collector
-                            .end_span(TraceEventKind::OpEnd, TracePhase::End)
-                            .rule_path(base_path)
-                            .operator(&expr_op.op)
-                            .finish_with_eval_output(collector, &value, None);
-                        Ok(value)
-                    }
-                    Err(error) => {
-                        collector
-                            .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
-                            .rule_path(base_path)
-                            .operator(&expr_op.op)
-                            .finish(collector);
-                        Err(error)
-                    }
+            let op_result = match expr_op.op.as_str() {
+                "coalesce" => eval_coalesce_traced(
+                    &expr_op.args,
+                    None,
+                    record,
+                    context,
+                    out,
+                    base_path,
+                    locals,
+                    collector,
+                ),
+                "and" => eval_bool_and_or_traced(
+                    &expr_op.args,
+                    None,
+                    record,
+                    context,
+                    out,
+                    base_path,
+                    true,
+                    locals,
+                    collector,
+                ),
+                "or" => eval_bool_and_or_traced(
+                    &expr_op.args,
+                    None,
+                    record,
+                    context,
+                    out,
+                    base_path,
+                    false,
+                    locals,
+                    collector,
+                ),
+                _ => eval_eager_op_traced(
+                    expr_op, record, context, out, base_path, locals, collector,
+                ),
+            };
+
+            match op_result {
+                Ok(value) => {
+                    collector
+                        .end_span(TraceEventKind::OpEnd, TracePhase::End)
+                        .rule_path(base_path)
+                        .operator(&expr_op.op)
+                        .finish_with_eval_output(collector, &value, None);
+                    Ok(value)
+                }
+                Err(error) => {
+                    collector
+                        .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                        .rule_path(base_path)
+                        .operator(&expr_op.op)
+                        .finish(collector);
+                    Err(error)
                 }
             }
         }
@@ -2878,6 +2962,168 @@ fn eval_expr_traced(
     }
 
     result
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_eager_op_traced(
+    expr_op: &ExprOp,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    for (arg_index, arg) in expr_op.args.iter().enumerate() {
+        let arg_path = format!("{}.args[{}]", base_path, arg_index);
+        let arg_value = eval_expr_traced(arg, record, context, out, &arg_path, locals, collector)?;
+        emit_arg_eval(collector, &arg_path, arg_index, &arg_value);
+    }
+    eval_op(expr_op, record, context, out, base_path, None, locals)
+}
+
+fn emit_arg_eval(
+    collector: &mut TraceCollector,
+    arg_path: &str,
+    arg_index: usize,
+    arg_value: &EvalValue,
+) {
+    collector
+        .emit(TraceEventKind::ArgEval, TracePhase::Instant)
+        .rule_path(arg_path)
+        .attr_index("arg_index", arg_index)
+        .input_eval_value(arg_value, collector.options(), None)
+        .finish(collector);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_expr_at_index_traced(
+    index: usize,
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    if let Some(injected) = injected {
+        if index == 0 {
+            return Ok(injected.clone());
+        }
+        let arg = args.get(index - 1).ok_or_else(|| {
+            TransformError::new(
+                TransformErrorKind::ExprError,
+                "expr.args index is out of bounds",
+            )
+            .with_path(format!("{}.args[{}]", base_path, index))
+        })?;
+        let arg_path = format!("{}.args[{}]", base_path, index);
+        return eval_expr_traced(arg, record, context, out, &arg_path, locals, collector);
+    }
+
+    let arg = args.get(index).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[{}]", base_path, index))
+    })?;
+    let arg_path = format!("{}.args[{}]", base_path, index);
+    eval_expr_traced(arg, record, context, out, &arg_path, locals, collector)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_coalesce_traced(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len == 0 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must be a non-empty array",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    for index in 0..total_len {
+        let arg_path = format!("{}.args[{}]", base_path, index);
+        let value = eval_expr_at_index_traced(
+            index, args, injected, record, context, out, base_path, locals, collector,
+        )?;
+        emit_arg_eval(collector, &arg_path, index, &value);
+        match value {
+            EvalValue::Missing => continue,
+            EvalValue::Value(value) => {
+                if value.is_null() {
+                    continue;
+                }
+                return Ok(EvalValue::Value(value));
+            }
+        }
+    }
+    Ok(EvalValue::Missing)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_bool_and_or_traced(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    is_and: bool,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len < 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain at least two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let mut saw_missing = false;
+    for index in 0..total_len {
+        let arg_path = format!("{}.args[{}]", base_path, index);
+        let value = eval_expr_at_index_traced(
+            index, args, injected, record, context, out, base_path, locals, collector,
+        )?;
+        emit_arg_eval(collector, &arg_path, index, &value);
+        match value {
+            EvalValue::Missing => {
+                saw_missing = true;
+                continue;
+            }
+            EvalValue::Value(value) => {
+                let flag = value_as_bool(&value, &arg_path)?;
+                if is_and {
+                    if !flag {
+                        return Ok(EvalValue::Value(JsonValue::Bool(false)));
+                    }
+                } else if flag {
+                    return Ok(EvalValue::Value(JsonValue::Bool(true)));
+                }
+            }
+        }
+    }
+
+    if saw_missing {
+        Ok(EvalValue::Missing)
+    } else {
+        Ok(EvalValue::Value(JsonValue::Bool(is_and)))
+    }
 }
 
 fn canonical_ref_path(ref_path: &str) -> String {

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -1042,12 +1042,13 @@ fn apply_mappings_into_traced(
                     .finish(collector);
                 return Err(error);
             }
+            let output_redaction_hint = mapping_output_redaction_hint(mapping);
             collector
                 .emit(TraceEventKind::OutputWrite, TracePhase::Instant)
                 .rule_path(format!("{}.target", mapping_path))
                 .output_path(canonical_output_path(&mapping.target))
                 .attr_path("target_path", canonical_output_path(&mapping.target))
-                .input_value(&value, collector.options(), Some(&mapping.target))
+                .input_value(&value, collector.options(), Some(&output_redaction_hint))
                 .finish(collector);
         }
 
@@ -1057,6 +1058,58 @@ fn apply_mappings_into_traced(
             .finish(collector);
     }
     Ok(())
+}
+
+fn mapping_output_redaction_hint(mapping: &Mapping) -> String {
+    let mut hint = mapping.target.clone();
+    if let Some(source) = &mapping.source {
+        hint.push(' ');
+        hint.push_str(source);
+    }
+    if let Some(expr) = &mapping.expr {
+        collect_expr_redaction_hints(expr, &mut hint);
+    }
+    hint
+}
+
+fn collect_expr_redaction_hints(expr: &Expr, hint: &mut String) {
+    match expr {
+        Expr::Ref(expr_ref) => {
+            hint.push(' ');
+            hint.push_str(&expr_ref.ref_path);
+        }
+        Expr::Op(expr_op) => {
+            for arg in &expr_op.args {
+                collect_expr_redaction_hints(arg, hint);
+            }
+        }
+        Expr::Chain(expr_chain) => {
+            for part in &expr_chain.chain {
+                collect_expr_redaction_hints(part, hint);
+            }
+        }
+        Expr::Literal(value) => collect_json_redaction_hints(value, hint),
+    }
+}
+
+fn collect_json_redaction_hints(value: &JsonValue, hint: &mut String) {
+    match value {
+        JsonValue::String(value) if value.starts_with('@') => {
+            hint.push(' ');
+            hint.push_str(value);
+        }
+        JsonValue::Array(values) => {
+            for value in values {
+                collect_json_redaction_hints(value, hint);
+            }
+        }
+        JsonValue::Object(values) => {
+            for value in values.values() {
+                collect_json_redaction_hints(value, hint);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn apply_rule_to_record_traced(

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -33,9 +33,94 @@ const REGEX_CACHE_CAPACITY: usize = 128;
 const BRANCH_MAX_DEPTH: usize = 64;
 
 #[cfg(test)]
-pub(crate) fn trace_supports_v2_operator(op: &str) -> bool {
-    crate::v2_validator::VALID_V2_OPERATORS.contains(&op)
-}
+pub(crate) const TRACE_GENERIC_V2_OPERATORS: &[&str] = &[
+    "lookup",
+    "lookup_first",
+    "to_string",
+    "pad_start",
+    "pad_end",
+    "+",
+    "-",
+    "*",
+    "/",
+    "multiply",
+    "add",
+    "subtract",
+    "divide",
+    "round",
+    "to_base",
+    "date_format",
+    "to_unixtime",
+    "and",
+    "or",
+    "not",
+    "==",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+    "~=",
+    "eq",
+    "ne",
+    "lt",
+    "lte",
+    "gt",
+    "gte",
+    "match",
+    "merge",
+    "deep_merge",
+    "get",
+    "pick",
+    "omit",
+    "keys",
+    "values",
+    "entries",
+    "len",
+    "from_entries",
+    "object_flatten",
+    "object_unflatten",
+    "map",
+    "filter",
+    "flat_map",
+    "flatten",
+    "take",
+    "drop",
+    "slice",
+    "chunk",
+    "zip",
+    "zip_with",
+    "unzip",
+    "group_by",
+    "key_by",
+    "partition",
+    "unique",
+    "distinct_by",
+    "sort_by",
+    "find",
+    "find_index",
+    "index_of",
+    "contains",
+    "sum",
+    "avg",
+    "min",
+    "max",
+    "reduce",
+    "fold",
+    "first",
+    "last",
+    "string",
+    "int",
+    "float",
+    "bool",
+    "trim",
+    "uppercase",
+    "lowercase",
+    "split",
+    "replace",
+    "concat",
+    "coalesce",
+];
 
 fn regex_cache() -> &'static Mutex<LruCache<String, Regex>> {
     static REGEX_CACHE: OnceLock<Mutex<LruCache<String, Regex>>> = OnceLock::new();
@@ -1048,8 +1133,7 @@ fn apply_mappings_into_traced(
                 .rule_path(format!("{}.target", mapping_path))
                 .output_path(canonical_output_path(&mapping.target))
                 .attr_path("target_path", canonical_output_path(&mapping.target))
-                .input_value(&value, collector.options(), Some(&output_redaction_hint))
-                .finish(collector);
+                .finish_with_output(collector, &value, Some(&output_redaction_hint));
         }
 
         collector
@@ -2281,14 +2365,6 @@ fn eval_v2_step_traced<'a>(
                 .input_v2_eval_value(&pipe_value, collector.options(), None)
                 .attr_count("arg_count", op.args.len())
                 .finish(collector);
-            for (arg_index, _) in op.args.iter().enumerate() {
-                let arg_path = format!("{}.args[{}]", step_path, arg_index);
-                collector
-                    .emit(TraceEventKind::ArgEval, TracePhase::Instant)
-                    .rule_path(&arg_path)
-                    .attr_index("arg_index", arg_index)
-                    .finish(collector);
-            }
             let result =
                 eval_v2_op_step(op, pipe_value.clone(), record, context, out, step_path, ctx);
             let output = match result {
@@ -2385,6 +2461,12 @@ fn eval_v2_step_traced<'a>(
                                     "item failed",
                                 )
                                 .rule_path(&item_path)
+                                .finish(collector);
+                            collector
+                                .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                                .rule_path(step_path)
+                                .operator("map")
+                                .input_v2_eval_value(&pipe_value, collector.options(), None)
                                 .finish(collector);
                             return Err(error);
                         }

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -14,10 +14,16 @@ use crate::normalization::{
     InputData, NormalizationOptions, NormalizedRecords, normalize_records_with_options,
 };
 use crate::path::{PathToken, get_path, parse_path};
+use crate::trace::{
+    TraceCollector, TraceEventKind, TracePhase, TransformRecordTraceResult, TransformTraceError,
+    TransformTraceOptions, TransformTraceResult, canonical_acc_path, canonical_context_path,
+    canonical_input_path, canonical_item_path, canonical_out_path, canonical_output_path,
+};
 use crate::v2_eval::{
     EvalItem as V2EvalItem, EvalValue as V2EvalValue, V2EvalContext, eval_v2_condition,
-    eval_v2_expr, eval_v2_pipe,
+    eval_v2_expr, eval_v2_let_step, eval_v2_op_step, eval_v2_pipe, eval_v2_ref, eval_v2_start,
 };
+use crate::v2_model::{V2Expr, V2Pipe, V2Ref, V2Start, V2Step};
 use crate::v2_parser::{
     is_literal_escape, is_pipe_value, is_v2_ref, parse_v2_condition, parse_v2_expr,
     parse_v2_pipe_from_value,
@@ -25,6 +31,11 @@ use crate::v2_parser::{
 
 const REGEX_CACHE_CAPACITY: usize = 128;
 const BRANCH_MAX_DEPTH: usize = 64;
+
+#[cfg(test)]
+pub(crate) fn trace_supports_v2_operator(op: &str) -> bool {
+    crate::v2_validator::VALID_V2_OPERATORS.contains(&op)
+}
 
 fn regex_cache() -> &'static Mutex<LruCache<String, Regex>> {
     static REGEX_CACHE: OnceLock<Mutex<LruCache<String, Regex>>> = OnceLock::new();
@@ -65,6 +76,52 @@ pub fn transform_input(
     context: Option<&JsonValue>,
 ) -> Result<JsonValue, TransformError> {
     transform_input_with_warnings(rule, input, context).map(|(output, _)| output)
+}
+
+pub fn transform_input_with_trace(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    trace_options: &TransformTraceOptions,
+) -> Result<TransformTraceResult, TransformTraceError> {
+    transform_input_with_trace_with_base_dir_and_options(
+        rule,
+        input,
+        context,
+        None,
+        &NormalizationOptions::default(),
+        trace_options,
+    )
+}
+
+pub fn transform_input_with_trace_with_base_dir_and_options(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: Option<&Path>,
+    options: &NormalizationOptions,
+    trace_options: &TransformTraceOptions,
+) -> Result<TransformTraceResult, TransformTraceError> {
+    let mut collector = TraceCollector::new(trace_options.clone());
+    match transform_with_warnings_inner_traced(
+        rule,
+        input,
+        context,
+        base_dir,
+        options,
+        &mut collector,
+    ) {
+        Ok((output, warnings)) => Ok(TransformTraceResult {
+            output,
+            warnings,
+            trace: collector.finish(),
+        }),
+        Err((error, warnings)) => Err(TransformTraceError {
+            error,
+            warnings,
+            trace: collector.finish(),
+        }),
+    }
 }
 
 pub fn transform_with_options(
@@ -532,6 +589,66 @@ fn transform_with_warnings_inner(
     Ok((output, warnings))
 }
 
+fn transform_with_warnings_inner_traced(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: Option<&Path>,
+    options: &NormalizationOptions,
+    collector: &mut TraceCollector,
+) -> Result<(JsonValue, Vec<TransformWarning>), (TransformError, Vec<TransformWarning>)> {
+    let mut warnings = Vec::new();
+    let mut output_records = Vec::new();
+    let mut records = input_records_iter_with_options(rule, input, options)
+        .map_err(|error| (error, warnings.clone()))?;
+    let mut record_index = 0usize;
+    while let Some(record) = records.next() {
+        let record = record.map_err(|error| (error, warnings.clone()))?;
+        collector.start_record(record_index, &record);
+        record_index += 1;
+        let mut record_warnings = Vec::new();
+        let mut branch_context = BranchContext::default();
+        match apply_rule_to_record_traced(
+            rule,
+            &record,
+            context,
+            &mut record_warnings,
+            base_dir,
+            &mut branch_context,
+            collector,
+        ) {
+            Ok(Some(output)) => output_records.push(output),
+            Ok(None) => {}
+            Err(error) => {
+                warnings.extend(record_warnings);
+                return Err((error, warnings));
+            }
+        }
+        warnings.extend(record_warnings);
+    }
+
+    let mut output = JsonValue::Array(output_records);
+    if let Some(finalize) = &rule.finalize {
+        collector.start_finalize(&output);
+        match apply_finalize_traced(finalize, output, context, collector) {
+            Ok(finalized) => {
+                output = finalized;
+                collector
+                    .end_span(TraceEventKind::FinalizeEnd, TracePhase::End)
+                    .finish(collector);
+            }
+            Err(error) => {
+                collector
+                    .error_span(TraceEventKind::Error, "FINALIZE_ERROR", "finalize failed")
+                    .finish(collector);
+                return Err((error, warnings));
+            }
+        }
+    }
+
+    Ok((output, warnings))
+}
+
 pub fn transform_record(
     rule: &RuleFile,
     record: &JsonValue,
@@ -539,6 +656,69 @@ pub fn transform_record(
 ) -> Result<Option<JsonValue>, TransformError> {
     let (output, _warnings) = transform_record_with_warnings(rule, record, context)?;
     Ok(output)
+}
+
+pub fn transform_record_with_trace(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    trace_options: &TransformTraceOptions,
+) -> Result<TransformRecordTraceResult, TransformTraceError> {
+    let mut collector = TraceCollector::new(trace_options.clone());
+    collector.start_record(0, record);
+    let mut warnings = Vec::new();
+    let mut branch_context = BranchContext::default();
+    let result = apply_rule_to_record_traced(
+        rule,
+        record,
+        context,
+        &mut warnings,
+        None,
+        &mut branch_context,
+        &mut collector,
+    );
+    match result {
+        Ok(output) => {
+            let output = if let Some(finalize) = &rule.finalize {
+                let mut records = Vec::new();
+                if let Some(value) = output {
+                    records.push(value);
+                }
+                let array = JsonValue::Array(records);
+                collector.start_finalize(&array);
+                match apply_finalize_traced(finalize, array, context, &mut collector) {
+                    Ok(finalized) => {
+                        collector
+                            .end_span(TraceEventKind::FinalizeEnd, TracePhase::End)
+                            .finish(&mut collector);
+                        Some(finalized)
+                    }
+                    Err(error) => {
+                        collector
+                            .error_span(TraceEventKind::Error, "FINALIZE_ERROR", "finalize failed")
+                            .finish(&mut collector);
+                        return Err(TransformTraceError {
+                            error,
+                            warnings,
+                            trace: collector.finish(),
+                        });
+                    }
+                }
+            } else {
+                output
+            };
+            Ok(TransformRecordTraceResult {
+                output,
+                warnings,
+                trace: collector.finish(),
+            })
+        }
+        Err(error) => Err(TransformTraceError {
+            error,
+            warnings,
+            trace: collector.finish(),
+        }),
+    }
 }
 
 pub fn transform_record_with_base_dir(
@@ -756,6 +936,176 @@ fn apply_mappings_into(
     Ok(())
 }
 
+fn apply_mappings_traced(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    warnings: &mut Vec<TransformWarning>,
+    collector: &mut TraceCollector,
+) -> Result<JsonValue, TransformError> {
+    let mut out = JsonValue::Object(Map::new());
+    apply_mappings_into_traced(
+        &rule.mappings,
+        record,
+        context,
+        &mut out,
+        warnings,
+        rule.version,
+        "mappings",
+        collector,
+    )?;
+    Ok(out)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_mappings_into_traced(
+    mappings: &[Mapping],
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &mut JsonValue,
+    warnings: &mut Vec<TransformWarning>,
+    rule_version: u8,
+    base_path: &str,
+    collector: &mut TraceCollector,
+) -> Result<(), TransformError> {
+    for (index, mapping) in mappings.iter().enumerate() {
+        let mapping_path = format!("{}[{}]", base_path, index);
+        collector
+            .start_span(TraceEventKind::MappingStart, TracePhase::Start)
+            .rule_path(&mapping_path)
+            .attr_index("mapping_index", index)
+            .finish(collector);
+
+        let applied = if mapping.when.is_some() {
+            let when_path = format!("{}.when", mapping_path);
+            collector
+                .start_span(TraceEventKind::MappingWhenStart, TracePhase::Start)
+                .rule_path(&when_path)
+                .finish(collector);
+            let flag = eval_when(
+                mapping,
+                record,
+                context,
+                out,
+                &mapping_path,
+                warnings,
+                rule_version,
+            );
+            collector
+                .end_span(TraceEventKind::MappingWhenEnd, TracePhase::End)
+                .rule_path(&when_path)
+                .finish_with_output(collector, &JsonValue::Bool(flag), None);
+            flag
+        } else {
+            true
+        };
+
+        collector
+            .emit(TraceEventKind::MappingDecision, TracePhase::Instant)
+            .rule_path(&mapping_path)
+            .attr_bool("applied", applied)
+            .attr_enum("skip_reason", if applied { "none" } else { "when_false" })
+            .finish(collector);
+
+        if !applied {
+            collector
+                .end_span(TraceEventKind::MappingEnd, TracePhase::End)
+                .rule_path(&mapping_path)
+                .finish(collector);
+            continue;
+        }
+
+        let value = match eval_mapping_traced(
+            mapping,
+            record,
+            context,
+            out,
+            &mapping_path,
+            rule_version,
+            collector,
+        ) {
+            Ok(value) => value,
+            Err(error) => {
+                collector
+                    .error_span(TraceEventKind::Error, "MAPPING_ERROR", "mapping failed")
+                    .rule_path(&mapping_path)
+                    .finish(collector);
+                return Err(error);
+            }
+        };
+
+        if let Some(value) = value {
+            if let Err(error) = set_path(out, &mapping.target, value.clone(), &mapping_path) {
+                collector
+                    .error_span(TraceEventKind::Error, "MAPPING_ERROR", "mapping failed")
+                    .rule_path(&mapping_path)
+                    .finish(collector);
+                return Err(error);
+            }
+            collector
+                .emit(TraceEventKind::OutputWrite, TracePhase::Instant)
+                .rule_path(format!("{}.target", mapping_path))
+                .output_path(canonical_output_path(&mapping.target))
+                .attr_path("target_path", canonical_output_path(&mapping.target))
+                .input_value(&value, collector.options(), Some(&mapping.target))
+                .finish(collector);
+        }
+
+        collector
+            .end_span(TraceEventKind::MappingEnd, TracePhase::End)
+            .rule_path(&mapping_path)
+            .finish(collector);
+    }
+    Ok(())
+}
+
+fn apply_rule_to_record_traced(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    warnings: &mut Vec<TransformWarning>,
+    base_dir: Option<&Path>,
+    branch_context: &mut BranchContext,
+    collector: &mut TraceCollector,
+) -> Result<Option<JsonValue>, TransformError> {
+    if let Some(steps) = &rule.steps {
+        return apply_steps_traced(
+            steps,
+            record,
+            context,
+            warnings,
+            rule.version,
+            base_dir,
+            branch_context,
+            collector,
+        );
+    }
+
+    if rule.record_when.is_some() {
+        collector
+            .start_span(TraceEventKind::RecordWhenStart, TracePhase::Start)
+            .rule_path("record_when")
+            .finish(collector);
+    }
+    let keep = eval_record_when(rule, record, context, warnings);
+    if rule.record_when.is_some() {
+        collector
+            .end_span(TraceEventKind::RecordWhenEnd, TracePhase::End)
+            .rule_path("record_when")
+            .finish_with_output(collector, &JsonValue::Bool(keep), None);
+    }
+    collector
+        .emit(TraceEventKind::RecordDecision, TracePhase::Instant)
+        .attr_bool("kept", keep)
+        .finish(collector);
+    if !keep {
+        return Ok(None);
+    }
+
+    let output = apply_mappings_traced(rule, record, context, warnings, collector)?;
+    Ok(Some(output))
+}
+
 fn apply_rule_to_record(
     rule: &RuleFile,
     record: &JsonValue,
@@ -888,6 +1238,213 @@ fn apply_steps(
                 merge_branch_output(&mut out, &branch_output, &branch_path)?;
             }
             continue;
+        }
+    }
+
+    Ok(Some(out))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_steps_traced(
+    steps: &[V2RuleStep],
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    warnings: &mut Vec<TransformWarning>,
+    rule_version: u8,
+    base_dir: Option<&Path>,
+    branch_context: &mut BranchContext,
+    collector: &mut TraceCollector,
+) -> Result<Option<JsonValue>, TransformError> {
+    let mut out = JsonValue::Object(Map::new());
+
+    for (step_index, step) in steps.iter().enumerate() {
+        let base_path = format!("steps[{}]", step_index);
+        collector
+            .start_span(TraceEventKind::StepStart, TracePhase::Start)
+            .rule_path(&base_path)
+            .attr_index("step_index", step_index)
+            .finish(collector);
+
+        let step_result = (|| -> Result<Option<JsonValue>, TransformError> {
+            if let Some(mappings) = &step.mappings {
+                apply_mappings_into_traced(
+                    mappings,
+                    record,
+                    context,
+                    &mut out,
+                    warnings,
+                    rule_version,
+                    &format!("{}.mappings", base_path),
+                    collector,
+                )?;
+                return Ok(None);
+            }
+
+            if let Some(expr) = &step.record_when {
+                let when_path = format!("{}.record_when", base_path);
+                collector
+                    .start_span(TraceEventKind::RecordWhenStart, TracePhase::Start)
+                    .rule_path(&when_path)
+                    .finish(collector);
+                let keep = eval_when_expr(expr, record, context, &out, &when_path, rule_version)?;
+                collector
+                    .end_span(TraceEventKind::RecordWhenEnd, TracePhase::End)
+                    .rule_path(&when_path)
+                    .finish_with_output(collector, &JsonValue::Bool(keep), None);
+                collector
+                    .emit(TraceEventKind::RecordDecision, TracePhase::Instant)
+                    .rule_path(&when_path)
+                    .attr_bool("kept", keep)
+                    .finish(collector);
+                if !keep {
+                    return Ok(Some(JsonValue::Null));
+                }
+                return Ok(None);
+            }
+
+            if let Some(asserts) = &step.asserts {
+                for (assert_index, assert) in asserts.iter().enumerate() {
+                    let assert_path = format!("{}.asserts[{}]", base_path, assert_index);
+                    let ok = eval_when_expr(
+                        &assert.when,
+                        record,
+                        context,
+                        &out,
+                        &format!("{}.when", assert_path),
+                        rule_version,
+                    )?;
+                    collector
+                        .emit(TraceEventKind::AssertEval, TracePhase::Instant)
+                        .rule_path(&assert_path)
+                        .attr_index("assert_index", assert_index)
+                        .finish_with_output(collector, &JsonValue::Bool(ok), None);
+                    if !ok {
+                        return Err(TransformError::new(
+                            TransformErrorKind::AssertionFailed,
+                            "assert failed",
+                        )
+                        .with_path(assert_path));
+                    }
+                }
+                return Ok(None);
+            }
+
+            if let Some(branch) = &step.branch {
+                let branch_path = format!("{}.branch", base_path);
+                let take = eval_when_expr(
+                    &branch.when,
+                    record,
+                    context,
+                    &out,
+                    &format!("{}.when", branch_path),
+                    rule_version,
+                )?;
+                collector
+                    .emit(TraceEventKind::BranchEval, TracePhase::Instant)
+                    .rule_path(format!("{}.when", branch_path))
+                    .finish_with_output(collector, &JsonValue::Bool(take), None);
+                let (target, target_field) = if take {
+                    (Some(branch.then.as_str()), "then")
+                } else {
+                    (branch.r#else.as_deref(), "else")
+                };
+                if let Some(target) = target {
+                    collector
+                        .start_span(TraceEventKind::BranchTaken, TracePhase::Start)
+                        .rule_path(&branch_path)
+                        .attr_enum("selected_branch", target_field)
+                        .finish(collector);
+                    let branch_path_guard =
+                        branch_context.enter(base_dir, target).map_err(|err| {
+                            err.with_path(format!("{}.{}", branch_path, target_field))
+                        })?;
+                    let branch_result = (|| {
+                        let (branch_rule, branch_base_dir) =
+                            load_rule_from_path(base_dir, target, branch_context.allowed_root())
+                                .map_err(|err| {
+                                    err.with_path(format!("{}.{}", branch_path, target_field))
+                                })?;
+                        let branch_input = out.clone();
+                        apply_rule_to_record_traced(
+                            &branch_rule,
+                            &branch_input,
+                            context,
+                            warnings,
+                            Some(&branch_base_dir),
+                            branch_context,
+                            collector,
+                        )
+                    })();
+                    branch_context.exit(branch_path_guard);
+                    let branch_output = match branch_result {
+                        Ok(output) => output,
+                        Err(error) => {
+                            collector
+                                .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
+                                .rule_path(&branch_path)
+                                .finish(collector);
+                            return Err(error);
+                        }
+                    };
+                    let Some(branch_output) = branch_output else {
+                        collector
+                            .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+                            .rule_path(&branch_path)
+                            .finish(collector);
+                        return Ok(Some(JsonValue::Null));
+                    };
+
+                    if branch.return_ {
+                        collector
+                            .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+                            .rule_path(&branch_path)
+                            .finish_with_output(collector, &branch_output, None);
+                        return Ok(Some(branch_output));
+                    }
+                    merge_branch_output(&mut out, &branch_output, &branch_path)?;
+                    collector
+                        .emit(TraceEventKind::BranchMerge, TracePhase::Instant)
+                        .rule_path(&branch_path)
+                        .finish_with_output(collector, &out, None);
+                    collector
+                        .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+                        .rule_path(&branch_path)
+                        .finish(collector);
+                }
+                return Ok(None);
+            }
+
+            Ok(None)
+        })();
+
+        match step_result {
+            Ok(Some(value)) if value.is_null() => {
+                collector
+                    .end_span(TraceEventKind::StepStart, TracePhase::End)
+                    .rule_path(&base_path)
+                    .finish(collector);
+                return Ok(None);
+            }
+            Ok(Some(value)) => {
+                collector
+                    .end_span(TraceEventKind::StepStart, TracePhase::End)
+                    .rule_path(&base_path)
+                    .finish_with_output(collector, &value, None);
+                return Ok(Some(value));
+            }
+            Ok(None) => {
+                collector
+                    .end_span(TraceEventKind::StepStart, TracePhase::End)
+                    .rule_path(&base_path)
+                    .finish(collector);
+            }
+            Err(error) => {
+                collector
+                    .error_span(TraceEventKind::Error, "STEP_ERROR", "step failed")
+                    .rule_path(&base_path)
+                    .finish(collector);
+                return Err(error);
+            }
         }
     }
 
@@ -1158,6 +1715,146 @@ fn apply_finalize(
     Ok(output)
 }
 
+fn apply_finalize_traced(
+    finalize: &FinalizeSpec,
+    output: JsonValue,
+    context: Option<&JsonValue>,
+    collector: &mut TraceCollector,
+) -> Result<JsonValue, TransformError> {
+    let mut records = match output {
+        JsonValue::Array(records) => records,
+        _ => {
+            return Err(TransformError::new(
+                TransformErrorKind::InvalidInput,
+                "finalize expects array output",
+            )
+            .with_path("finalize"));
+        }
+    };
+
+    if let Some(filter) = &finalize.filter {
+        let raw = expr_to_json_for_v2_condition(filter).ok_or_else(|| {
+            TransformError::new(
+                TransformErrorKind::ExprError,
+                "finalize.filter must be a v2 condition",
+            )
+            .with_path("finalize.filter")
+        })?;
+        let cond = parse_v2_condition(&raw).map_err(|err| {
+            TransformError::new(
+                TransformErrorKind::ExprError,
+                format!("invalid v2 condition: {}", err),
+            )
+            .with_path("finalize.filter")
+        })?;
+        let base_out = JsonValue::Array(records.clone());
+        let before_count = records.len();
+        let mut filtered = Vec::new();
+        for (index, item) in records.iter().enumerate() {
+            let ctx = V2EvalContext::new().with_item(V2EvalItem { value: item, index });
+            let keep = eval_v2_condition(&cond, item, context, &base_out, "finalize.filter", &ctx)?;
+            if keep {
+                filtered.push(item.clone());
+            }
+        }
+        records = filtered;
+        collector
+            .emit(TraceEventKind::FinalizeFilter, TracePhase::Instant)
+            .rule_path("finalize.filter")
+            .attr_count("input_count", before_count)
+            .attr_count("output_count", records.len())
+            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+    }
+
+    if let Some(sort) = &finalize.sort {
+        let tokens = parse_path(&sort.by).map_err(|_| {
+            TransformError::new(
+                TransformErrorKind::InvalidRecordsPath,
+                "finalize.sort.by is invalid",
+            )
+            .with_path("finalize.sort.by")
+        })?;
+
+        struct SortItem {
+            key: SortKey,
+            index: usize,
+            value: JsonValue,
+        }
+
+        let mut items = Vec::with_capacity(records.len());
+        for (index, item) in records.iter().enumerate() {
+            let key_value = get_path(item, &tokens).ok_or_else(|| {
+                TransformError::new(
+                    TransformErrorKind::InvalidRef,
+                    "finalize.sort.by path not found",
+                )
+                .with_path("finalize.sort.by")
+            })?;
+            let key = sort_key_from_value(key_value, "finalize.sort.by")?;
+            items.push(SortItem {
+                key,
+                index,
+                value: item.clone(),
+            });
+        }
+
+        items.sort_by(|left, right| {
+            let mut ordering = compare_sort_keys(&left.key, &right.key);
+            if sort.order == "desc" {
+                ordering = ordering.reverse();
+            }
+            if ordering == Ordering::Equal {
+                left.index.cmp(&right.index)
+            } else {
+                ordering
+            }
+        });
+
+        records = items.into_iter().map(|item| item.value).collect();
+        collector
+            .emit(TraceEventKind::FinalizeSort, TracePhase::Instant)
+            .rule_path("finalize.sort")
+            .attr_enum("order", if sort.order == "desc" { "desc" } else { "asc" })
+            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+    }
+
+    if let Some(offset) = finalize.offset {
+        if offset > 0 && offset < records.len() {
+            records = records.split_off(offset);
+        } else if offset >= records.len() {
+            records = Vec::new();
+        }
+        collector
+            .emit(TraceEventKind::FinalizeOffset, TracePhase::Instant)
+            .rule_path("finalize.offset")
+            .attr_index("offset", offset)
+            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+    }
+
+    if let Some(limit) = finalize.limit {
+        if limit < records.len() {
+            records.truncate(limit);
+        }
+        collector
+            .emit(TraceEventKind::FinalizeLimit, TracePhase::Instant)
+            .rule_path("finalize.limit")
+            .attr_count("limit", limit)
+            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+    }
+
+    let output = JsonValue::Array(records);
+    if let Some(wrap) = &finalize.wrap {
+        let wrapped = eval_wrap_value(wrap, &output, context, "finalize.wrap")?;
+        collector
+            .emit(TraceEventKind::FinalizeWrap, TracePhase::Instant)
+            .rule_path("finalize.wrap")
+            .finish_with_output(collector, &wrapped, None);
+        return Ok(wrapped);
+    }
+
+    Ok(output)
+}
+
 fn eval_wrap_value(
     value: &JsonValue,
     out: &JsonValue,
@@ -1324,6 +2021,492 @@ fn eval_mapping(
     Ok(Some(value))
 }
 
+fn eval_mapping_traced(
+    mapping: &crate::model::Mapping,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    mapping_path: &str,
+    version: u8,
+    collector: &mut TraceCollector,
+) -> Result<Option<JsonValue>, TransformError> {
+    let value = if let Some(source) = &mapping.source {
+        let value = resolve_source(source, record, context, out, mapping_path)?;
+        collector
+            .emit(TraceEventKind::SourceRead, TracePhase::Instant)
+            .rule_path(format!("{}.source", mapping_path))
+            .input_path(canonical_source_path(source))
+            .finish_with_eval_output(collector, &value, Some(source));
+        value
+    } else if let Some(literal) = &mapping.value {
+        collector
+            .emit(TraceEventKind::LiteralEval, TracePhase::Instant)
+            .rule_path(format!("{}.value", mapping_path))
+            .finish_with_output(collector, literal, None);
+        EvalValue::Value(literal.clone())
+    } else if let Some(expr) = &mapping.expr {
+        if version >= 2 {
+            let expr_path = format!("{}.expr", mapping_path);
+            let v2_json = expr_to_json_for_v2_pipe(expr);
+            if let Some(json_val) = v2_json {
+                let v2_pipe = parse_v2_pipe_from_value(&json_val).map_err(|e| {
+                    TransformError::new(TransformErrorKind::ExprError, e.to_string())
+                        .with_path(&expr_path)
+                })?;
+                let v2_ctx = V2EvalContext::new();
+                let v2_result = eval_v2_pipe_traced(
+                    &v2_pipe, record, context, out, &expr_path, &v2_ctx, collector,
+                )?;
+                match v2_result {
+                    V2EvalValue::Missing => EvalValue::Missing,
+                    V2EvalValue::Value(v) => EvalValue::Value(v),
+                }
+            } else {
+                eval_expr_traced(expr, record, context, out, &expr_path, None, collector)?
+            }
+        } else {
+            eval_expr_traced(
+                expr,
+                record,
+                context,
+                out,
+                &format!("{}.expr", mapping_path),
+                None,
+                collector,
+            )?
+        }
+    } else {
+        return Err(TransformError::new(
+            TransformErrorKind::InvalidInput,
+            "mapping must define source, value, or expr",
+        )
+        .with_path(mapping_path));
+    };
+
+    let mut value = match value {
+        EvalValue::Missing => {
+            if let Some(default) = &mapping.default {
+                collector
+                    .emit(TraceEventKind::DefaultApplied, TracePhase::Instant)
+                    .rule_path(format!("{}.default", mapping_path))
+                    .finish_with_output(collector, default, None);
+                default.clone()
+            } else if mapping.required {
+                return Err(TransformError::new(
+                    TransformErrorKind::MissingRequired,
+                    "required value is missing",
+                )
+                .with_path(mapping_path));
+            } else {
+                return Ok(None);
+            }
+        }
+        EvalValue::Value(value) => value,
+    };
+
+    if value.is_null() {
+        if mapping.required {
+            return Err(TransformError::new(
+                TransformErrorKind::MissingRequired,
+                "required value is null",
+            )
+            .with_path(mapping_path));
+        }
+        return Ok(Some(value));
+    }
+
+    if let Some(type_name) = &mapping.value_type {
+        value = cast_value(&value, type_name, &format!("{}.type", mapping_path))?;
+        collector
+            .emit(TraceEventKind::TypeCast, TracePhase::Instant)
+            .rule_path(format!("{}.type", mapping_path))
+            .finish_with_output(collector, &value, None);
+    }
+
+    Ok(Some(value))
+}
+
+fn canonical_source_path(source: &str) -> String {
+    match parse_source(source) {
+        Ok((Namespace::Input, path)) => canonical_input_path(path),
+        Ok((Namespace::Context, path)) => canonical_context_path(path),
+        Ok((Namespace::Out, path)) => canonical_out_path(path),
+        _ => canonical_input_path(source),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_pipe_traced<'a>(
+    pipe: &V2Pipe,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    base_path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    collector
+        .start_span(TraceEventKind::ExprStart, TracePhase::Start)
+        .rule_path(base_path)
+        .finish(collector);
+
+    let mut current = match eval_v2_start(&pipe.start, record, context, out, base_path, ctx) {
+        Ok(value) => {
+            emit_v2_start_trace(&pipe.start, &value, base_path, collector);
+            value
+        }
+        Err(error) => {
+            collector
+                .error_span(TraceEventKind::Error, "EXPR_ERROR", "expression failed")
+                .rule_path(base_path)
+                .finish(collector);
+            return Err(error);
+        }
+    };
+    let mut current_ctx = ctx.clone();
+
+    for (step_index, step) in pipe.steps.iter().enumerate() {
+        let step_path = format!("{}[{}]", base_path, step_index + 1);
+        current_ctx = current_ctx.clone().with_pipe_value(current.clone());
+        current = match eval_v2_step_traced(
+            step,
+            current,
+            record,
+            context,
+            out,
+            &step_path,
+            &current_ctx,
+            collector,
+        ) {
+            Ok(value) => value,
+            Err(error) => {
+                collector
+                    .error_span(TraceEventKind::Error, "EXPR_ERROR", "expression failed")
+                    .rule_path(base_path)
+                    .finish(collector);
+                return Err(error);
+            }
+        };
+    }
+
+    collector
+        .end_span(TraceEventKind::ExprEnd, TracePhase::End)
+        .rule_path(base_path)
+        .finish_with_v2_eval_output(collector, &current, None);
+    Ok(current)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_step_traced<'a>(
+    step: &V2Step,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    step_path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    match step {
+        V2Step::Op(op) => {
+            collector
+                .start_span(TraceEventKind::OpStart, TracePhase::Start)
+                .rule_path(step_path)
+                .operator(&op.op)
+                .input_v2_eval_value(&pipe_value, collector.options(), None)
+                .attr_count("arg_count", op.args.len())
+                .finish(collector);
+            for (arg_index, _arg) in op.args.iter().enumerate() {
+                let arg_path = format!("{}.args[{}]", step_path, arg_index);
+                let arg_value = match eval_v2_expr_with_trace(
+                    _arg, record, context, out, &arg_path, ctx, collector,
+                ) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        collector
+                            .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                            .rule_path(step_path)
+                            .operator(&op.op)
+                            .input_v2_eval_value(&pipe_value, collector.options(), None)
+                            .finish(collector);
+                        return Err(error);
+                    }
+                };
+                collector
+                    .emit(TraceEventKind::ArgEval, TracePhase::Instant)
+                    .rule_path(&arg_path)
+                    .attr_index("arg_index", arg_index)
+                    .input_v2_eval_value(&arg_value, collector.options(), None)
+                    .finish(collector);
+            }
+            let result =
+                eval_v2_op_step(op, pipe_value.clone(), record, context, out, step_path, ctx);
+            let output = match result {
+                Ok(output) => output,
+                Err(error) => {
+                    collector
+                        .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                        .rule_path(step_path)
+                        .operator(&op.op)
+                        .input_v2_eval_value(&pipe_value, collector.options(), None)
+                        .finish(collector);
+                    return Err(error);
+                }
+            };
+            collector
+                .end_span(TraceEventKind::OpEnd, TracePhase::End)
+                .rule_path(step_path)
+                .operator(&op.op)
+                .input_v2_eval_value(&pipe_value, collector.options(), None)
+                .finish_with_v2_eval_output(collector, &output, None);
+            Ok(output)
+        }
+        V2Step::Map(map) => {
+            collector
+                .start_span(TraceEventKind::OpStart, TracePhase::Start)
+                .rule_path(step_path)
+                .operator("map")
+                .input_v2_eval_value(&pipe_value, collector.options(), None)
+                .finish(collector);
+            let arr = match &pipe_value {
+                V2EvalValue::Missing => {
+                    collector
+                        .end_span(TraceEventKind::OpEnd, TracePhase::End)
+                        .rule_path(step_path)
+                        .operator("map")
+                        .finish_with_v2_eval_output(collector, &V2EvalValue::Missing, None);
+                    return Ok(V2EvalValue::Missing);
+                }
+                V2EvalValue::Value(JsonValue::Array(arr)) => arr,
+                V2EvalValue::Value(_) => {
+                    collector
+                        .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                        .rule_path(step_path)
+                        .operator("map")
+                        .finish(collector);
+                    return Err(TransformError::new(
+                        TransformErrorKind::ExprError,
+                        "map step requires array",
+                    )
+                    .with_path(step_path));
+                }
+            };
+            let mut results = Vec::with_capacity(arr.len());
+            for (index, item_value) in arr.iter().enumerate() {
+                let item_path = format!("{}[{}]", step_path, index);
+                let item_eval_value = V2EvalValue::Value(item_value.clone());
+                let item_ctx = ctx
+                    .clone()
+                    .with_pipe_value(item_eval_value.clone())
+                    .with_item(V2EvalItem {
+                        value: item_value,
+                        index,
+                    });
+                let mut current = item_eval_value;
+                let mut step_ctx = item_ctx.clone();
+
+                collector
+                    .start_span(TraceEventKind::CollectionItemStart, TracePhase::Start)
+                    .rule_path(&item_path)
+                    .input_path(canonical_item_path(""))
+                    .attr_index("item_index", index)
+                    .attr_enum("scope", "item")
+                    .input_value(item_value, collector.options(), Some("@item"))
+                    .finish(collector);
+
+                for (nested_index, nested_step) in map.steps.iter().enumerate() {
+                    step_ctx = step_ctx.clone().with_pipe_value(current.clone());
+                    current = match eval_v2_step_traced(
+                        nested_step,
+                        current,
+                        record,
+                        context,
+                        out,
+                        &format!("{}.step[{}]", item_path, nested_index),
+                        &step_ctx,
+                        collector,
+                    ) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            collector
+                                .error_span(
+                                    TraceEventKind::Error,
+                                    "COLLECTION_ERROR",
+                                    "item failed",
+                                )
+                                .rule_path(&item_path)
+                                .finish(collector);
+                            return Err(error);
+                        }
+                    };
+                }
+                collector
+                    .end_span(TraceEventKind::CollectionItemEnd, TracePhase::End)
+                    .rule_path(&item_path)
+                    .finish_with_v2_eval_output(collector, &current, Some("@item"));
+                if let V2EvalValue::Value(value) = current {
+                    results.push(value);
+                }
+            }
+            collector
+                .end_span(TraceEventKind::OpEnd, TracePhase::End)
+                .rule_path(step_path)
+                .operator("map")
+                .finish_with_v2_eval_output(
+                    collector,
+                    &V2EvalValue::Value(JsonValue::Array(results.clone())),
+                    None,
+                );
+            Ok(V2EvalValue::Value(JsonValue::Array(results)))
+        }
+        V2Step::Let(let_step) => {
+            let new_ctx = eval_v2_let_step(
+                let_step,
+                pipe_value.clone(),
+                record,
+                context,
+                out,
+                step_path,
+                ctx,
+            )?;
+            collector
+                .emit(TraceEventKind::ChainStep, TracePhase::Instant)
+                .rule_path(step_path)
+                .input_v2_eval_value(&pipe_value, collector.options(), None)
+                .finish(collector);
+            Ok(new_ctx.get_pipe_value().cloned().unwrap_or(pipe_value))
+        }
+        V2Step::If(if_step) => {
+            let cond_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
+            let cond_path = format!("{}.cond", step_path);
+            let cond =
+                eval_v2_condition(&if_step.cond, record, context, out, &cond_path, &cond_ctx)?;
+            collector
+                .emit(TraceEventKind::BranchEval, TracePhase::Instant)
+                .rule_path(&cond_path)
+                .finish_with_output(collector, &JsonValue::Bool(cond), None);
+            if cond {
+                collector
+                    .start_span(TraceEventKind::BranchTaken, TracePhase::Start)
+                    .rule_path(step_path)
+                    .attr_enum("selected_branch", "then")
+                    .finish(collector);
+                let result = eval_v2_pipe_traced(
+                    &if_step.then_branch,
+                    record,
+                    context,
+                    out,
+                    &format!("{}.then", step_path),
+                    &cond_ctx,
+                    collector,
+                )?;
+                collector
+                    .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+                    .rule_path(step_path)
+                    .finish_with_v2_eval_output(collector, &result, None);
+                Ok(result)
+            } else if let Some(else_branch) = &if_step.else_branch {
+                collector
+                    .start_span(TraceEventKind::BranchTaken, TracePhase::Start)
+                    .rule_path(step_path)
+                    .attr_enum("selected_branch", "else")
+                    .finish(collector);
+                let result = eval_v2_pipe_traced(
+                    else_branch,
+                    record,
+                    context,
+                    out,
+                    &format!("{}.else", step_path),
+                    &cond_ctx,
+                    collector,
+                )?;
+                collector
+                    .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+                    .rule_path(step_path)
+                    .finish_with_v2_eval_output(collector, &result, None);
+                Ok(result)
+            } else {
+                Ok(pipe_value)
+            }
+        }
+        V2Step::Ref(v2_ref) => {
+            let result = eval_v2_ref(v2_ref, record, context, out, step_path, ctx)?;
+            let mut event = collector
+                .emit(TraceEventKind::RefRead, TracePhase::Instant)
+                .rule_path(step_path);
+            if let Some(path) = canonical_v2_ref_path(v2_ref) {
+                event = event.input_path(path);
+            }
+            event.finish_with_v2_eval_output(collector, &result, None);
+            Ok(result)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_expr_with_trace<'a>(
+    expr: &V2Expr,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    match expr {
+        V2Expr::Pipe(pipe) => eval_v2_pipe_traced(pipe, record, context, out, path, ctx, collector),
+        V2Expr::V1Fallback(expr) => {
+            let result = eval_expr_traced(expr, record, context, out, path, None, collector)?;
+            Ok(match result {
+                EvalValue::Missing => V2EvalValue::Missing,
+                EvalValue::Value(value) => V2EvalValue::Value(value),
+            })
+        }
+    }
+}
+
+fn emit_v2_start_trace(
+    start: &V2Start,
+    value: &V2EvalValue,
+    path: &str,
+    collector: &mut TraceCollector,
+) {
+    match start {
+        V2Start::Ref(v2_ref) => {
+            let mut event = collector
+                .emit(TraceEventKind::RefRead, TracePhase::Instant)
+                .rule_path(path);
+            if let Some(input_path) = canonical_v2_ref_path(v2_ref) {
+                event = event.input_path(input_path);
+            }
+            event.finish_with_v2_eval_output(collector, value, None);
+        }
+        V2Start::Literal(_) => {
+            collector
+                .emit(TraceEventKind::LiteralEval, TracePhase::Instant)
+                .rule_path(path)
+                .finish_with_v2_eval_output(collector, value, None);
+        }
+        V2Start::PipeValue | V2Start::V1Expr(_) => {
+            collector
+                .emit(TraceEventKind::ChainStep, TracePhase::Instant)
+                .rule_path(path)
+                .finish_with_v2_eval_output(collector, value, None);
+        }
+    }
+}
+
+fn canonical_v2_ref_path(v2_ref: &V2Ref) -> Option<String> {
+    match v2_ref {
+        V2Ref::Input(path) => Some(canonical_input_path(path)),
+        V2Ref::Context(path) => Some(canonical_context_path(path)),
+        V2Ref::Out(path) => Some(canonical_out_path(path)),
+        V2Ref::Item(path) => Some(canonical_item_path(path)),
+        V2Ref::Acc(path) => Some(canonical_acc_path(path)),
+        V2Ref::Local(_) => None,
+    }
+}
+
 fn eval_when(
     mapping: &crate::model::Mapping,
     record: &JsonValue,
@@ -1473,6 +2656,123 @@ fn eval_expr(
         Expr::Ref(expr_ref) => eval_ref(expr_ref, record, context, out, base_path, locals),
         Expr::Op(expr_op) => eval_op(expr_op, record, context, out, base_path, None, locals),
         Expr::Chain(expr_chain) => eval_chain(expr_chain, record, context, out, base_path, locals),
+    }
+}
+
+fn eval_expr_traced(
+    expr: &Expr,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    collector
+        .start_span(TraceEventKind::ExprStart, TracePhase::Start)
+        .rule_path(base_path)
+        .finish(collector);
+
+    let result = match expr {
+        Expr::Literal(value) => {
+            let value = EvalValue::Value(value.clone());
+            collector
+                .emit(TraceEventKind::LiteralEval, TracePhase::Instant)
+                .rule_path(base_path)
+                .finish_with_eval_output(collector, &value, None);
+            Ok(value)
+        }
+        Expr::Ref(expr_ref) => {
+            let value = eval_ref(expr_ref, record, context, out, base_path, locals);
+            if let Ok(value) = &value {
+                collector
+                    .emit(TraceEventKind::RefRead, TracePhase::Instant)
+                    .rule_path(base_path)
+                    .input_path(canonical_ref_path(&expr_ref.ref_path))
+                    .finish_with_eval_output(collector, value, Some(&expr_ref.ref_path));
+            }
+            value
+        }
+        Expr::Op(expr_op) => {
+            collector
+                .start_span(TraceEventKind::OpStart, TracePhase::Start)
+                .rule_path(base_path)
+                .operator(&expr_op.op)
+                .finish(collector);
+            let mut arg_error = None;
+            for (arg_index, arg) in expr_op.args.iter().enumerate() {
+                let arg_path = format!("{}.args[{}]", base_path, arg_index);
+                let arg_value =
+                    match eval_expr_traced(arg, record, context, out, &arg_path, locals, collector)
+                    {
+                        Ok(value) => value,
+                        Err(error) => {
+                            arg_error = Some(error);
+                            break;
+                        }
+                    };
+                collector
+                    .emit(TraceEventKind::ArgEval, TracePhase::Instant)
+                    .rule_path(&arg_path)
+                    .attr_index("arg_index", arg_index)
+                    .input_eval_value(&arg_value, collector.options(), None)
+                    .finish(collector);
+            }
+            if let Some(error) = arg_error {
+                collector
+                    .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                    .rule_path(base_path)
+                    .operator(&expr_op.op)
+                    .finish(collector);
+                Err(error)
+            } else {
+                match eval_op(expr_op, record, context, out, base_path, None, locals) {
+                    Ok(value) => {
+                        collector
+                            .end_span(TraceEventKind::OpEnd, TracePhase::End)
+                            .rule_path(base_path)
+                            .operator(&expr_op.op)
+                            .finish_with_eval_output(collector, &value, None);
+                        Ok(value)
+                    }
+                    Err(error) => {
+                        collector
+                            .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                            .rule_path(base_path)
+                            .operator(&expr_op.op)
+                            .finish(collector);
+                        Err(error)
+                    }
+                }
+            }
+        }
+        Expr::Chain(expr_chain) => eval_chain(expr_chain, record, context, out, base_path, locals),
+    };
+
+    match &result {
+        Ok(value) => {
+            collector
+                .end_span(TraceEventKind::ExprEnd, TracePhase::End)
+                .rule_path(base_path)
+                .finish_with_eval_output(collector, value, None);
+        }
+        Err(_) => {
+            collector
+                .error_span(TraceEventKind::Error, "EXPR_ERROR", "expression failed")
+                .rule_path(base_path)
+                .finish(collector);
+        }
+    }
+
+    result
+}
+
+fn canonical_ref_path(ref_path: &str) -> String {
+    match parse_ref(ref_path) {
+        Ok((Namespace::Input, path)) => canonical_input_path(path),
+        Ok((Namespace::Context, path)) => canonical_context_path(path),
+        Ok((Namespace::Out, path)) => canonical_out_path(path),
+        _ => canonical_input_path(ref_path),
     }
 }
 

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -23,7 +23,7 @@ use crate::v2_eval::{
     EvalItem as V2EvalItem, EvalValue as V2EvalValue, V2EvalContext, eval_v2_condition,
     eval_v2_expr, eval_v2_let_step, eval_v2_op_step, eval_v2_pipe, eval_v2_ref, eval_v2_start,
 };
-use crate::v2_model::{V2Pipe, V2Ref, V2Start, V2Step};
+use crate::v2_model::{V2ComparisonOp, V2Condition, V2Pipe, V2Ref, V2Start, V2Step};
 use crate::v2_parser::{
     is_literal_escape, is_pipe_value, is_v2_ref, parse_v2_condition, parse_v2_expr,
     parse_v2_pipe_from_value,
@@ -1072,7 +1072,7 @@ fn apply_mappings_into_traced(
                 .start_span(TraceEventKind::MappingWhenStart, TracePhase::Start)
                 .rule_path(&when_path)
                 .finish(collector);
-            let flag = eval_when(
+            let flag = eval_when_traced(
                 mapping,
                 record,
                 context,
@@ -1080,6 +1080,7 @@ fn apply_mappings_into_traced(
                 &mapping_path,
                 warnings,
                 rule_version,
+                collector,
             );
             collector
                 .end_span(TraceEventKind::MappingWhenEnd, TracePhase::End)
@@ -1229,7 +1230,7 @@ fn apply_rule_to_record_traced(
             .rule_path("record_when")
             .finish(collector);
     }
-    let keep = eval_record_when(rule, record, context, warnings);
+    let keep = eval_record_when_traced(rule, record, context, warnings, collector);
     if rule.record_when.is_some() {
         collector
             .end_span(TraceEventKind::RecordWhenEnd, TracePhase::End)
@@ -1484,21 +1485,28 @@ fn apply_steps_traced(
                     .start_span(TraceEventKind::RecordWhenStart, TracePhase::Start)
                     .rule_path(&when_path)
                     .finish(collector);
-                let keep =
-                    match eval_when_expr(expr, record, context, &out, &when_path, rule_version) {
-                        Ok(keep) => keep,
-                        Err(error) => {
-                            collector
-                                .error_span(
-                                    TraceEventKind::Error,
-                                    "RECORD_WHEN_ERROR",
-                                    "record_when failed",
-                                )
-                                .rule_path(&when_path)
-                                .finish(collector);
-                            return Err(error);
-                        }
-                    };
+                let keep = match eval_when_expr_traced(
+                    expr,
+                    record,
+                    context,
+                    &out,
+                    &when_path,
+                    rule_version,
+                    collector,
+                ) {
+                    Ok(keep) => keep,
+                    Err(error) => {
+                        collector
+                            .error_span(
+                                TraceEventKind::Error,
+                                "RECORD_WHEN_ERROR",
+                                "record_when failed",
+                            )
+                            .rule_path(&when_path)
+                            .finish(collector);
+                        return Err(error);
+                    }
+                };
                 collector
                     .end_span(TraceEventKind::RecordWhenEnd, TracePhase::End)
                     .rule_path(&when_path)
@@ -1980,7 +1988,18 @@ fn apply_finalize_traced(
         let mut filtered = Vec::new();
         for (index, item) in records.iter().enumerate() {
             let ctx = V2EvalContext::new().with_item(V2EvalItem { value: item, index });
-            let keep = eval_v2_condition(&cond, item, context, &base_out, "finalize.filter", &ctx)?;
+            let item_path = format!("finalize.filter[{}]", index);
+            let keep = eval_v2_condition_traced(
+                &cond, item, context, &base_out, &item_path, &ctx, collector,
+            )?;
+            collector
+                .emit(TraceEventKind::FinalizeFilter, TracePhase::Instant)
+                .rule_path(&item_path)
+                .input_path(canonical_item_path(""))
+                .attr_index("item_index", index)
+                .attr_bool("kept", keep)
+                .input_value(item, collector.options(), Some("@item"))
+                .finish_with_output(collector, &JsonValue::Bool(keep), None);
             if keep {
                 filtered.push(item.clone());
             }
@@ -2037,6 +2056,17 @@ fn apply_finalize_traced(
                 ordering
             }
         });
+
+        for (to_index, item) in items.iter().enumerate() {
+            collector
+                .emit(TraceEventKind::FinalizeSort, TracePhase::Instant)
+                .rule_path(format!("finalize.sort[{}]", item.index))
+                .attr_index("from_index", item.index)
+                .attr_index("to_index", to_index)
+                .attr_enum("order", if sort.order == "desc" { "desc" } else { "asc" })
+                .input_value(&item.value, collector.options(), Some("@item"))
+                .finish_with_output(collector, &sort_key_to_json(&item.key), None);
+        }
 
         records = items.into_iter().map(|item| item.value).collect();
         collector
@@ -2439,8 +2469,42 @@ fn eval_v2_step_traced<'a>(
                 .input_v2_eval_value(&pipe_value, collector.options(), None)
                 .attr_count("arg_count", op.args.len())
                 .finish(collector);
-            let result =
-                eval_v2_op_step(op, pipe_value.clone(), record, context, out, step_path, ctx);
+            let result = if v2_operator_has_item_level_trace(&op.op) {
+                eval_v2_collection_op_traced(
+                    op,
+                    pipe_value.clone(),
+                    record,
+                    context,
+                    out,
+                    step_path,
+                    ctx,
+                    collector,
+                )
+            } else if v2_operator_has_eager_args(&op.op) {
+                eval_v2_eager_op_traced(
+                    op,
+                    pipe_value.clone(),
+                    record,
+                    context,
+                    out,
+                    step_path,
+                    ctx,
+                    collector,
+                )
+            } else if v2_operator_has_lazy_arg_trace(&op.op) {
+                eval_v2_lazy_op_traced(
+                    op,
+                    pipe_value.clone(),
+                    record,
+                    context,
+                    out,
+                    step_path,
+                    ctx,
+                    collector,
+                )
+            } else {
+                eval_v2_op_step(op, pipe_value.clone(), record, context, out, step_path, ctx)
+            };
             let output = match result {
                 Ok(output) => output,
                 Err(error) => {
@@ -2588,8 +2652,15 @@ fn eval_v2_step_traced<'a>(
         V2Step::If(if_step) => {
             let cond_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
             let cond_path = format!("{}.cond", step_path);
-            let cond =
-                eval_v2_condition(&if_step.cond, record, context, out, &cond_path, &cond_ctx)?;
+            let cond = eval_v2_condition_traced(
+                &if_step.cond,
+                record,
+                context,
+                out,
+                &cond_path,
+                &cond_ctx,
+                collector,
+            )?;
             collector
                 .emit(TraceEventKind::BranchEval, TracePhase::Instant)
                 .rule_path(&cond_path)
@@ -2649,6 +2720,1032 @@ fn eval_v2_step_traced<'a>(
             event.finish_with_v2_eval_output(collector, &result, None);
             Ok((result, ctx.clone()))
         }
+    }
+}
+
+fn v2_operator_has_eager_args(op: &str) -> bool {
+    !matches!(
+        op,
+        "and"
+            | "or"
+            | "coalesce"
+            | "map"
+            | "filter"
+            | "flat_map"
+            | "group_by"
+            | "key_by"
+            | "partition"
+            | "distinct_by"
+            | "sort_by"
+            | "find"
+            | "find_index"
+            | "zip_with"
+            | "reduce"
+            | "fold"
+    )
+}
+
+fn v2_operator_has_item_level_trace(op: &str) -> bool {
+    matches!(
+        op,
+        "map"
+            | "filter"
+            | "flat_map"
+            | "group_by"
+            | "key_by"
+            | "partition"
+            | "distinct_by"
+            | "sort_by"
+            | "find"
+            | "find_index"
+            | "reduce"
+            | "fold"
+    )
+}
+
+fn v2_operator_has_lazy_arg_trace(op: &str) -> bool {
+    matches!(op, "and" | "or" | "coalesce")
+}
+
+fn emit_v2_arg_eval(
+    collector: &mut TraceCollector,
+    rule_path: &str,
+    arg_index: usize,
+    operator: &str,
+    value: &V2EvalValue,
+) {
+    collector
+        .emit(TraceEventKind::ArgEval, TracePhase::Instant)
+        .rule_path(rule_path)
+        .operator(operator)
+        .attr_index("arg_index", arg_index)
+        .finish_with_v2_eval_output(collector, value, None);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_lazy_op_traced<'a>(
+    op: &crate::v2_model::V2OpStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    step_path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    let step_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
+    match op.op.as_str() {
+        "coalesce" => {
+            if let V2EvalValue::Value(value) = &pipe_value
+                && !value.is_null()
+            {
+                return Ok(pipe_value);
+            }
+            for (arg_index, arg) in op.args.iter().enumerate() {
+                let arg_path = format!("{}.args[{}]", step_path, arg_index);
+                let value = eval_v2_expr_traced(
+                    arg, record, context, out, &arg_path, &step_ctx, collector,
+                )?;
+                emit_v2_arg_eval(collector, &arg_path, arg_index, &op.op, &value);
+                if let V2EvalValue::Value(json) = &value
+                    && !json.is_null()
+                {
+                    return Ok(value);
+                }
+            }
+            Ok(V2EvalValue::Missing)
+        }
+        "and" | "or" => {
+            let is_and = op.op == "and";
+            let total_len = op.args.len() + 1;
+            if total_len < 2 {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "expr.args must contain at least two items",
+                )
+                .with_path(format!("{}.args", step_path)));
+            }
+
+            let mut saw_missing = false;
+            match &pipe_value {
+                V2EvalValue::Missing => saw_missing = true,
+                V2EvalValue::Value(value) => {
+                    let flag = value_as_bool(value, step_path)?;
+                    if is_and {
+                        if !flag {
+                            return Ok(V2EvalValue::Value(JsonValue::Bool(false)));
+                        }
+                    } else if flag {
+                        return Ok(V2EvalValue::Value(JsonValue::Bool(true)));
+                    }
+                }
+            }
+
+            for (arg_index, arg) in op.args.iter().enumerate() {
+                let arg_path = format!("{}.args[{}]", step_path, arg_index);
+                let value = eval_v2_expr_traced(
+                    arg, record, context, out, &arg_path, &step_ctx, collector,
+                )?;
+                emit_v2_arg_eval(collector, &arg_path, arg_index, &op.op, &value);
+                match value {
+                    V2EvalValue::Missing => {
+                        saw_missing = true;
+                    }
+                    V2EvalValue::Value(value) => {
+                        let flag = value_as_bool(&value, &arg_path)?;
+                        if is_and {
+                            if !flag {
+                                return Ok(V2EvalValue::Value(JsonValue::Bool(false)));
+                            }
+                        } else if flag {
+                            return Ok(V2EvalValue::Value(JsonValue::Bool(true)));
+                        }
+                    }
+                }
+            }
+
+            if saw_missing {
+                Ok(V2EvalValue::Missing)
+            } else {
+                Ok(V2EvalValue::Value(JsonValue::Bool(is_and)))
+            }
+        }
+        _ => eval_v2_op_step(op, pipe_value, record, context, out, step_path, ctx),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_eager_op_traced<'a>(
+    op: &crate::v2_model::V2OpStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    step_path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    let step_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
+    let mut arg_values = Vec::with_capacity(op.args.len());
+    for (arg_index, arg) in op.args.iter().enumerate() {
+        let arg_path = format!("{}.args[{}]", step_path, arg_index);
+        let value =
+            eval_v2_expr_traced(arg, record, context, out, &arg_path, &step_ctx, collector)?;
+        emit_v2_arg_eval(collector, &arg_path, arg_index, &op.op, &value);
+        arg_values.push(value);
+    }
+    let cached_ctx = ctx
+        .clone()
+        .with_pipe_value(pipe_value.clone())
+        .with_precomputed_op_args(step_path, arg_values);
+    eval_v2_op_step(op, pipe_value, record, context, out, step_path, &cached_ctx)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_expr_traced<'a>(
+    expr: &crate::v2_model::V2Expr,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    match expr {
+        crate::v2_model::V2Expr::Pipe(pipe) => {
+            eval_v2_pipe_traced(pipe, record, context, out, path, ctx, collector)
+        }
+        crate::v2_model::V2Expr::V1Fallback(_) => {
+            eval_v2_expr(expr, record, context, out, path, ctx)
+        }
+    }
+}
+
+fn v2_eval_array_from_value(
+    value: V2EvalValue,
+    path: &str,
+) -> Result<Vec<JsonValue>, TransformError> {
+    match value {
+        V2EvalValue::Missing => Ok(Vec::new()),
+        V2EvalValue::Value(value) => {
+            if value.is_null() {
+                Ok(Vec::new())
+            } else if let JsonValue::Array(items) = value {
+                Ok(items)
+            } else {
+                Err(
+                    TransformError::new(TransformErrorKind::ExprError, "expr arg must be an array")
+                        .with_path(path),
+                )
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_expr_or_null_traced<'a>(
+    expr: &crate::v2_model::V2Expr,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<JsonValue, TransformError> {
+    match eval_v2_expr_traced(expr, record, context, out, path, ctx, collector)? {
+        V2EvalValue::Missing => Ok(JsonValue::Null),
+        V2EvalValue::Value(value) => Ok(value),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_predicate_expr_traced<'a>(
+    expr: &crate::v2_model::V2Expr,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<bool, TransformError> {
+    match eval_v2_expr_traced(expr, record, context, out, path, ctx, collector)? {
+        V2EvalValue::Missing => Ok(false),
+        V2EvalValue::Value(value) => {
+            if value.is_null() {
+                Ok(false)
+            } else {
+                value_as_bool(&value, path)
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_key_expr_string_traced<'a>(
+    expr: &crate::v2_model::V2Expr,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<String, TransformError> {
+    let value = match eval_v2_expr_traced(expr, record, context, out, path, ctx, collector)? {
+        V2EvalValue::Missing => {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "expr arg must not be missing",
+            )
+            .with_path(path));
+        }
+        V2EvalValue::Value(value) => value,
+    };
+    if value.is_null() {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr arg must not be null",
+        )
+        .with_path(path));
+    }
+    value_to_string(&value, path)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_sort_key_traced<'a>(
+    expr: &crate::v2_model::V2Expr,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<SortKey, TransformError> {
+    let value = match eval_v2_expr_traced(expr, record, context, out, path, ctx, collector)? {
+        V2EvalValue::Missing => {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "expr arg must not be missing",
+            )
+            .with_path(path));
+        }
+        V2EvalValue::Value(value) => value,
+    };
+    if value.is_null() {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr arg must not be null",
+        )
+        .with_path(path));
+    }
+    sort_key_from_value(&value, path)
+}
+
+fn emit_v2_collection_item_start(
+    collector: &mut TraceCollector,
+    item_path: &str,
+    operator: &str,
+    index: usize,
+    item: &JsonValue,
+) {
+    collector
+        .start_span(TraceEventKind::CollectionItemStart, TracePhase::Start)
+        .rule_path(item_path)
+        .operator(operator)
+        .input_path(canonical_item_path(""))
+        .attr_index("item_index", index)
+        .attr_enum("scope", "item")
+        .input_value(item, collector.options(), Some("@item"))
+        .finish(collector);
+}
+
+fn finish_v2_collection_item(
+    collector: &mut TraceCollector,
+    item_path: &str,
+    operator: &str,
+    index: usize,
+    output: &V2EvalValue,
+    bool_attr: Option<(&'static str, bool)>,
+) {
+    let mut event = collector
+        .end_span(TraceEventKind::CollectionItemEnd, TracePhase::End)
+        .rule_path(item_path)
+        .operator(operator)
+        .attr_index("item_index", index);
+    if let Some((key, value)) = bool_attr {
+        event = event.attr_bool(key, value);
+    }
+    event.finish_with_v2_eval_output(collector, output, Some("@item"));
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_collection_op_traced<'a>(
+    op_step: &crate::v2_model::V2OpStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    let step_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
+    let operator = op_step.op.as_str();
+
+    match operator {
+        "map" => {
+            if op_step.args.len() != 1 {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "map requires exactly one argument",
+                )
+                .with_path(path));
+            }
+            let array = v2_eval_array_from_value(pipe_value, path)?;
+            let arg_path = format!("{}.args[0]", path);
+            let mut results = Vec::new();
+            for (index, item) in array.iter().enumerate() {
+                let item_path = format!("{}[{}]", path, index);
+                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+                let item_ctx = step_ctx
+                    .clone()
+                    .with_pipe_value(V2EvalValue::Value(item.clone()))
+                    .with_item(V2EvalItem { value: item, index });
+                let value = eval_v2_expr_traced(
+                    &op_step.args[0],
+                    record,
+                    context,
+                    out,
+                    &arg_path,
+                    &item_ctx,
+                    collector,
+                )?;
+                emit_v2_arg_eval(collector, &arg_path, 0, operator, &value);
+                finish_v2_collection_item(collector, &item_path, operator, index, &value, None);
+                if let V2EvalValue::Value(value) = value {
+                    results.push(value);
+                }
+            }
+            Ok(V2EvalValue::Value(JsonValue::Array(results)))
+        }
+        "filter" | "partition" | "find" | "find_index" => {
+            if op_step.args.len() != 1 {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    format!("{operator} requires exactly one argument"),
+                )
+                .with_path(path));
+            }
+            let array = v2_eval_array_from_value(pipe_value, path)?;
+            let arg_path = format!("{}.args[0]", path);
+            let mut kept = Vec::new();
+            let mut rejected = Vec::new();
+            for (index, item) in array.iter().enumerate() {
+                let item_path = format!("{}[{}]", path, index);
+                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+                let item_ctx = step_ctx
+                    .clone()
+                    .with_pipe_value(V2EvalValue::Value(item.clone()))
+                    .with_item(V2EvalItem { value: item, index });
+                let matches = eval_v2_predicate_expr_traced(
+                    &op_step.args[0],
+                    record,
+                    context,
+                    out,
+                    &arg_path,
+                    &item_ctx,
+                    collector,
+                )?;
+                let match_value = V2EvalValue::Value(JsonValue::Bool(matches));
+                emit_v2_arg_eval(collector, &arg_path, 0, operator, &match_value);
+                finish_v2_collection_item(
+                    collector,
+                    &item_path,
+                    operator,
+                    index,
+                    &match_value,
+                    Some(("matched", matches)),
+                );
+                match operator {
+                    "filter" => {
+                        if matches {
+                            kept.push(item.clone());
+                        }
+                    }
+                    "partition" => {
+                        if matches {
+                            kept.push(item.clone());
+                        } else {
+                            rejected.push(item.clone());
+                        }
+                    }
+                    "find" if matches => return Ok(V2EvalValue::Value(item.clone())),
+                    "find_index" if matches => {
+                        return Ok(V2EvalValue::Value(JsonValue::Number((index as i64).into())));
+                    }
+                    _ => {}
+                }
+            }
+            match operator {
+                "filter" => Ok(V2EvalValue::Value(JsonValue::Array(kept))),
+                "partition" => Ok(V2EvalValue::Value(JsonValue::Array(vec![
+                    JsonValue::Array(kept),
+                    JsonValue::Array(rejected),
+                ]))),
+                "find" => Ok(V2EvalValue::Value(JsonValue::Null)),
+                "find_index" => Ok(V2EvalValue::Value(JsonValue::Number((-1).into()))),
+                _ => unreachable!(),
+            }
+        }
+        "flat_map" => {
+            if op_step.args.len() != 1 {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "flat_map requires exactly one argument",
+                )
+                .with_path(path));
+            }
+            let array = v2_eval_array_from_value(pipe_value, path)?;
+            let arg_path = format!("{}.args[0]", path);
+            let mut results = Vec::new();
+            for (index, item) in array.iter().enumerate() {
+                let item_path = format!("{}[{}]", path, index);
+                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+                let item_ctx = step_ctx
+                    .clone()
+                    .with_pipe_value(V2EvalValue::Value(item.clone()))
+                    .with_item(V2EvalItem { value: item, index });
+                let value = eval_v2_expr_or_null_traced(
+                    &op_step.args[0],
+                    record,
+                    context,
+                    out,
+                    &arg_path,
+                    &item_ctx,
+                    collector,
+                )?;
+                let output = V2EvalValue::Value(value.clone());
+                emit_v2_arg_eval(collector, &arg_path, 0, operator, &output);
+                finish_v2_collection_item(collector, &item_path, operator, index, &output, None);
+                match value {
+                    JsonValue::Array(items) => results.extend(items),
+                    value => results.push(value),
+                }
+            }
+            Ok(V2EvalValue::Value(JsonValue::Array(results)))
+        }
+        "group_by" | "key_by" | "distinct_by" => {
+            if op_step.args.len() != 1 {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    format!("{operator} requires exactly one argument"),
+                )
+                .with_path(path));
+            }
+            let array = v2_eval_array_from_value(pipe_value, path)?;
+            let arg_path = format!("{}.args[0]", path);
+            let mut grouped = serde_json::Map::new();
+            let mut keyed = serde_json::Map::new();
+            let mut distinct = Vec::new();
+            let mut seen = HashSet::new();
+            for (index, item) in array.iter().enumerate() {
+                let item_path = format!("{}[{}]", path, index);
+                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+                let item_ctx = step_ctx
+                    .clone()
+                    .with_pipe_value(V2EvalValue::Value(item.clone()))
+                    .with_item(V2EvalItem { value: item, index });
+                let key = eval_v2_key_expr_string_traced(
+                    &op_step.args[0],
+                    record,
+                    context,
+                    out,
+                    &arg_path,
+                    &item_ctx,
+                    collector,
+                )?;
+                let key_output = V2EvalValue::Value(JsonValue::String(key.clone()));
+                emit_v2_arg_eval(collector, &arg_path, 0, operator, &key_output);
+                let selected = match operator {
+                    "group_by" => {
+                        let entry = grouped
+                            .entry(key)
+                            .or_insert_with(|| JsonValue::Array(Vec::new()));
+                        if let JsonValue::Array(items) = entry {
+                            items.push(item.clone());
+                        }
+                        true
+                    }
+                    "key_by" => {
+                        keyed.insert(key, item.clone());
+                        true
+                    }
+                    "distinct_by" => {
+                        if seen.insert(key) {
+                            distinct.push(item.clone());
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => unreachable!(),
+                };
+                finish_v2_collection_item(
+                    collector,
+                    &item_path,
+                    operator,
+                    index,
+                    &key_output,
+                    Some(("selected", selected)),
+                );
+            }
+            match operator {
+                "group_by" => Ok(V2EvalValue::Value(JsonValue::Object(grouped))),
+                "key_by" => Ok(V2EvalValue::Value(JsonValue::Object(keyed))),
+                "distinct_by" => Ok(V2EvalValue::Value(JsonValue::Array(distinct))),
+                _ => unreachable!(),
+            }
+        }
+        "sort_by" => {
+            if !(1..=2).contains(&op_step.args.len()) {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "sort_by requires one or two arguments",
+                )
+                .with_path(path));
+            }
+            let array = v2_eval_array_from_value(pipe_value, path)?;
+            if array.is_empty() {
+                return Ok(V2EvalValue::Value(JsonValue::Array(Vec::new())));
+            }
+            let expr_path = format!("{}.args[0]", path);
+            let order = if op_step.args.len() == 2 {
+                let order_path = format!("{}.args[1]", path);
+                let order_value = eval_v2_expr_traced(
+                    &op_step.args[1],
+                    record,
+                    context,
+                    out,
+                    &order_path,
+                    &step_ctx,
+                    collector,
+                )?;
+                emit_v2_arg_eval(collector, &order_path, 1, operator, &order_value);
+                let order = match order_value {
+                    V2EvalValue::Missing => return Ok(V2EvalValue::Missing),
+                    V2EvalValue::Value(value) => value_to_string(&value, &order_path)?,
+                };
+                if order != "asc" && order != "desc" {
+                    return Err(TransformError::new(
+                        TransformErrorKind::ExprError,
+                        "order must be asc or desc",
+                    )
+                    .with_path(order_path));
+                }
+                order
+            } else {
+                "asc".to_string()
+            };
+
+            struct TracedSortItem {
+                key: SortKey,
+                index: usize,
+                value: JsonValue,
+            }
+
+            let mut items = Vec::with_capacity(array.len());
+            let mut key_kind = None;
+            for (index, item) in array.iter().enumerate() {
+                let item_path = format!("{}[{}]", path, index);
+                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+                let item_ctx = step_ctx
+                    .clone()
+                    .with_pipe_value(V2EvalValue::Value(item.clone()))
+                    .with_item(V2EvalItem { value: item, index });
+                let key = eval_v2_sort_key_traced(
+                    &op_step.args[0],
+                    record,
+                    context,
+                    out,
+                    &expr_path,
+                    &item_ctx,
+                    collector,
+                )?;
+                let kind = key.kind();
+                if let Some(existing) = key_kind {
+                    if existing != kind {
+                        return Err(TransformError::new(
+                            TransformErrorKind::ExprError,
+                            "sort_by keys must be all the same type",
+                        )
+                        .with_path(&expr_path));
+                    }
+                } else {
+                    key_kind = Some(kind);
+                }
+                let key_value = sort_key_to_json(&key);
+                let key_output = V2EvalValue::Value(key_value);
+                emit_v2_arg_eval(collector, &expr_path, 0, operator, &key_output);
+                finish_v2_collection_item(
+                    collector,
+                    &item_path,
+                    operator,
+                    index,
+                    &key_output,
+                    None,
+                );
+                items.push(TracedSortItem {
+                    key,
+                    index,
+                    value: item.clone(),
+                });
+            }
+
+            items.sort_by(|left, right| {
+                let mut ordering = compare_sort_keys(&left.key, &right.key);
+                if order == "desc" {
+                    ordering = ordering.reverse();
+                }
+                if ordering == Ordering::Equal {
+                    left.index.cmp(&right.index)
+                } else {
+                    ordering
+                }
+            });
+            Ok(V2EvalValue::Value(JsonValue::Array(
+                items.into_iter().map(|item| item.value).collect(),
+            )))
+        }
+        "reduce" => {
+            if op_step.args.len() != 1 {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "reduce requires exactly one argument",
+                )
+                .with_path(path));
+            }
+            let array = v2_eval_array_from_value(pipe_value, path)?;
+            if array.is_empty() {
+                return Ok(V2EvalValue::Value(JsonValue::Null));
+            }
+            let expr_path = format!("{}.args[0]", path);
+            let mut acc = array[0].clone();
+            for (index, item) in array.iter().enumerate().skip(1) {
+                let item_path = format!("{}[{}]", path, index);
+                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+                let item_ctx = step_ctx
+                    .clone()
+                    .with_pipe_value(V2EvalValue::Value(item.clone()))
+                    .with_item(V2EvalItem { value: item, index })
+                    .with_acc(&acc);
+                let value = eval_v2_expr_or_null_traced(
+                    &op_step.args[0],
+                    record,
+                    context,
+                    out,
+                    &expr_path,
+                    &item_ctx,
+                    collector,
+                )?;
+                let output = V2EvalValue::Value(value.clone());
+                emit_v2_arg_eval(collector, &expr_path, 0, operator, &output);
+                acc = value;
+                finish_v2_collection_item(collector, &item_path, operator, index, &output, None);
+            }
+            Ok(V2EvalValue::Value(acc))
+        }
+        "fold" => {
+            if op_step.args.len() != 2 {
+                return Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "fold requires exactly two arguments",
+                )
+                .with_path(path));
+            }
+            let array = v2_eval_array_from_value(pipe_value, path)?;
+            let init_path = format!("{}.args[0]", path);
+            let initial = eval_v2_expr_traced(
+                &op_step.args[0],
+                record,
+                context,
+                out,
+                &init_path,
+                &step_ctx,
+                collector,
+            )?;
+            emit_v2_arg_eval(collector, &init_path, 0, operator, &initial);
+            let mut acc = match initial {
+                V2EvalValue::Missing => return Ok(V2EvalValue::Missing),
+                V2EvalValue::Value(value) => value,
+            };
+            let expr_path = format!("{}.args[1]", path);
+            for (index, item) in array.iter().enumerate() {
+                let item_path = format!("{}[{}]", path, index);
+                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+                let item_ctx = step_ctx
+                    .clone()
+                    .with_pipe_value(V2EvalValue::Value(item.clone()))
+                    .with_item(V2EvalItem { value: item, index })
+                    .with_acc(&acc);
+                let value = eval_v2_expr_or_null_traced(
+                    &op_step.args[1],
+                    record,
+                    context,
+                    out,
+                    &expr_path,
+                    &item_ctx,
+                    collector,
+                )?;
+                let output = V2EvalValue::Value(value.clone());
+                emit_v2_arg_eval(collector, &expr_path, 1, operator, &output);
+                acc = value;
+                finish_v2_collection_item(collector, &item_path, operator, index, &output, None);
+            }
+            Ok(V2EvalValue::Value(acc))
+        }
+        _ => eval_v2_op_step(op_step, pipe_value, record, context, out, path, ctx),
+    }
+}
+
+fn sort_key_to_json(key: &SortKey) -> JsonValue {
+    match key {
+        SortKey::Number(value) => serde_json::Number::from_f64(*value)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        SortKey::String(value) => JsonValue::String(value.clone()),
+        SortKey::Bool(value) => JsonValue::Bool(*value),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_condition_traced<'a>(
+    condition: &V2Condition,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<bool, TransformError> {
+    match condition {
+        V2Condition::All(conditions) => {
+            for (index, cond) in conditions.iter().enumerate() {
+                let cond_path = format!("{}[{}]", path, index);
+                if !eval_v2_condition_traced(
+                    cond, record, context, out, &cond_path, ctx, collector,
+                )? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        V2Condition::Any(conditions) => {
+            for (index, cond) in conditions.iter().enumerate() {
+                let cond_path = format!("{}[{}]", path, index);
+                if eval_v2_condition_traced(cond, record, context, out, &cond_path, ctx, collector)?
+                {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        V2Condition::Comparison(comparison) => {
+            eval_v2_comparison_traced(comparison, record, context, out, path, ctx, collector)
+        }
+        V2Condition::Expr(expr) => {
+            let expr_path = format!("{}.expr", path);
+            let value =
+                eval_v2_expr_traced(expr, record, context, out, &expr_path, ctx, collector)?;
+            match value {
+                V2EvalValue::Value(JsonValue::Bool(flag)) => Ok(flag),
+                V2EvalValue::Missing => Ok(false),
+                V2EvalValue::Value(_) => Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "when/record_when must evaluate to boolean",
+                )
+                .with_path(&expr_path)),
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_comparison_traced<'a>(
+    comparison: &crate::v2_model::V2Comparison,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<bool, TransformError> {
+    if comparison.args.len() != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            format!(
+                "comparison requires exactly 2 arguments, got {}",
+                comparison.args.len()
+            ),
+        )
+        .with_path(path));
+    }
+
+    let operator = v2_comparison_operator_name(comparison.op);
+    collector
+        .start_span(TraceEventKind::OpStart, TracePhase::Start)
+        .rule_path(path)
+        .operator(operator)
+        .attr_count("arg_count", 2)
+        .finish(collector);
+
+    let result =
+        (|| {
+            let left_path = format!("{}.args[0]", path);
+            let right_path = format!("{}.args[1]", path);
+            let left = eval_v2_expr_traced(
+                &comparison.args[0],
+                record,
+                context,
+                out,
+                &left_path,
+                ctx,
+                collector,
+            )?;
+            emit_v2_arg_eval(collector, &left_path, 0, operator, &left);
+            let right = eval_v2_expr_traced(
+                &comparison.args[1],
+                record,
+                context,
+                out,
+                &right_path,
+                ctx,
+                collector,
+            )?;
+            emit_v2_arg_eval(collector, &right_path, 1, operator, &right);
+
+            match comparison.op {
+                V2ComparisonOp::Eq => Ok(compare_v2_eval_eq(&left, &right)),
+                V2ComparisonOp::Ne => Ok(!compare_v2_eval_eq(&left, &right)),
+                V2ComparisonOp::Gt => compare_v2_eval_ord(&left, &right, path)
+                    .map(|ordering| ordering == Ordering::Greater),
+                V2ComparisonOp::Gte => compare_v2_eval_ord(&left, &right, path)
+                    .map(|ordering| ordering != Ordering::Less),
+                V2ComparisonOp::Lt => compare_v2_eval_ord(&left, &right, path)
+                    .map(|ordering| ordering == Ordering::Less),
+                V2ComparisonOp::Lte => compare_v2_eval_ord(&left, &right, path)
+                    .map(|ordering| ordering != Ordering::Greater),
+                V2ComparisonOp::Match => compare_v2_eval_match(&left, &right, path),
+            }
+        })();
+
+    match result {
+        Ok(flag) => {
+            collector
+                .end_span(TraceEventKind::OpEnd, TracePhase::End)
+                .rule_path(path)
+                .operator(operator)
+                .finish_with_output(collector, &JsonValue::Bool(flag), None);
+            Ok(flag)
+        }
+        Err(error) => {
+            collector
+                .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                .rule_path(path)
+                .operator(operator)
+                .finish(collector);
+            Err(error)
+        }
+    }
+}
+
+fn v2_comparison_operator_name(op: V2ComparisonOp) -> &'static str {
+    match op {
+        V2ComparisonOp::Eq => "eq",
+        V2ComparisonOp::Ne => "ne",
+        V2ComparisonOp::Gt => "gt",
+        V2ComparisonOp::Gte => "gte",
+        V2ComparisonOp::Lt => "lt",
+        V2ComparisonOp::Lte => "lte",
+        V2ComparisonOp::Match => "match",
+    }
+}
+
+fn compare_v2_eval_eq(left: &V2EvalValue, right: &V2EvalValue) -> bool {
+    match (left, right) {
+        (V2EvalValue::Value(left), V2EvalValue::Value(right)) => left == right,
+        (V2EvalValue::Missing, V2EvalValue::Missing) => true,
+        (V2EvalValue::Missing, V2EvalValue::Value(right)) => right.is_null(),
+        (V2EvalValue::Value(left), V2EvalValue::Missing) => left.is_null(),
+    }
+}
+
+fn compare_v2_eval_ord(
+    left: &V2EvalValue,
+    right: &V2EvalValue,
+    path: &str,
+) -> Result<Ordering, TransformError> {
+    match (left, right) {
+        (V2EvalValue::Value(left), V2EvalValue::Value(right)) => {
+            if let (Some(left), Some(right)) = (json_value_as_f64(left), json_value_as_f64(right)) {
+                return Ok(left.partial_cmp(&right).unwrap_or(Ordering::Equal));
+            }
+            if let (Some(left), Some(right)) = (left.as_str(), right.as_str()) {
+                return Ok(left.cmp(right));
+            }
+            Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "cannot compare values of different types",
+            )
+            .with_path(path))
+        }
+        _ => Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "cannot compare missing values",
+        )
+        .with_path(path)),
+    }
+}
+
+fn compare_v2_eval_match(
+    left: &V2EvalValue,
+    right: &V2EvalValue,
+    path: &str,
+) -> Result<bool, TransformError> {
+    let text = match left {
+        V2EvalValue::Value(JsonValue::String(value)) => value,
+        _ => {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "match operator requires string on left side",
+            )
+            .with_path(path));
+        }
+    };
+    let pattern = match right {
+        V2EvalValue::Value(JsonValue::String(value)) => value,
+        _ => {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "match operator requires regex pattern string on right side",
+            )
+            .with_path(path));
+        }
+    };
+    Regex::new(pattern)
+        .map_err(|err| {
+            TransformError::new(
+                TransformErrorKind::ExprError,
+                format!("invalid regex pattern: {}", err),
+            )
+            .with_path(path)
+        })
+        .map(|regex| regex.is_match(text))
+}
+
+fn json_value_as_f64(value: &JsonValue) -> Option<f64> {
+    match value {
+        JsonValue::Number(number) => number.as_f64(),
+        JsonValue::String(value) => value.parse::<f64>().ok(),
+        _ => None,
     }
 }
 
@@ -2718,6 +3815,40 @@ fn eval_when(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn eval_when_traced(
+    mapping: &crate::model::Mapping,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    mapping_path: &str,
+    warnings: &mut Vec<TransformWarning>,
+    rule_version: u8,
+    collector: &mut TraceCollector,
+) -> bool {
+    let expr = match &mapping.when {
+        Some(expr) => expr,
+        None => return true,
+    };
+
+    let when_path = format!("{}.when", mapping_path);
+    match eval_when_expr_traced(
+        expr,
+        record,
+        context,
+        out,
+        &when_path,
+        rule_version,
+        collector,
+    ) {
+        Ok(flag) => flag,
+        Err(err) => {
+            warnings.push(err.into());
+            false
+        }
+    }
+}
+
 fn eval_record_when(
     rule: &RuleFile,
     record: &JsonValue,
@@ -2746,6 +3877,36 @@ fn eval_record_when(
     }
 }
 
+fn eval_record_when_traced(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    warnings: &mut Vec<TransformWarning>,
+    collector: &mut TraceCollector,
+) -> bool {
+    let expr = match &rule.record_when {
+        Some(expr) => expr,
+        None => return true,
+    };
+
+    let empty_out = JsonValue::Object(Map::new());
+    match eval_when_expr_traced(
+        expr,
+        record,
+        context,
+        &empty_out,
+        "record_when",
+        rule.version,
+        collector,
+    ) {
+        Ok(flag) => flag,
+        Err(err) => {
+            warnings.push(err.into());
+            false
+        }
+    }
+}
+
 fn eval_bool_expr(
     expr: &Expr,
     record: &JsonValue,
@@ -2754,6 +3915,25 @@ fn eval_bool_expr(
     path: &str,
 ) -> Result<bool, TransformError> {
     let value = eval_expr(expr, record, context, out, path, None)?;
+    let value = match value {
+        EvalValue::Missing => JsonValue::Null,
+        EvalValue::Value(value) => value,
+    };
+    match value {
+        JsonValue::Bool(flag) => Ok(flag),
+        _ => Err(when_type_error(path)),
+    }
+}
+
+fn eval_bool_expr_traced(
+    expr: &Expr,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    path: &str,
+    collector: &mut TraceCollector,
+) -> Result<bool, TransformError> {
+    let value = eval_expr_traced(expr, record, context, out, path, None, collector)?;
     let value = match value {
         EvalValue::Missing => JsonValue::Null,
         EvalValue::Value(value) => value,
@@ -2787,6 +3967,34 @@ fn eval_when_expr(
     }
 
     eval_bool_expr(expr, record, context, out, path)
+}
+
+fn eval_when_expr_traced(
+    expr: &Expr,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    path: &str,
+    rule_version: u8,
+    collector: &mut TraceCollector,
+) -> Result<bool, TransformError> {
+    if rule_version >= 2 {
+        if let Some(raw_value) = expr_to_json_for_v2_condition(expr) {
+            let condition = parse_v2_condition(&raw_value).map_err(|err| {
+                TransformError::new(
+                    TransformErrorKind::ExprError,
+                    format!("invalid v2 condition: {}", err),
+                )
+                .with_path(path)
+            })?;
+            let ctx = V2EvalContext::new();
+            return eval_v2_condition_traced(
+                &condition, record, context, out, path, &ctx, collector,
+            );
+        }
+    }
+
+    eval_bool_expr_traced(expr, record, context, out, path, collector)
 }
 
 fn when_type_error(path: &str) -> TransformError {

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -2729,6 +2729,8 @@ fn v2_operator_has_eager_args(op: &str) -> bool {
         "and"
             | "or"
             | "coalesce"
+            | "lookup"
+            | "lookup_first"
             | "map"
             | "filter"
             | "flat_map"
@@ -2765,6 +2767,100 @@ fn v2_operator_has_item_level_trace(op: &str) -> bool {
 
 fn v2_operator_has_lazy_arg_trace(op: &str) -> bool {
     matches!(op, "and" | "or" | "coalesce")
+}
+
+fn v2_operator_skips_args_when_pipe_is_missing(op: &str) -> bool {
+    matches!(
+        op,
+        "concat"
+            | "replace"
+            | "split"
+            | "pad_start"
+            | "pad_end"
+            | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "add"
+            | "subtract"
+            | "multiply"
+            | "divide"
+            | "round"
+            | "to_base"
+            | "date_format"
+            | "to_unixtime"
+            | "merge"
+            | "deep_merge"
+            | "get"
+            | "keys"
+            | "values"
+            | "entries"
+            | "len"
+            | "from_entries"
+            | "object_flatten"
+            | "object_unflatten"
+            | "flatten"
+            | "take"
+            | "drop"
+            | "slice"
+            | "chunk"
+            | "zip"
+            | "unzip"
+            | "unique"
+            | "index_of"
+            | "contains"
+            | "sum"
+            | "avg"
+            | "min"
+            | "max"
+            | "first"
+            | "last"
+            | "string"
+            | "int"
+            | "float"
+            | "bool"
+            | "trim"
+            | "uppercase"
+            | "lowercase"
+            | "to_string"
+            | "not"
+    )
+}
+
+fn v2_operator_stops_after_missing_arg(op: &str) -> bool {
+    matches!(
+        op,
+        "concat"
+            | "replace"
+            | "split"
+            | "pad_start"
+            | "pad_end"
+            | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "add"
+            | "subtract"
+            | "multiply"
+            | "divide"
+            | "round"
+            | "to_base"
+            | "date_format"
+            | "to_unixtime"
+            | "merge"
+            | "deep_merge"
+            | "get"
+            | "pick"
+            | "omit"
+            | "flatten"
+            | "take"
+            | "drop"
+            | "slice"
+            | "chunk"
+            | "zip"
+            | "index_of"
+            | "contains"
+    )
 }
 
 fn emit_v2_arg_eval(
@@ -2885,6 +2981,12 @@ fn eval_v2_eager_op_traced<'a>(
     ctx: &V2EvalContext<'a>,
     collector: &mut TraceCollector,
 ) -> Result<V2EvalValue, TransformError> {
+    if matches!(pipe_value, V2EvalValue::Missing)
+        && v2_operator_skips_args_when_pipe_is_missing(&op.op)
+    {
+        return eval_v2_op_step(op, pipe_value, record, context, out, step_path, ctx);
+    }
+
     let step_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
     let mut arg_values = Vec::with_capacity(op.args.len());
     for (arg_index, arg) in op.args.iter().enumerate() {
@@ -2892,7 +2994,11 @@ fn eval_v2_eager_op_traced<'a>(
         let value =
             eval_v2_expr_traced(arg, record, context, out, &arg_path, &step_ctx, collector)?;
         emit_v2_arg_eval(collector, &arg_path, arg_index, &op.op, &value);
+        let is_missing = matches!(value, V2EvalValue::Missing);
         arg_values.push(value);
+        if is_missing && v2_operator_stops_after_missing_arg(&op.op) {
+            break;
+        }
     }
     let cached_ctx = ctx
         .clone()
@@ -4220,7 +4326,11 @@ fn eval_eager_op_traced(
         let arg_path = format!("{}.args[{}]", base_path, arg_index);
         let arg_value = eval_expr_traced(arg, record, context, out, &arg_path, locals, collector)?;
         emit_arg_eval(collector, &arg_path, arg_index, &arg_value);
+        let is_missing = matches!(arg_value, EvalValue::Missing);
         arg_values.push(arg_value);
+        if is_missing && v1_operator_stops_after_missing_arg(&expr_op.op) {
+            break;
+        }
     }
     let cached_locals = locals_with_precomputed_args(locals, base_path, &arg_values);
     eval_op(
@@ -4247,6 +4357,38 @@ fn v1_operator_has_scoped_expr_args(op: &str) -> bool {
             | "sort_by"
             | "find"
             | "find_index"
+    )
+}
+
+fn v1_operator_stops_after_missing_arg(op: &str) -> bool {
+    matches!(
+        op,
+        "concat"
+            | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "replace"
+            | "split"
+            | "pad_start"
+            | "pad_end"
+            | "round"
+            | "to_base"
+            | "date_format"
+            | "to_unixtime"
+            | "merge"
+            | "deep_merge"
+            | "get"
+            | "pick"
+            | "omit"
+            | "flatten"
+            | "take"
+            | "drop"
+            | "slice"
+            | "chunk"
+            | "zip"
+            | "index_of"
+            | "contains"
     )
 }
 

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -23,7 +23,7 @@ use crate::v2_eval::{
     EvalItem as V2EvalItem, EvalValue as V2EvalValue, V2EvalContext, eval_v2_condition,
     eval_v2_expr, eval_v2_let_step, eval_v2_op_step, eval_v2_pipe, eval_v2_ref, eval_v2_start,
 };
-use crate::v2_model::{V2Expr, V2Pipe, V2Ref, V2Start, V2Step};
+use crate::v2_model::{V2Pipe, V2Ref, V2Start, V2Step};
 use crate::v2_parser::{
     is_literal_escape, is_pipe_value, is_v2_ref, parse_v2_condition, parse_v2_expr,
     parse_v2_pipe_from_value,
@@ -1339,7 +1339,21 @@ fn apply_steps_traced(
                     .start_span(TraceEventKind::RecordWhenStart, TracePhase::Start)
                     .rule_path(&when_path)
                     .finish(collector);
-                let keep = eval_when_expr(expr, record, context, &out, &when_path, rule_version)?;
+                let keep =
+                    match eval_when_expr(expr, record, context, &out, &when_path, rule_version) {
+                        Ok(keep) => keep,
+                        Err(error) => {
+                            collector
+                                .error_span(
+                                    TraceEventKind::Error,
+                                    "RECORD_WHEN_ERROR",
+                                    "record_when failed",
+                                )
+                                .rule_path(&when_path)
+                                .finish(collector);
+                            return Err(error);
+                        }
+                    };
                 collector
                     .end_span(TraceEventKind::RecordWhenEnd, TracePhase::End)
                     .rule_path(&when_path)
@@ -1374,7 +1388,10 @@ fn apply_steps_traced(
                     if !ok {
                         return Err(TransformError::new(
                             TransformErrorKind::AssertionFailed,
-                            "assert failed",
+                            format!(
+                                "assert failed: {}: {}",
+                                assert.error.code, assert.error.message
+                            ),
                         )
                         .with_path(assert_path));
                     }
@@ -2220,18 +2237,11 @@ fn eval_v2_pipe_traced<'a>(
 
     for (step_index, step) in pipe.steps.iter().enumerate() {
         let step_path = format!("{}[{}]", base_path, step_index + 1);
-        current_ctx = current_ctx.clone().with_pipe_value(current.clone());
-        current = match eval_v2_step_traced(
-            step,
-            current,
-            record,
-            context,
-            out,
-            &step_path,
-            &current_ctx,
-            collector,
+        let step_ctx = current_ctx.clone().with_pipe_value(current.clone());
+        let (next, next_ctx) = match eval_v2_step_traced(
+            step, current, record, context, out, &step_path, &step_ctx, collector,
         ) {
-            Ok(value) => value,
+            Ok(result) => result,
             Err(error) => {
                 collector
                     .error_span(TraceEventKind::Error, "EXPR_ERROR", "expression failed")
@@ -2240,6 +2250,8 @@ fn eval_v2_pipe_traced<'a>(
                 return Err(error);
             }
         };
+        current = next;
+        current_ctx = next_ctx;
     }
 
     collector
@@ -2259,7 +2271,7 @@ fn eval_v2_step_traced<'a>(
     step_path: &str,
     ctx: &V2EvalContext<'a>,
     collector: &mut TraceCollector,
-) -> Result<V2EvalValue, TransformError> {
+) -> Result<(V2EvalValue, V2EvalContext<'a>), TransformError> {
     match step {
         V2Step::Op(op) => {
             collector
@@ -2269,27 +2281,12 @@ fn eval_v2_step_traced<'a>(
                 .input_v2_eval_value(&pipe_value, collector.options(), None)
                 .attr_count("arg_count", op.args.len())
                 .finish(collector);
-            for (arg_index, _arg) in op.args.iter().enumerate() {
+            for (arg_index, _) in op.args.iter().enumerate() {
                 let arg_path = format!("{}.args[{}]", step_path, arg_index);
-                let arg_value = match eval_v2_expr_with_trace(
-                    _arg, record, context, out, &arg_path, ctx, collector,
-                ) {
-                    Ok(value) => value,
-                    Err(error) => {
-                        collector
-                            .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
-                            .rule_path(step_path)
-                            .operator(&op.op)
-                            .input_v2_eval_value(&pipe_value, collector.options(), None)
-                            .finish(collector);
-                        return Err(error);
-                    }
-                };
                 collector
                     .emit(TraceEventKind::ArgEval, TracePhase::Instant)
                     .rule_path(&arg_path)
                     .attr_index("arg_index", arg_index)
-                    .input_v2_eval_value(&arg_value, collector.options(), None)
                     .finish(collector);
             }
             let result =
@@ -2312,7 +2309,7 @@ fn eval_v2_step_traced<'a>(
                 .operator(&op.op)
                 .input_v2_eval_value(&pipe_value, collector.options(), None)
                 .finish_with_v2_eval_output(collector, &output, None);
-            Ok(output)
+            Ok((output, ctx.clone()))
         }
         V2Step::Map(map) => {
             collector
@@ -2328,7 +2325,7 @@ fn eval_v2_step_traced<'a>(
                         .rule_path(step_path)
                         .operator("map")
                         .finish_with_v2_eval_output(collector, &V2EvalValue::Missing, None);
-                    return Ok(V2EvalValue::Missing);
+                    return Ok((V2EvalValue::Missing, ctx.clone()));
                 }
                 V2EvalValue::Value(JsonValue::Array(arr)) => arr,
                 V2EvalValue::Value(_) => {
@@ -2368,18 +2365,18 @@ fn eval_v2_step_traced<'a>(
                     .finish(collector);
 
                 for (nested_index, nested_step) in map.steps.iter().enumerate() {
-                    step_ctx = step_ctx.clone().with_pipe_value(current.clone());
-                    current = match eval_v2_step_traced(
+                    let nested_ctx = step_ctx.clone().with_pipe_value(current.clone());
+                    let (next, next_ctx) = match eval_v2_step_traced(
                         nested_step,
                         current,
                         record,
                         context,
                         out,
                         &format!("{}.step[{}]", item_path, nested_index),
-                        &step_ctx,
+                        &nested_ctx,
                         collector,
                     ) {
-                        Ok(value) => value,
+                        Ok(result) => result,
                         Err(error) => {
                             collector
                                 .error_span(
@@ -2392,6 +2389,8 @@ fn eval_v2_step_traced<'a>(
                             return Err(error);
                         }
                     };
+                    current = next;
+                    step_ctx = next_ctx;
                 }
                 collector
                     .end_span(TraceEventKind::CollectionItemEnd, TracePhase::End)
@@ -2410,7 +2409,7 @@ fn eval_v2_step_traced<'a>(
                     &V2EvalValue::Value(JsonValue::Array(results.clone())),
                     None,
                 );
-            Ok(V2EvalValue::Value(JsonValue::Array(results)))
+            Ok((V2EvalValue::Value(JsonValue::Array(results)), ctx.clone()))
         }
         V2Step::Let(let_step) => {
             let new_ctx = eval_v2_let_step(
@@ -2427,7 +2426,8 @@ fn eval_v2_step_traced<'a>(
                 .rule_path(step_path)
                 .input_v2_eval_value(&pipe_value, collector.options(), None)
                 .finish(collector);
-            Ok(new_ctx.get_pipe_value().cloned().unwrap_or(pipe_value))
+            let output = new_ctx.get_pipe_value().cloned().unwrap_or(pipe_value);
+            Ok((output, new_ctx))
         }
         V2Step::If(if_step) => {
             let cond_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
@@ -2457,7 +2457,7 @@ fn eval_v2_step_traced<'a>(
                     .end_span(TraceEventKind::BranchTaken, TracePhase::End)
                     .rule_path(step_path)
                     .finish_with_v2_eval_output(collector, &result, None);
-                Ok(result)
+                Ok((result, ctx.clone()))
             } else if let Some(else_branch) = &if_step.else_branch {
                 collector
                     .start_span(TraceEventKind::BranchTaken, TracePhase::Start)
@@ -2477,9 +2477,9 @@ fn eval_v2_step_traced<'a>(
                     .end_span(TraceEventKind::BranchTaken, TracePhase::End)
                     .rule_path(step_path)
                     .finish_with_v2_eval_output(collector, &result, None);
-                Ok(result)
+                Ok((result, ctx.clone()))
             } else {
-                Ok(pipe_value)
+                Ok((pipe_value, ctx.clone()))
             }
         }
         V2Step::Ref(v2_ref) => {
@@ -2491,29 +2491,7 @@ fn eval_v2_step_traced<'a>(
                 event = event.input_path(path);
             }
             event.finish_with_v2_eval_output(collector, &result, None);
-            Ok(result)
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn eval_v2_expr_with_trace<'a>(
-    expr: &V2Expr,
-    record: &'a JsonValue,
-    context: Option<&'a JsonValue>,
-    out: &'a JsonValue,
-    path: &str,
-    ctx: &V2EvalContext<'a>,
-    collector: &mut TraceCollector,
-) -> Result<V2EvalValue, TransformError> {
-    match expr {
-        V2Expr::Pipe(pipe) => eval_v2_pipe_traced(pipe, record, context, out, path, ctx, collector),
-        V2Expr::V1Fallback(expr) => {
-            let result = eval_expr_traced(expr, record, context, out, path, None, collector)?;
-            Ok(match result {
-                EvalValue::Missing => V2EvalValue::Missing,
-                EvalValue::Value(value) => V2EvalValue::Value(value),
-            })
+            Ok((result, ctx.clone()))
         }
     }
 }

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -2919,6 +2919,39 @@ fn eval_expr_traced(
                     locals,
                     collector,
                 ),
+                "map" => eval_array_map_traced(
+                    &expr_op.args,
+                    None,
+                    record,
+                    context,
+                    out,
+                    base_path,
+                    locals,
+                    collector,
+                ),
+                "reduce" => eval_array_reduce_traced(
+                    &expr_op.args,
+                    None,
+                    record,
+                    context,
+                    out,
+                    base_path,
+                    locals,
+                    collector,
+                ),
+                "fold" => eval_array_fold_traced(
+                    &expr_op.args,
+                    None,
+                    record,
+                    context,
+                    out,
+                    base_path,
+                    locals,
+                    collector,
+                ),
+                op if v1_operator_has_scoped_expr_args(op) => {
+                    eval_op(expr_op, record, context, out, base_path, None, locals)
+                }
                 _ => eval_eager_op_traced(
                     expr_op, record, context, out, base_path, locals, collector,
                 ),
@@ -2974,12 +3007,39 @@ fn eval_eager_op_traced(
     locals: Option<&EvalLocals<'_>>,
     collector: &mut TraceCollector,
 ) -> Result<EvalValue, TransformError> {
+    let mut arg_values = Vec::with_capacity(expr_op.args.len());
     for (arg_index, arg) in expr_op.args.iter().enumerate() {
         let arg_path = format!("{}.args[{}]", base_path, arg_index);
         let arg_value = eval_expr_traced(arg, record, context, out, &arg_path, locals, collector)?;
         emit_arg_eval(collector, &arg_path, arg_index, &arg_value);
+        arg_values.push(arg_value);
     }
-    eval_op(expr_op, record, context, out, base_path, None, locals)
+    let cached_locals = locals_with_precomputed_args(locals, base_path, &arg_values);
+    eval_op(
+        expr_op,
+        record,
+        context,
+        out,
+        base_path,
+        None,
+        Some(&cached_locals),
+    )
+}
+
+fn v1_operator_has_scoped_expr_args(op: &str) -> bool {
+    matches!(
+        op,
+        "filter"
+            | "flat_map"
+            | "zip_with"
+            | "group_by"
+            | "key_by"
+            | "partition"
+            | "distinct_by"
+            | "sort_by"
+            | "find"
+            | "find_index"
+    )
 }
 
 fn emit_arg_eval(
@@ -3035,6 +3095,40 @@ fn eval_expr_at_index_traced(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn eval_array_arg_traced(
+    index: usize,
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<Vec<JsonValue>, TransformError> {
+    let arg_path = format!("{}.args[{}]", base_path, index);
+    let value = eval_expr_at_index_traced(
+        index, args, injected, record, context, out, base_path, locals, collector,
+    )?;
+    emit_arg_eval(collector, &arg_path, index, &value);
+    match value {
+        EvalValue::Missing => Ok(Vec::new()),
+        EvalValue::Value(value) => {
+            if value.is_null() {
+                Ok(Vec::new())
+            } else if let JsonValue::Array(items) = value {
+                Ok(items)
+            } else {
+                Err(
+                    TransformError::new(TransformErrorKind::ExprError, "expr arg must be an array")
+                        .with_path(arg_path),
+                )
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn eval_coalesce_traced(
     args: &[Expr],
     injected: Option<&EvalValue>,
@@ -3071,6 +3165,196 @@ fn eval_coalesce_traced(
         }
     }
     Ok(EvalValue::Missing)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_array_map_traced(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg_traced(
+        0, args, injected, record, context, out, base_path, locals, collector,
+    )?;
+    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[1]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 0 } else { 1 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    let mut results = Vec::with_capacity(array.len());
+    for (index, item) in array.iter().enumerate() {
+        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
+        let value = eval_expr_traced(
+            expr,
+            record,
+            context,
+            out,
+            &expr_path,
+            Some(&item_locals),
+            collector,
+        )?;
+        emit_arg_eval(collector, &expr_path, expr_index, &value);
+        results.push(match value {
+            EvalValue::Missing => JsonValue::Null,
+            EvalValue::Value(value) => value,
+        });
+    }
+
+    Ok(EvalValue::Value(JsonValue::Array(results)))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_array_reduce_traced(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg_traced(
+        0, args, injected, record, context, out, base_path, locals, collector,
+    )?;
+    if array.is_empty() {
+        return Ok(EvalValue::Value(JsonValue::Null));
+    }
+
+    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[1]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 0 } else { 1 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    let mut acc = array[0].clone();
+    for (index, item) in array.iter().enumerate().skip(1) {
+        let item_locals = EvalLocals {
+            item: Some(EvalItem { value: item, index }),
+            acc: Some(&acc),
+            pipe: locals.and_then(|locals| locals.pipe),
+            locals: locals.and_then(|locals| locals.locals),
+            precomputed_op_args: None,
+        };
+        let value = eval_expr_traced(
+            expr,
+            record,
+            context,
+            out,
+            &expr_path,
+            Some(&item_locals),
+            collector,
+        )?;
+        emit_arg_eval(collector, &expr_path, expr_index, &value);
+        acc = match value {
+            EvalValue::Missing => JsonValue::Null,
+            EvalValue::Value(value) => value,
+        };
+    }
+
+    Ok(EvalValue::Value(acc))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_array_fold_traced(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 3 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly three items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg_traced(
+        0, args, injected, record, context, out, base_path, locals, collector,
+    )?;
+    let initial_path = format!("{}.args[1]", base_path);
+    let initial = eval_expr_at_index_traced(
+        1, args, injected, record, context, out, base_path, locals, collector,
+    )?;
+    emit_arg_eval(collector, &initial_path, 1, &initial);
+    let mut acc = match initial {
+        EvalValue::Missing => return Ok(EvalValue::Missing),
+        EvalValue::Value(value) => value,
+    };
+
+    let expr = arg_expr_at(2, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[2]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 1 } else { 2 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    for (index, item) in array.iter().enumerate() {
+        let item_locals = EvalLocals {
+            item: Some(EvalItem { value: item, index }),
+            acc: Some(&acc),
+            pipe: locals.and_then(|locals| locals.pipe),
+            locals: locals.and_then(|locals| locals.locals),
+            precomputed_op_args: None,
+        };
+        let value = eval_expr_traced(
+            expr,
+            record,
+            context,
+            out,
+            &expr_path,
+            Some(&item_locals),
+            collector,
+        )?;
+        emit_arg_eval(collector, &expr_path, expr_index, &value);
+        acc = match value {
+            EvalValue::Missing => JsonValue::Null,
+            EvalValue::Value(value) => value,
+        };
+    }
+
+    Ok(EvalValue::Value(acc))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3131,6 +3415,8 @@ fn canonical_ref_path(ref_path: &str) -> String {
         Ok((Namespace::Input, path)) => canonical_input_path(path),
         Ok((Namespace::Context, path)) => canonical_context_path(path),
         Ok((Namespace::Out, path)) => canonical_out_path(path),
+        Ok((Namespace::Item, path)) => canonical_item_path(path),
+        Ok((Namespace::Acc, path)) => canonical_acc_path(path),
         _ => canonical_input_path(ref_path),
     }
 }
@@ -4007,6 +4293,22 @@ fn eval_expr_at_index(
     base_path: &str,
     locals: Option<&EvalLocals<'_>>,
 ) -> Result<EvalValue, TransformError> {
+    if injected.is_none() {
+        if let Some((cached_base_path, cached_values)) =
+            locals.and_then(|locals| locals.precomputed_op_args)
+        {
+            if cached_base_path == base_path {
+                return cached_values.get(index).cloned().ok_or_else(|| {
+                    TransformError::new(
+                        TransformErrorKind::ExprError,
+                        "expr.args index is out of bounds",
+                    )
+                    .with_path(format!("{}.args[{}]", base_path, index))
+                });
+            }
+        }
+    }
+
     if let Some(injected) = injected {
         if index == 0 {
             return Ok(injected.clone());
@@ -4833,6 +5135,21 @@ fn locals_with_item<'a>(locals: Option<&EvalLocals<'a>>, item: EvalItem<'a>) -> 
         acc: locals.and_then(|locals| locals.acc),
         pipe: locals.and_then(|locals| locals.pipe),
         locals: locals.and_then(|locals| locals.locals),
+        precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
+    }
+}
+
+fn locals_with_precomputed_args<'a>(
+    locals: Option<&EvalLocals<'a>>,
+    base_path: &'a str,
+    arg_values: &'a [EvalValue],
+) -> EvalLocals<'a> {
+    EvalLocals {
+        item: locals.and_then(|locals| locals.item),
+        acc: locals.and_then(|locals| locals.acc),
+        pipe: locals.and_then(|locals| locals.pipe),
+        locals: locals.and_then(|locals| locals.locals),
+        precomputed_op_args: Some((base_path, arg_values)),
     }
 }
 
@@ -6244,6 +6561,7 @@ fn eval_array_reduce(
             acc: Some(&acc),
             pipe: locals.and_then(|locals| locals.pipe),
             locals: locals.and_then(|locals| locals.locals),
+            precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
         };
         let value = eval_expr_or_null(expr, record, context, out, &expr_path, Some(&item_locals))?;
         acc = value;
@@ -6294,6 +6612,7 @@ fn eval_array_fold(
             acc: Some(&acc),
             pipe: locals.and_then(|locals| locals.pipe),
             locals: locals.and_then(|locals| locals.locals),
+            precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
         };
         let value = eval_expr_or_null(expr, record, context, out, &expr_path, Some(&item_locals))?;
         acc = value;
@@ -8202,6 +8521,7 @@ pub(crate) struct EvalLocals<'a> {
     pub(crate) acc: Option<&'a JsonValue>,
     pub(crate) pipe: Option<&'a EvalValue>,
     pub(crate) locals: Option<&'a HashMap<String, EvalValue>>,
+    pub(crate) precomputed_op_args: Option<(&'a str, &'a [EvalValue])>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -71,6 +71,8 @@ pub struct V2EvalContext<'a> {
     item: Option<EvalItem<'a>>,
     /// Accumulator scope for reduce/fold operations (@acc)
     acc: Option<&'a JsonValue>,
+    /// Trace-mode precomputed operator args, keyed by the operator rule path.
+    precomputed_op_args: Option<(String, Vec<EvalValue>)>,
 }
 
 impl<'a> V2EvalContext<'a> {
@@ -81,6 +83,7 @@ impl<'a> V2EvalContext<'a> {
             let_bindings: HashMap::new(),
             item: None,
             acc: None,
+            precomputed_op_args: None,
         }
     }
 
@@ -116,6 +119,15 @@ impl<'a> V2EvalContext<'a> {
         self
     }
 
+    pub(crate) fn with_precomputed_op_args(
+        mut self,
+        base_path: impl Into<String>,
+        values: Vec<EvalValue>,
+    ) -> Self {
+        self.precomputed_op_args = Some((base_path.into(), values));
+        self
+    }
+
     /// Get the current pipe value
     pub fn get_pipe_value(&self) -> Option<&EvalValue> {
         self.pipe_value.as_ref()
@@ -144,6 +156,17 @@ impl<'a> V2EvalContext<'a> {
     /// Check if accumulator scope is available
     pub fn has_acc_scope(&self) -> bool {
         self.acc.is_some()
+    }
+
+    fn precomputed_arg_for_path(&self, path: &str) -> Option<EvalValue> {
+        let (base_path, values) = self.precomputed_op_args.as_ref()?;
+        let suffix = path.strip_prefix(base_path)?;
+        let index_text = suffix.strip_prefix(".args[")?.strip_suffix(']')?;
+        if index_text.contains(|ch: char| !ch.is_ascii_digit()) {
+            return None;
+        }
+        let index = index_text.parse::<usize>().ok()?;
+        values.get(index).cloned()
     }
 }
 
@@ -1243,6 +1266,9 @@ pub fn eval_v2_expr<'a>(
     path: &str,
     ctx: &V2EvalContext<'a>,
 ) -> Result<EvalValue, TransformError> {
+    if let Some(value) = ctx.precomputed_arg_for_path(path) {
+        return Ok(value);
+    }
     match expr {
         V2Expr::Pipe(pipe) => eval_v2_pipe(pipe, record, context, out, path, ctx),
         V2Expr::V1Fallback(_) => Err(TransformError::new(

--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -1624,6 +1624,7 @@ fn eval_v2_op_with_v1_fallback<'a>(
         acc: ctx.get_acc(),
         pipe: Some(&v1_pipe),
         locals: Some(&v1_locals_map),
+        precomputed_op_args: None,
     };
 
     let result = eval_v1_op(

--- a/crates/rulemorph/src/v2_validator.rs
+++ b/crates/rulemorph/src/v2_validator.rs
@@ -1105,13 +1105,19 @@ mod tests {
     }
 
     #[test]
-    fn test_valid_v2_operator_inventory_is_trace_supported() {
-        for op in VALID_V2_OPERATORS {
-            assert!(
-                crate::transform::trace_supports_v2_operator(op),
-                "{op} is valid but missing from trace operator coverage"
-            );
-        }
+    fn test_valid_v2_operator_inventory_matches_traced_generic_operator_inventory() {
+        let valid = VALID_V2_OPERATORS
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>();
+        let traced = crate::transform::TRACE_GENERIC_V2_OPERATORS
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            traced, valid,
+            "trace generic operator inventory must drift with valid v2 operators"
+        );
     }
 
     #[test]

--- a/crates/rulemorph/src/v2_validator.rs
+++ b/crates/rulemorph/src/v2_validator.rs
@@ -663,106 +663,107 @@ fn validate_v2_comparison(
 // =============================================================================
 
 /// Check if an operation name is valid
+pub(crate) const VALID_V2_OPERATORS: &[&str] = &[
+    // String operations
+    "concat",
+    "to_string",
+    "trim",
+    "lowercase",
+    "uppercase",
+    "replace",
+    "split",
+    "pad_start",
+    "pad_end",
+    // Null handling
+    "coalesce",
+    // Lookup
+    "lookup",
+    "lookup_first",
+    // Arithmetic
+    "+",
+    "-",
+    "*",
+    "/",
+    "multiply",
+    "add",
+    "subtract",
+    "divide",
+    "round",
+    "to_base",
+    // Date
+    "date_format",
+    "to_unixtime",
+    // Logical
+    "and",
+    "or",
+    "not",
+    // Comparison
+    "==",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+    "~=",
+    "eq",
+    "ne",
+    "lt",
+    "lte",
+    "gt",
+    "gte",
+    "match",
+    // JSON
+    "merge",
+    "deep_merge",
+    "get",
+    "pick",
+    "omit",
+    "keys",
+    "values",
+    "entries",
+    "len",
+    "from_entries",
+    "object_flatten",
+    "object_unflatten",
+    // Array
+    "map",
+    "filter",
+    "flat_map",
+    "flatten",
+    "take",
+    "drop",
+    "slice",
+    "chunk",
+    "zip",
+    "zip_with",
+    "unzip",
+    "group_by",
+    "key_by",
+    "partition",
+    "unique",
+    "distinct_by",
+    "sort_by",
+    "find",
+    "find_index",
+    "index_of",
+    "contains",
+    "sum",
+    "avg",
+    "min",
+    "max",
+    "reduce",
+    "fold",
+    "first",
+    "last",
+    // Type casts
+    "string",
+    "int",
+    "float",
+    "bool",
+];
+
 pub(crate) fn is_valid_op(op: &str) -> bool {
-    matches!(
-        op,
-        // String operations
-        "concat"
-            | "to_string"
-            | "trim"
-            | "lowercase"
-            | "uppercase"
-            | "replace"
-            | "split"
-            | "pad_start"
-            | "pad_end"
-            // Null handling
-            | "coalesce"
-            // Lookup
-            | "lookup"
-            | "lookup_first"
-            // Arithmetic
-            | "+"
-            | "-"
-            | "*"
-            | "/"
-            | "multiply"
-            | "add"
-            | "subtract"
-            | "divide"
-            | "round"
-            | "to_base"
-            // Date
-            | "date_format"
-            | "to_unixtime"
-            // Logical
-            | "and"
-            | "or"
-            | "not"
-            // Comparison
-            | "=="
-            | "!="
-            | "<"
-            | "<="
-            | ">"
-            | ">="
-            | "~="
-            | "eq"
-            | "ne"
-            | "lt"
-            | "lte"
-            | "gt"
-            | "gte"
-            | "match"
-            // JSON
-            | "merge"
-            | "deep_merge"
-            | "get"
-            | "pick"
-            | "omit"
-            | "keys"
-            | "values"
-            | "entries"
-            | "len"
-            | "from_entries"
-            | "object_flatten"
-            | "object_unflatten"
-            // Array
-            | "map"
-            | "filter"
-            | "flat_map"
-            | "flatten"
-            | "take"
-            | "drop"
-            | "slice"
-            | "chunk"
-            | "zip"
-            | "zip_with"
-            | "unzip"
-            | "group_by"
-            | "key_by"
-            | "partition"
-            | "unique"
-            | "distinct_by"
-            | "sort_by"
-            | "find"
-            | "find_index"
-            | "index_of"
-            | "contains"
-            | "sum"
-            | "avg"
-            | "min"
-            | "max"
-            | "reduce"
-            | "fold"
-            | "first"
-            | "last"
-            // Type casts
-            | "string"
-            | "int"
-            | "float"
-            | "bool"
-    )
+    VALID_V2_OPERATORS.contains(&op)
 }
 
 /// Get the appropriate scope for an operation argument
@@ -1097,34 +1098,20 @@ mod tests {
     // Op validation tests
     #[test]
     fn test_is_valid_op() {
-        assert!(is_valid_op("trim"));
-        assert!(is_valid_op("concat"));
-        assert!(is_valid_op("coalesce"));
-        assert!(is_valid_op("lookup_first"));
-        assert!(is_valid_op("add"));
-        assert!(is_valid_op("subtract"));
-        assert!(is_valid_op("multiply"));
-        assert!(is_valid_op("divide"));
-        assert!(is_valid_op("+"));
-        assert!(is_valid_op("replace"));
-        assert!(is_valid_op("split"));
-        assert!(is_valid_op("pad_start"));
-        assert!(is_valid_op("merge"));
-        assert!(is_valid_op("map"));
-        assert!(is_valid_op("filter"));
-        assert!(is_valid_op("round"));
-        assert!(is_valid_op("to_base"));
-        assert!(is_valid_op("date_format"));
-        assert!(is_valid_op("to_unixtime"));
-        assert!(is_valid_op("string"));
-        assert!(is_valid_op("gt"));
-        assert!(is_valid_op("gte"));
-        assert!(is_valid_op("lt"));
-        assert!(is_valid_op("lte"));
-        assert!(is_valid_op("eq"));
-        assert!(is_valid_op("ne"));
-        assert!(is_valid_op("match"));
+        for op in VALID_V2_OPERATORS {
+            assert!(is_valid_op(op), "{op} must be valid");
+        }
         assert!(!is_valid_op("nonexistent_op"));
+    }
+
+    #[test]
+    fn test_valid_v2_operator_inventory_is_trace_supported() {
+        for op in VALID_V2_OPERATORS {
+            assert!(
+                crate::transform::trace_supports_v2_operator(op),
+                "{op} is valid but missing from trace operator coverage"
+            );
+        }
     }
 
     #[test]

--- a/crates/rulemorph/tests/transform_trace.rs
+++ b/crates/rulemorph/tests/transform_trace.rs
@@ -363,6 +363,58 @@ mappings:
 }
 
 #[test]
+fn redacted_mode_hides_secret_source_written_to_public_target() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "public_id"
+    source: "api_token"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"api_token":"secret-token"}]"#),
+        None,
+        &TransformTraceOptions::redacted(),
+    )
+    .expect("traced transform");
+
+    assert_trace_does_not_contain_string(&traced.trace, "secret-token");
+    assert_no_raw_leak_in_attributes_or_messages(&traced.trace, &["secret-token"]);
+    let value = serde_json::to_value(&traced.trace).expect("trace json");
+    assert!(value.to_string().contains("secret_like_path"));
+}
+
+#[test]
+fn redacted_mode_hides_secret_expr_ref_written_to_public_target() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "public_id"
+    expr:
+      - "@input.api_token"
+      - trim
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"api_token":" secret-token "}]"#),
+        None,
+        &TransformTraceOptions::redacted(),
+    )
+    .expect("traced transform");
+
+    assert_trace_does_not_contain_string(&traced.trace, "secret-token");
+    assert_no_raw_leak_in_attributes_or_messages(&traced.trace, &["secret-token"]);
+    let value = serde_json::to_value(&traced.trace).expect("trace json");
+    assert!(value.to_string().contains("secret_like_path"));
+}
+
+#[test]
 fn metadata_only_mode_never_serializes_raw_values() {
     let yaml = r#"
 version: 2

--- a/crates/rulemorph/tests/transform_trace.rs
+++ b/crates/rulemorph/tests/transform_trace.rs
@@ -338,6 +338,224 @@ mappings:
 }
 
 #[test]
+fn trace_v2_filter_preserves_item_scope() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "active_names"
+    expr:
+      - "@input.users"
+      - filter: ["@item.active"]
+      - map:
+          - "@item.name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"users":[{"name":"alice","active":true},{"name":"bob","active":false}]}]"#;
+
+    let normal = transform(&rule, input, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, normal);
+    assert_eq!(traced.output, json!([{ "active_names": ["alice"] }]));
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+}
+
+#[test]
+fn trace_v2_sort_by_preserves_item_scope() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "names"
+    expr:
+      - "@input.users"
+      - sort_by: ["@item.rank", "asc"]
+      - map:
+          - "@item.name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"users":[{"name":"bob","rank":2},{"name":"alice","rank":1}]}]"#;
+
+    let normal = transform(&rule, input, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, normal);
+    assert_eq!(traced.output, json!([{ "names": ["alice", "bob"] }]));
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+}
+
+#[test]
+fn trace_v2_reduce_preserves_acc_scope() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "sum"
+    expr:
+      - "@input.numbers"
+      - reduce:
+          - ["@acc", { "+": "@item" }]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"numbers":[1,2,3]}]"#;
+
+    let normal = transform(&rule, input, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, normal);
+    assert_eq!(traced.output, json!([{ "sum": 6.0 }]));
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+}
+
+#[test]
+fn trace_v2_coalesce_preserves_short_circuit() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "name"
+    expr:
+      - "@input.name"
+      - coalesce: ["@item.name"]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"name":"alice"}]"#;
+
+    let normal = transform(&rule, input, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, normal);
+    assert_eq!(traced.output, json!([{ "name": "alice" }]));
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+}
+
+#[test]
+fn trace_v2_let_binding_is_visible_to_following_steps() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "discounted"
+    expr:
+      - "@input.price"
+      - let: { factor: 0.9 }
+      - multiply: ["@factor"]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"price":100}]"#;
+
+    let normal = transform(&rule, input, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, normal);
+    assert_eq!(traced.output, json!([{ "discounted": 90.0 }]));
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+}
+
+#[test]
+fn trace_step_record_when_error_closes_open_spans() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+steps:
+  - record_when: "@input.name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        transform_input_with_trace(
+            &rule,
+            InputData::Text(r#"[{"name":"alice"}]"#),
+            None,
+            &TransformTraceOptions::raw(),
+        )
+    }));
+
+    assert!(
+        result.is_ok(),
+        "record_when trace error must not leave an open span"
+    );
+    let err = result
+        .expect("no panic")
+        .expect_err("record_when should fail");
+    assert_eq!(err.error.kind, rulemorph::TransformErrorKind::ExprError);
+}
+
+#[test]
+fn trace_assert_failure_uses_configured_error_message() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+steps:
+  - asserts:
+      - when:
+          eq: ["@input.ok", true]
+        error:
+          code: "bad_input"
+          message: "expected ok"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"ok":false}]"#;
+
+    let normal = transform(&rule, input, None).expect_err("normal assertion error");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect_err("traced assertion error");
+
+    assert_eq!(traced.error, normal);
+    assert_eq!(
+        traced.error.message,
+        "assert failed: bad_input: expected ok"
+    );
+}
+
+#[test]
 fn redacted_mode_hides_secret_like_paths() {
     let yaml = r#"
 version: 2

--- a/crates/rulemorph/tests/transform_trace.rs
+++ b/crates/rulemorph/tests/transform_trace.rs
@@ -1,0 +1,599 @@
+use rulemorph::{
+    InputData, TraceEvent, TraceEventKind, TraceJsonType, TracePhase, TraceValueSnapshot,
+    TraceValueState, TransformTraceOptions, parse_rule_file, transform, transform_input_with_trace,
+    transform_input_with_trace_with_base_dir_and_options,
+};
+use serde_json::json;
+
+fn iter_trace_events(trace: &rulemorph::TransformTrace) -> Vec<&rulemorph::TraceEvent> {
+    trace
+        .records
+        .iter()
+        .flat_map(|record| record.events.iter())
+        .chain(trace.finalize.iter().flatten())
+        .collect()
+}
+
+fn assert_operator_lifecycle(trace: &rulemorph::TransformTrace, operator: &str) {
+    let events = iter_trace_events(trace);
+    let op_start = events
+        .iter()
+        .find(|event| {
+            event.kind == TraceEventKind::OpStart && event.operator.as_deref() == Some(operator)
+        })
+        .copied()
+        .unwrap_or_else(|| panic!("missing op_start for {operator}"));
+    let has_end_or_error = events.iter().any(|event| {
+        matches!(&event.kind, TraceEventKind::OpEnd | TraceEventKind::OpError)
+            && event.operator.as_deref() == Some(operator)
+            && event.parent_id == Some(op_start.id)
+    });
+    assert!(has_end_or_error, "missing op_end/op_error for {operator}");
+}
+
+fn assert_parent_ids_point_to_emitted_events(trace: &rulemorph::TransformTrace) {
+    let ids = iter_trace_events(trace)
+        .into_iter()
+        .map(|event| event.id)
+        .collect::<std::collections::BTreeSet<_>>();
+    for event in iter_trace_events(trace) {
+        if let Some(parent_id) = event.parent_id {
+            assert!(
+                ids.contains(&parent_id),
+                "dangling parent_id {parent_id} on {:?}",
+                event.kind
+            );
+        }
+    }
+}
+
+fn assert_trace_paths_are_canonical(trace: &rulemorph::TransformTrace) {
+    for event in iter_trace_events(trace) {
+        if let Some(path) = event.input_path.as_deref() {
+            assert!(
+                path == "@input"
+                    || path.starts_with("@input.")
+                    || path.starts_with("@input[")
+                    || path == "@item"
+                    || path.starts_with("@item.")
+                    || path.starts_with("@item[")
+                    || path == "@acc"
+                    || path.starts_with("@acc.")
+                    || path == "@context"
+                    || path.starts_with("@context.")
+                    || path == "@out"
+                    || path.starts_with("@out."),
+                "non-canonical input_path: {path}"
+            );
+        }
+        if let Some(path) = event.output_path.as_deref() {
+            assert!(
+                path == "$" || path.starts_with("$.") || path.starts_with("$["),
+                "non-canonical output_path: {path}"
+            );
+        }
+    }
+}
+
+fn assert_json_tree_does_not_contain_string(value: &serde_json::Value, needle: &str) {
+    match value {
+        serde_json::Value::String(text) => assert!(!text.contains(needle)),
+        serde_json::Value::Array(items) => {
+            for item in items {
+                assert_json_tree_does_not_contain_string(item, needle);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for (key, value) in map {
+                assert!(!key.contains(needle));
+                assert_json_tree_does_not_contain_string(value, needle);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_trace_does_not_contain_string(trace: &rulemorph::TransformTrace, needle: &str) {
+    let value = serde_json::to_value(trace).expect("trace json");
+    assert_json_tree_does_not_contain_string(&value, needle);
+}
+
+fn assert_no_raw_leak_in_attributes_or_messages(
+    trace: &rulemorph::TransformTrace,
+    secrets: &[&str],
+) {
+    for event in iter_trace_events(trace) {
+        let metadata = serde_json::json!({
+            "attributes": &event.attributes,
+            "message": &event.message,
+        });
+        let text = serde_json::to_string(&metadata).expect("metadata json");
+        for secret in secrets {
+            assert!(
+                !text.contains(secret),
+                "secret leaked through attributes/message"
+            );
+        }
+    }
+}
+
+#[test]
+fn trace_value_raw_mode_preserves_missing_null_and_empty_string() {
+    let options = TransformTraceOptions::raw();
+
+    let missing = TraceValueSnapshot::missing(&options, None);
+    let null = TraceValueSnapshot::from_json(&json!(null), &options, None);
+    let empty = TraceValueSnapshot::from_json(&json!(""), &options, None);
+
+    assert_eq!(missing.state, TraceValueState::Missing);
+    assert_eq!(missing.value_type, TraceJsonType::Missing);
+    assert_eq!(null.state, TraceValueState::Null);
+    assert_eq!(null.value_type, TraceJsonType::Null);
+    assert_eq!(null.value, Some(json!(null)));
+    assert_eq!(empty.state, TraceValueState::Present);
+    assert_eq!(empty.value_type, TraceJsonType::String);
+    assert_eq!(empty.value, Some(json!("")));
+}
+
+#[test]
+fn trace_event_is_json_serializable() {
+    let event = TraceEvent {
+        id: 1,
+        parent_id: None,
+        kind: TraceEventKind::SourceRead,
+        phase: TracePhase::Instant,
+        rule_path: Some("mappings[0].source".to_string()),
+        input_path: Some("@input.name".to_string()),
+        output_path: None,
+        namespace: Some("input".to_string()),
+        operator: None,
+        message: None,
+        inputs: Vec::new(),
+        output: Some(TraceValueSnapshot::from_json(
+            &json!("alice"),
+            &TransformTraceOptions::raw(),
+            None,
+        )),
+        attributes: Default::default(),
+    };
+
+    let value = serde_json::to_value(event).expect("serialize trace event");
+    assert_eq!(value["kind"], "source_read");
+    assert_eq!(value["output"]["value"], "alice");
+}
+
+#[test]
+fn enabling_trace_does_not_change_transform_output() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "name"
+    source: "name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"name":"alice"}]"#;
+
+    let normal = transform(&rule, input, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, normal);
+    assert!(traced.warnings.is_empty());
+    assert_eq!(traced.trace.records.len(), 1);
+}
+
+#[test]
+fn trace_records_source_default_and_output_write_with_raw_values() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+record_when:
+  eq: ["@input.active", true]
+mappings:
+  - target: "profile.name"
+    source: "name"
+  - target: "profile.nickname"
+    source: "nickname"
+    default: "anonymous"
+  - target: "profile.skip"
+    source: "skip"
+    when:
+      eq: ["@input.include_skip", true]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"active":true,"name":"alice"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    let events = &traced.trace.records[0].events;
+    let kinds = events
+        .iter()
+        .map(|event| serde_json::to_value(&event.kind).unwrap())
+        .collect::<Vec<_>>();
+    assert!(kinds.contains(&json!("record_when_start")));
+    assert!(kinds.contains(&json!("record_when_end")));
+    assert!(kinds.contains(&json!("source_read")));
+    assert!(kinds.contains(&json!("default_applied")));
+    assert!(kinds.contains(&json!("mapping_when_start")));
+    assert!(kinds.contains(&json!("mapping_when_end")));
+    assert!(kinds.contains(&json!("mapping_decision")));
+    assert!(kinds.contains(&json!("output_write")));
+
+    let raw_values = serde_json::to_string(&traced.trace).expect("serialize trace");
+    assert!(raw_values.contains("alice"));
+    assert!(raw_values.contains("anonymous"));
+}
+
+#[test]
+fn trace_v1_expression_operator_lifecycle() {
+    let yaml = r#"
+version: 1
+input:
+  format: json
+mappings:
+  - target: "label"
+    expr:
+      op: "concat"
+      args:
+        - ref: "input.first"
+        - " "
+        - ref: "input.last"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"first":"Ada","last":"Lovelace"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_operator_lifecycle(&traced.trace, "concat");
+
+    let text = serde_json::to_string(&traced.trace).unwrap();
+    assert!(text.contains("Ada Lovelace"));
+}
+
+#[test]
+fn trace_v2_pipe_operator_lifecycle_and_collection_items() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "names"
+    expr:
+      - "@input.users"
+      - map:
+          - "@item.name"
+          - uppercase
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"users":[{"name":"alice"},{"name":"bob"}]}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "names": ["ALICE", "BOB"] }]));
+    assert_operator_lifecycle(&traced.trace, "map");
+    assert_operator_lifecycle(&traced.trace, "uppercase");
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+
+    let text = serde_json::to_string(&traced.trace).unwrap();
+    assert!(text.contains("@item"));
+    assert!(text.contains("ALICE"));
+    assert!(text.contains("BOB"));
+}
+
+#[test]
+fn trace_v2_operator_inputs_preserve_missing_values() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "name"
+    expr:
+      - "@input.missing_name"
+      - coalesce: ["anonymous"]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "name": "anonymous" }]));
+    assert_operator_lifecycle(&traced.trace, "coalesce");
+    let events = iter_trace_events(&traced.trace);
+    let coalesce_start = events
+        .iter()
+        .find(|event| {
+            event.kind == TraceEventKind::OpStart && event.operator.as_deref() == Some("coalesce")
+        })
+        .expect("coalesce op_start");
+    assert_eq!(coalesce_start.inputs[0].state, TraceValueState::Missing);
+    assert_eq!(coalesce_start.inputs[0].value_type, TraceJsonType::Missing);
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+}
+
+#[test]
+fn redacted_mode_hides_secret_like_paths() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "token"
+    source: "api_token"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"api_token":"secret-token"}]"#),
+        None,
+        &TransformTraceOptions::redacted(),
+    )
+    .expect("traced transform");
+
+    assert_trace_does_not_contain_string(&traced.trace, "secret-token");
+    assert_no_raw_leak_in_attributes_or_messages(&traced.trace, &["secret-token"]);
+    let value = serde_json::to_value(&traced.trace).expect("trace json");
+    assert!(value.to_string().contains("secret_like_path"));
+}
+
+#[test]
+fn metadata_only_mode_never_serializes_raw_values() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "name"
+    source: "name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"name":"alice"}]"#),
+        None,
+        &TransformTraceOptions::metadata_only(),
+    )
+    .expect("traced transform");
+
+    assert_trace_does_not_contain_string(&traced.trace, "alice");
+    assert_no_raw_leak_in_attributes_or_messages(&traced.trace, &["alice"]);
+    let value = serde_json::to_value(&traced.trace).expect("trace json");
+    assert!(value.to_string().contains("metadata_only"));
+    assert!(!traced.trace.contains_raw_values);
+}
+
+#[test]
+fn transform_trace_error_debug_display_and_error_are_raw_safe() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "token"
+    source: "api_token"
+  - target: "bad"
+    expr:
+      - "@input.age"
+      - divide: 0
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let err = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"api_token":"secret-token","age":10}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect_err("traced transform should fail");
+
+    let debug = format!("{err:?}");
+    let display = format!("{err}");
+    assert!(!debug.contains("secret-token"));
+    assert!(!debug.contains("api_token"));
+    assert!(debug.contains("expr_error"));
+    assert!(!display.contains("secret-token"));
+    assert!(!display.contains("api_token"));
+    assert!(display.contains("expr_error"));
+    let source = std::error::Error::source(&err);
+    assert!(
+        source.is_none(),
+        "TransformTraceError must not expose raw TransformError as source"
+    );
+    assert!(err.trace.contains_raw_values);
+}
+
+#[test]
+fn trace_steps_record_when_asserts_and_finalize_as_spans() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+steps:
+  - mappings:
+      - target: "name"
+        source: "name"
+  - record_when:
+      eq: ["@out.name", "alice"]
+  - asserts:
+      - when:
+          eq: ["@out.name", "alice"]
+        error:
+          code: "bad_name"
+          message: "bad name"
+finalize:
+  filter:
+    eq: ["@item.name", "alice"]
+  sort:
+    by: "name"
+    order: "asc"
+  offset: 0
+  limit: 1
+  wrap:
+    data: "@out"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"name":"alice"},{"name":"bob"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!({"data":[{"name":"alice"}]}));
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+
+    let events = iter_trace_events(&traced.trace);
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == TraceEventKind::StepStart)
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == TraceEventKind::AssertEval)
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == TraceEventKind::FinalizeStart)
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == TraceEventKind::FinalizeFilter)
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == TraceEventKind::FinalizeSort)
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == TraceEventKind::FinalizeLimit)
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == TraceEventKind::FinalizeWrap)
+    );
+
+    let finalize_start = events
+        .iter()
+        .find(|event| event.kind == TraceEventKind::FinalizeStart)
+        .expect("finalize start");
+    for kind in [
+        TraceEventKind::FinalizeFilter,
+        TraceEventKind::FinalizeSort,
+        TraceEventKind::FinalizeLimit,
+        TraceEventKind::FinalizeWrap,
+    ] {
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == kind && event.parent_id == Some(finalize_start.id)),
+            "missing child finalize event for {kind:?}"
+        );
+    }
+}
+
+#[test]
+fn trace_branch_child_rule_stays_in_same_record_trace() {
+    let temp_dir =
+        std::env::temp_dir().join(format!("rulemorph-trace-branch-{}", std::process::id()));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let child_path = temp_dir.join("child.yaml");
+    std::fs::write(
+        &child_path,
+        r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "branch_value"
+    source: "name"
+"#,
+    )
+    .expect("write child rule");
+
+    let yaml = r#"
+version: 2
+input:
+  format: json
+steps:
+  - mappings:
+      - target: "name"
+        source: "name"
+  - branch:
+      when:
+        eq: ["@out.name", "alice"]
+      then: "child.yaml"
+      return: false
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace_with_base_dir_and_options(
+        &rule,
+        InputData::Text(r#"[{"name":"alice"}]"#),
+        None,
+        Some(&temp_dir),
+        &Default::default(),
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(
+        traced.output,
+        json!([{ "name": "alice", "branch_value": "alice" }])
+    );
+    assert_eq!(traced.trace.records.len(), 1);
+    assert_parent_ids_point_to_emitted_events(&traced.trace);
+    assert_trace_paths_are_canonical(&traced.trace);
+
+    let events = iter_trace_events(&traced.trace);
+    let branch_taken = events
+        .iter()
+        .find(|event| event.kind == TraceEventKind::BranchTaken)
+        .expect("branch_taken");
+    assert!(
+        events.iter().any(|event| {
+            event.kind == TraceEventKind::MappingStart && event.parent_id == Some(branch_taken.id)
+        }),
+        "child rule mapping must be nested under branch_taken"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.kind == TraceEventKind::RecordStart)
+            .count(),
+        1,
+        "branch child rule must not call start_record"
+    );
+}

--- a/crates/rulemorph/tests/transform_trace_semantics.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics.rs
@@ -208,6 +208,74 @@ mappings:
 }
 
 #[test]
+fn trace_v1_map_ref_read_preserves_item_namespace() {
+    let yaml = r#"
+version: 1
+input:
+  format: json
+mappings:
+  - target: "names"
+    expr:
+      op: map
+      args:
+        - { ref: "input.users" }
+        - { ref: "item.value.name" }
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"users":[{"name":"alice"},{"name":"bob"}]}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "names": ["alice", "bob"] }]));
+    assert!(
+        iter_trace_events(&traced.trace).into_iter().any(|event| {
+            event.kind == TraceEventKind::RefRead
+                && event.input_path.as_deref() == Some("@item.value.name")
+        }),
+        "item-scoped ref reads must not be reported as @input paths"
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_v1_reduce_ref_read_preserves_acc_namespace() {
+    let yaml = r#"
+version: 1
+input:
+  format: json
+mappings:
+  - target: "total"
+    expr:
+      op: reduce
+      args:
+        - { ref: "input.values" }
+        - { op: "+", args: [ { ref: "acc.value" }, { ref: "item.value" } ] }
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"values":[1,2,3]}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "total": 6 }]));
+    assert!(
+        iter_trace_events(&traced.trace).into_iter().any(|event| {
+            event.kind == TraceEventKind::RefRead
+                && event.input_path.as_deref() == Some("@acc.value")
+        }),
+        "acc-scoped ref reads must not be reported as @input paths"
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
 fn trace_v2_and_short_circuits_false_pipe_without_evaluating_invalid_arg() {
     let yaml = r#"
 version: 2

--- a/crates/rulemorph/tests/transform_trace_semantics.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics.rs
@@ -1,6 +1,12 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use rulemorph::{
-    InputData, TraceEvent, TraceEventKind, TransformTrace, TransformTraceOptions, parse_rule_file,
-    transform, transform_input_with_trace, transform_record, transform_record_with_trace,
+    InputData, TraceAttributeValue, TraceEvent, TraceEventKind, TransformTrace,
+    TransformTraceOptions, parse_rule_file, transform, transform_input_with_trace,
+    transform_input_with_trace_with_base_dir_and_options, transform_record,
+    transform_record_with_trace, transform_with_base_dir,
 };
 use serde_json::{Value as JsonValue, json};
 
@@ -81,6 +87,16 @@ fn assert_traced_output_matches_normal(yaml: &str, input: &str, expected: JsonVa
     assert_trace_shape(&traced.trace);
 }
 
+fn unique_temp_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("rulemorph-trace-{name}-{nanos}"));
+    fs::create_dir_all(&path).expect("create temp dir");
+    path
+}
+
 #[test]
 fn trace_output_write_uses_output_snapshot_not_input_slot() {
     let yaml = r#"
@@ -115,6 +131,80 @@ mappings:
             .and_then(|snapshot| snapshot.value.as_ref()),
         Some(&json!("alice"))
     );
+}
+
+#[test]
+fn trace_v1_coalesce_does_not_evaluate_short_circuited_arg() {
+    let yaml = r#"
+version: 1
+input:
+  format: json
+mappings:
+  - target: "name"
+    expr:
+      op: coalesce
+      args:
+        - { ref: "input.name" }
+        - { ref: "item.value" }
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"name":"alice"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "name": "alice" }]));
+    let arg_eval_indexes = iter_trace_events(&traced.trace)
+        .into_iter()
+        .filter(|event| event.kind == TraceEventKind::ArgEval)
+        .filter_map(|event| event.attributes.get("arg_index"))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        arg_eval_indexes,
+        vec![TraceAttributeValue::Number(0.into())]
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_v1_and_does_not_evaluate_short_circuited_arg() {
+    let yaml = r#"
+version: 1
+input:
+  format: json
+mappings:
+  - target: "flag"
+    expr:
+      op: and
+      args:
+        - false
+        - { ref: "item.value" }
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "flag": false }]));
+    let arg_eval_indexes = iter_trace_events(&traced.trace)
+        .into_iter()
+        .filter(|event| event.kind == TraceEventKind::ArgEval)
+        .filter_map(|event| event.attributes.get("arg_index"))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        arg_eval_indexes,
+        vec![TraceAttributeValue::Number(0.into())]
+    );
+    assert_trace_shape(&traced.trace);
 }
 
 #[test]
@@ -283,6 +373,188 @@ finalize:
             .any(|event| event.kind == TraceEventKind::FinalizeStart),
         "single-record trace API must mirror normal finalize behavior"
     );
+}
+
+#[test]
+fn trace_record_api_skips_finalize_when_record_is_dropped() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+record_when: false
+mappings:
+  - target: "name"
+    source: "name"
+finalize:
+  wrap:
+    data: "@out"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let record = json!({"name":"alice"});
+
+    let normal = transform_record(&rule, &record, None).expect("normal record transform");
+    let traced = transform_record_with_trace(&rule, &record, None, &TransformTraceOptions::raw())
+        .expect("traced record transform");
+
+    assert_eq!(normal, None);
+    assert_eq!(traced.output, normal);
+    assert!(
+        iter_trace_events(&traced.trace)
+            .into_iter()
+            .all(|event| event.kind != TraceEventKind::FinalizeStart),
+        "dropped record must not run finalize in trace mode"
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_branch_return_preserves_child_finalize_null_output() {
+    let dir = unique_temp_dir("branch-null-finalize");
+    fs::write(
+        dir.join("child.yaml"),
+        r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "ignored"
+    value: true
+finalize:
+  wrap: "@context.missing"
+"#,
+    )
+    .expect("write child rule");
+    let yaml = r#"
+version: 2
+input:
+  format: json
+steps:
+  - branch:
+      when: true
+      then: child.yaml
+      return: true
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"name":"alice"}]"#;
+
+    let normal = transform_with_base_dir(&rule, input, None, &dir).expect("normal transform");
+    let traced = transform_input_with_trace_with_base_dir_and_options(
+        &rule,
+        InputData::Text(input),
+        None,
+        Some(&dir),
+        &Default::default(),
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(normal, json!([null]));
+    assert_eq!(traced.output, normal);
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_branch_child_rule_applies_finalize_like_normal_execution() {
+    let dir = unique_temp_dir("branch-child-finalize");
+    fs::write(
+        dir.join("child.yaml"),
+        r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "final_name"
+    source: "name"
+finalize:
+  wrap:
+    data: "@out"
+"#,
+    )
+    .expect("write child rule");
+    let yaml = r#"
+version: 2
+input:
+  format: json
+steps:
+  - mappings:
+      - target: "name"
+        source: "name"
+  - branch:
+      when: true
+      then: child.yaml
+      return: true
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"name":"alice"}]"#;
+
+    let normal = transform_with_base_dir(&rule, input, None, &dir).expect("normal transform");
+    let traced = transform_input_with_trace_with_base_dir_and_options(
+        &rule,
+        InputData::Text(input),
+        None,
+        Some(&dir),
+        &Default::default(),
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(normal, json!([{ "data": [{ "final_name": "alice" }] }]));
+    assert_eq!(traced.output, normal);
+    assert!(
+        iter_trace_events(&traced.trace)
+            .into_iter()
+            .any(|event| event.kind == TraceEventKind::FinalizeStart),
+        "branch child finalize should be visible in the record trace"
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_branch_merge_error_closes_branch_and_step_spans() {
+    let dir = unique_temp_dir("branch-merge-error");
+    fs::write(
+        dir.join("child.yaml"),
+        r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "ignored"
+    value: true
+finalize:
+  wrap: "@context.missing"
+"#,
+    )
+    .expect("write child rule");
+    let yaml = r#"
+version: 2
+input:
+  format: json
+steps:
+  - branch:
+      when: true
+      then: child.yaml
+      return: false
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        transform_input_with_trace_with_base_dir_and_options(
+            &rule,
+            InputData::Text(r#"[{}]"#),
+            None,
+            Some(&dir),
+            &Default::default(),
+            &TransformTraceOptions::raw(),
+        )
+    }));
+
+    assert!(
+        result.is_ok(),
+        "branch merge error must not leave open spans"
+    );
+    let err = result.expect("no panic").expect_err("traced error");
+    assert_eq!(err.error.kind, rulemorph::TransformErrorKind::InvalidTarget);
+    assert_trace_shape(&err.trace);
 }
 
 #[test]

--- a/crates/rulemorph/tests/transform_trace_semantics.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics.rs
@@ -150,6 +150,112 @@ mappings:
 }
 
 #[test]
+fn trace_v2_missing_short_circuit_does_not_evaluate_later_invalid_arg() {
+    let cases = [
+        (
+            "concat",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.missing"
+      - concat: ["@item.invalid"]
+"#,
+        ),
+        (
+            "pick",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.obj"
+      - pick: ["@input.missing", "@item.invalid"]
+"#,
+        ),
+        (
+            "lookup_first",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.missing"
+      - lookup_first: ["@input.not_array", "@item.invalid", "@item.invalid"]
+"#,
+        ),
+    ];
+    let input = r#"[{"obj":{"a":1},"not_array":"not-array"}]"#;
+
+    for (name, yaml) in cases {
+        let rule = parse_rule_file(yaml).unwrap_or_else(|err| panic!("{name} parse: {err:?}"));
+        let normal = transform(&rule, input, None)
+            .unwrap_or_else(|err| panic!("{name} normal transform: {err:?}"));
+        let traced = transform_input_with_trace(
+            &rule,
+            InputData::Text(input),
+            None,
+            &TransformTraceOptions::raw(),
+        )
+        .unwrap_or_else(|err| panic!("{name} traced transform: {err:?}"));
+
+        assert_eq!(normal, json!([{}]), "{name} normal output");
+        assert_eq!(traced.output, normal, "{name} traced output");
+        assert!(
+            iter_trace_events(&traced.trace).into_iter().all(|event| {
+                event.kind != TraceEventKind::RefRead
+                    || event.input_path.as_deref() != Some("@item.invalid")
+            }),
+            "{name} should not evaluate skipped invalid @item arg"
+        );
+        assert_trace_shape(&traced.trace);
+    }
+}
+
+#[test]
+fn trace_v1_missing_short_circuit_does_not_evaluate_later_invalid_arg() {
+    let yaml = r#"
+version: 1
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      op: concat
+      args:
+        - { ref: "input.missing" }
+        - { ref: "item.value" }
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let normal = transform(&rule, r#"[{}]"#, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(normal, json!([{}]));
+    assert_eq!(traced.output, normal);
+    assert!(
+        iter_trace_events(&traced.trace).into_iter().all(|event| {
+            event.kind != TraceEventKind::RefRead
+                || event.input_path.as_deref() != Some("@item.value")
+        }),
+        "v1 traced missing short-circuit should not evaluate skipped invalid @item arg"
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
 fn trace_output_write_uses_output_snapshot_not_input_slot() {
     let yaml = r#"
 version: 2

--- a/crates/rulemorph/tests/transform_trace_semantics.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics.rs
@@ -1,0 +1,378 @@
+use rulemorph::{
+    InputData, TraceEvent, TraceEventKind, TransformTrace, TransformTraceOptions, parse_rule_file,
+    transform, transform_input_with_trace,
+};
+use serde_json::{Value as JsonValue, json};
+
+fn iter_trace_events(trace: &TransformTrace) -> Vec<&TraceEvent> {
+    trace
+        .records
+        .iter()
+        .flat_map(|record| record.events.iter())
+        .chain(trace.finalize.iter().flatten())
+        .collect()
+}
+
+fn assert_parent_ids_point_to_emitted_events(trace: &TransformTrace) {
+    let ids = iter_trace_events(trace)
+        .into_iter()
+        .map(|event| event.id)
+        .collect::<std::collections::BTreeSet<_>>();
+    for event in iter_trace_events(trace) {
+        if let Some(parent_id) = event.parent_id {
+            assert!(
+                ids.contains(&parent_id),
+                "dangling parent_id {parent_id} on {:?}",
+                event.kind
+            );
+        }
+    }
+}
+
+fn assert_trace_paths_are_canonical(trace: &TransformTrace) {
+    for event in iter_trace_events(trace) {
+        if let Some(path) = event.input_path.as_deref() {
+            assert!(
+                path == "@input"
+                    || path.starts_with("@input.")
+                    || path.starts_with("@input[")
+                    || path == "@item"
+                    || path.starts_with("@item.")
+                    || path.starts_with("@item[")
+                    || path == "@acc"
+                    || path.starts_with("@acc.")
+                    || path.starts_with("@acc[")
+                    || path == "@context"
+                    || path.starts_with("@context.")
+                    || path.starts_with("@context[")
+                    || path == "@out"
+                    || path.starts_with("@out.")
+                    || path.starts_with("@out["),
+                "non-canonical input_path: {path}"
+            );
+        }
+        if let Some(path) = event.output_path.as_deref() {
+            assert!(
+                path == "$" || path.starts_with("$.") || path.starts_with("$["),
+                "non-canonical output_path: {path}"
+            );
+        }
+    }
+}
+
+fn assert_trace_shape(trace: &TransformTrace) {
+    assert_parent_ids_point_to_emitted_events(trace);
+    assert_trace_paths_are_canonical(trace);
+}
+
+fn assert_traced_output_matches_normal(yaml: &str, input: &str, expected: JsonValue) {
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let normal = transform(&rule, input, None).expect("normal transform");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(normal, expected);
+    assert_eq!(traced.output, normal);
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_v2_and_short_circuits_false_pipe_without_evaluating_invalid_arg() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "flag"
+    expr:
+      - "@input.enabled"
+      - and: ["@item.enabled"]
+"#;
+
+    assert_traced_output_matches_normal(yaml, r#"[{"enabled":false}]"#, json!([{ "flag": false }]));
+}
+
+#[test]
+fn trace_v2_or_short_circuits_true_pipe_without_evaluating_invalid_arg() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "flag"
+    expr:
+      - "@input.enabled"
+      - or: ["@item.enabled"]
+"#;
+
+    assert_traced_output_matches_normal(yaml, r#"[{"enabled":true}]"#, json!([{ "flag": true }]));
+}
+
+#[test]
+fn trace_v2_coalesce_short_circuits_after_first_present_arg() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "name"
+    expr:
+      - "@input.primary"
+      - coalesce: ["@input.secondary", "@item.name"]
+"#;
+
+    assert_traced_output_matches_normal(
+        yaml,
+        r#"[{"secondary":"fallback"}]"#,
+        json!([{ "name": "fallback" }]),
+    );
+}
+
+#[test]
+fn trace_v2_non_short_circuited_invalid_arg_errors_like_normal() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "flag"
+    expr:
+      - "@input.enabled"
+      - and: ["@item.enabled"]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let input = r#"[{"enabled":true}]"#;
+
+    let normal = transform(&rule, input, None).expect_err("normal error");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(input),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect_err("traced error");
+
+    assert_eq!(traced.error, normal);
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_v2_item_scoped_collection_ops_match_normal() {
+    let cases = [
+        (
+            "flat_map",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "tags"
+    expr:
+      - "@input.users"
+      - flat_map: ["@item.tags"]
+"#,
+            json!([{ "tags": ["a", "b", "c"] }]),
+        ),
+        (
+            "group_by",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "by_role"
+    expr:
+      - "@input.users"
+      - group_by: ["@item.role"]
+"#,
+            json!([{ "by_role": {
+                "admin": [
+                    {"id":"u1","name":"Alice","role":"admin","active":false,"tags":["a","b"]},
+                    {"id":"u3","name":"Carol","role":"admin","active":true,"tags":[]}
+                ],
+                "member": [
+                    {"id":"u2","name":"Bob","role":"member","active":true,"tags":["c"]}
+                ]
+            } }]),
+        ),
+        (
+            "key_by",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "by_id"
+    expr:
+      - "@input.users"
+      - key_by: ["@item.id"]
+"#,
+            json!([{ "by_id": {
+                "u1": {"id":"u1","name":"Alice","role":"admin","active":false,"tags":["a","b"]},
+                "u2": {"id":"u2","name":"Bob","role":"member","active":true,"tags":["c"]},
+                "u3": {"id":"u3","name":"Carol","role":"admin","active":true,"tags":[]}
+            } }]),
+        ),
+        (
+            "partition",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "active_groups"
+    expr:
+      - "@input.users"
+      - partition: ["@item.active"]
+"#,
+            json!([{ "active_groups": [
+                [
+                    {"id":"u2","name":"Bob","role":"member","active":true,"tags":["c"]},
+                    {"id":"u3","name":"Carol","role":"admin","active":true,"tags":[]}
+                ],
+                [
+                    {"id":"u1","name":"Alice","role":"admin","active":false,"tags":["a","b"]}
+                ]
+            ] }]),
+        ),
+        (
+            "distinct_by",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "first_by_role"
+    expr:
+      - "@input.users"
+      - distinct_by: ["@item.role"]
+"#,
+            json!([{ "first_by_role": [
+                {"id":"u1","name":"Alice","role":"admin","active":false,"tags":["a","b"]},
+                {"id":"u2","name":"Bob","role":"member","active":true,"tags":["c"]}
+            ] }]),
+        ),
+        (
+            "find",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "first_active"
+    expr:
+      - "@input.users"
+      - find: ["@item.active"]
+"#,
+            json!([{ "first_active": {"id":"u2","name":"Bob","role":"member","active":true,"tags":["c"]} }]),
+        ),
+        (
+            "find_index",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "first_active_index"
+    expr:
+      - "@input.users"
+      - find_index: ["@item.active"]
+"#,
+            json!([{ "first_active_index": 1 }]),
+        ),
+    ];
+    let input = r#"[{"users":[
+        {"id":"u1","name":"Alice","role":"admin","active":false,"tags":["a","b"]},
+        {"id":"u2","name":"Bob","role":"member","active":true,"tags":["c"]},
+        {"id":"u3","name":"Carol","role":"admin","active":true,"tags":[]}
+    ]}]"#;
+
+    for (name, yaml, expected) in cases {
+        assert_traced_output_matches_normal(yaml, input, expected);
+        let rule = parse_rule_file(yaml).unwrap_or_else(|err| panic!("{name} parse: {err:?}"));
+        let traced = transform_input_with_trace(
+            &rule,
+            InputData::Text(input),
+            None,
+            &TransformTraceOptions::raw(),
+        )
+        .unwrap_or_else(|err| panic!("{name} traced transform: {err:?}"));
+        assert!(
+            iter_trace_events(&traced.trace).iter().any(|event| {
+                event.kind == TraceEventKind::OpStart && event.operator.as_deref() == Some(name)
+            }),
+            "missing op_start for {name}"
+        );
+    }
+}
+
+#[test]
+fn trace_v2_fold_preserves_acc_and_item_scope() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "sum"
+    expr:
+      - "@input.numbers"
+      - fold:
+          - 0
+          - ["@acc", { "+": "@item" }]
+"#;
+
+    assert_traced_output_matches_normal(yaml, r#"[{"numbers":[1,2,3]}]"#, json!([{ "sum": 6.0 }]));
+}
+
+#[test]
+fn trace_v2_let_binding_survives_nested_map_steps() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "totals"
+    expr:
+      - "@input.prices"
+      - map:
+          - let: { tax: 1.1 }
+          - multiply: ["@tax"]
+"#;
+
+    assert_traced_output_matches_normal(
+        yaml,
+        r#"[{"prices":[100,200]}]"#,
+        json!([{ "totals": [110.00000000000001, 220.00000000000003] }]),
+    );
+}
+
+#[test]
+fn trace_v2_if_does_not_evaluate_unselected_branch() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "label"
+    expr:
+      - "@input.enabled"
+      - if:
+          cond:
+            eq: ["$", true]
+          then:
+            - "enabled"
+          else:
+            - "@item.label"
+"#;
+
+    assert_traced_output_matches_normal(
+        yaml,
+        r#"[{"enabled":true}]"#,
+        json!([{ "label": "enabled" }]),
+    );
+}

--- a/crates/rulemorph/tests/transform_trace_semantics.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics.rs
@@ -87,6 +87,20 @@ fn assert_traced_output_matches_normal(yaml: &str, input: &str, expected: JsonVa
     assert_trace_shape(&traced.trace);
 }
 
+fn attr_number(event: &TraceEvent, key: &str) -> Option<u64> {
+    match event.attributes.get(key) {
+        Some(TraceAttributeValue::Number(number)) => number.as_u64(),
+        _ => None,
+    }
+}
+
+fn attr_bool(event: &TraceEvent, key: &str) -> Option<bool> {
+    match event.attributes.get(key) {
+        Some(TraceAttributeValue::Bool(flag)) => Some(*flag),
+        _ => None,
+    }
+}
+
 fn unique_temp_dir(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -95,6 +109,44 @@ fn unique_temp_dir(name: &str) -> PathBuf {
     let path = std::env::temp_dir().join(format!("rulemorph-trace-{name}-{nanos}"));
     fs::create_dir_all(&path).expect("create temp dir");
     path
+}
+
+#[test]
+fn trace_v2_eager_operator_emits_arg_eval_for_actual_args() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "label"
+    expr:
+      - "@input.first"
+      - concat: ["@input.second"]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"first":"A","second":"B"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "label": "AB" }]));
+    assert!(
+        iter_trace_events(&traced.trace).into_iter().any(|event| {
+            event.kind == TraceEventKind::ArgEval
+                && event.operator.as_deref() == Some("concat")
+                && attr_number(event, "arg_index") == Some(0)
+                && event
+                    .output
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.value.as_ref())
+                    == Some(&json!("B"))
+        }),
+        "v2 eager operator args should be traced when actually evaluated"
+    );
+    assert_trace_shape(&traced.trace);
 }
 
 #[test]
@@ -131,6 +183,663 @@ mappings:
             .and_then(|snapshot| snapshot.value.as_ref()),
         Some(&json!("alice"))
     );
+}
+
+#[test]
+fn trace_v2_collection_operators_emit_item_level_events() {
+    let cases = [
+        (
+            "filter",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - filter: ["@item.active"]
+"#,
+            json!([{ "out": [
+                {"id":"u2","role":"member","active":true,"tags":["c"],"score":1},
+                {"id":"u3","role":"admin","active":true,"tags":[],"score":3}
+            ] }]),
+        ),
+        (
+            "flat_map",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - flat_map: ["@item.tags"]
+"#,
+            json!([{ "out": ["a", "b", "c"] }]),
+        ),
+        (
+            "reduce",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.scores"
+      - reduce: [["@acc", { "+": "@item" }]]
+"#,
+            json!([{ "out": 6.0 }]),
+        ),
+        (
+            "fold",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.scores"
+      - fold:
+          - 0
+          - ["@acc", { "+": "@item" }]
+"#,
+            json!([{ "out": 6.0 }]),
+        ),
+        (
+            "group_by",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - group_by: ["@item.role"]
+"#,
+            json!([{ "out": {
+                "admin": [
+                    {"id":"u1","role":"admin","active":false,"tags":["a","b"],"score":2},
+                    {"id":"u3","role":"admin","active":true,"tags":[],"score":3}
+                ],
+                "member": [
+                    {"id":"u2","role":"member","active":true,"tags":["c"],"score":1}
+                ]
+            } }]),
+        ),
+        (
+            "key_by",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - key_by: ["@item.id"]
+"#,
+            json!([{ "out": {
+                "u1": {"id":"u1","role":"admin","active":false,"tags":["a","b"],"score":2},
+                "u2": {"id":"u2","role":"member","active":true,"tags":["c"],"score":1},
+                "u3": {"id":"u3","role":"admin","active":true,"tags":[],"score":3}
+            } }]),
+        ),
+        (
+            "partition",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - partition: ["@item.active"]
+"#,
+            json!([{ "out": [
+                [
+                    {"id":"u2","role":"member","active":true,"tags":["c"],"score":1},
+                    {"id":"u3","role":"admin","active":true,"tags":[],"score":3}
+                ],
+                [
+                    {"id":"u1","role":"admin","active":false,"tags":["a","b"],"score":2}
+                ]
+            ] }]),
+        ),
+        (
+            "distinct_by",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - distinct_by: ["@item.role"]
+"#,
+            json!([{ "out": [
+                {"id":"u1","role":"admin","active":false,"tags":["a","b"],"score":2},
+                {"id":"u2","role":"member","active":true,"tags":["c"],"score":1}
+            ] }]),
+        ),
+        (
+            "sort_by",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - sort_by: ["@item.score"]
+"#,
+            json!([{ "out": [
+                {"id":"u2","role":"member","active":true,"tags":["c"],"score":1},
+                {"id":"u1","role":"admin","active":false,"tags":["a","b"],"score":2},
+                {"id":"u3","role":"admin","active":true,"tags":[],"score":3}
+            ] }]),
+        ),
+        (
+            "find",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - find: ["@item.active"]
+"#,
+            json!([{ "out": {"id":"u2","role":"member","active":true,"tags":["c"],"score":1} }]),
+        ),
+        (
+            "find_index",
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr:
+      - "@input.users"
+      - find_index: ["@item.active"]
+"#,
+            json!([{ "out": 1 }]),
+        ),
+    ];
+    let input = r#"[{
+        "users":[
+            {"id":"u1","role":"admin","active":false,"tags":["a","b"],"score":2},
+            {"id":"u2","role":"member","active":true,"tags":["c"],"score":1},
+            {"id":"u3","role":"admin","active":true,"tags":[],"score":3}
+        ],
+        "scores":[1,2,3]
+    }]"#;
+
+    for (operator, yaml, expected) in cases {
+        let rule = parse_rule_file(yaml).unwrap_or_else(|err| panic!("{operator} parse: {err:?}"));
+        let normal = transform(&rule, input, None)
+            .unwrap_or_else(|err| panic!("{operator} normal transform: {err:?}"));
+        let traced = transform_input_with_trace(
+            &rule,
+            InputData::Text(input),
+            None,
+            &TransformTraceOptions::raw(),
+        )
+        .unwrap_or_else(|err| panic!("{operator} traced transform: {err:?}"));
+
+        assert_eq!(normal, expected, "{operator} normal output");
+        assert_eq!(traced.output, normal, "{operator} traced output");
+        let events = iter_trace_events(&traced.trace);
+        assert!(
+            events.iter().any(|event| {
+                event.kind == TraceEventKind::CollectionItemStart
+                    && event.operator.as_deref() == Some(operator)
+            }),
+            "{operator} should emit per-item start events"
+        );
+        assert!(
+            events.iter().any(|event| {
+                event.kind == TraceEventKind::CollectionItemEnd
+                    && event.operator.as_deref() == Some(operator)
+                    && event.attributes.contains_key("item_index")
+            }),
+            "{operator} should emit per-item end/decision events"
+        );
+        assert_trace_shape(&traced.trace);
+    }
+}
+
+#[test]
+fn trace_record_when_and_mapping_when_include_internal_condition_trace() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+record_when:
+  eq: ["@input.kind", "keep"]
+mappings:
+  - target: "name"
+    when:
+      eq: ["@input.enabled", true]
+    source: "name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"kind":"keep","enabled":true,"name":"alice"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "name": "alice" }]));
+    let events = iter_trace_events(&traced.trace);
+    assert!(
+        events.iter().any(|event| {
+            event.kind == TraceEventKind::RefRead
+                && event.input_path.as_deref() == Some("@input.kind")
+        }),
+        "record_when should expose internal ref evaluation"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event.kind == TraceEventKind::RefRead
+                && event.input_path.as_deref() == Some("@input.enabled")
+        }),
+        "mapping.when should expose internal ref evaluation"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event.kind == TraceEventKind::ArgEval
+                && event.operator.as_deref() == Some("eq")
+                && attr_number(event, "arg_index") == Some(1)
+        }),
+        "condition comparison should expose actual argument evaluation"
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_finalize_filter_and_sort_emit_item_level_decisions() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "id"
+    source: "id"
+  - target: "active"
+    source: "active"
+  - target: "score"
+    source: "score"
+finalize:
+  filter:
+    eq: ["@item.active", true]
+  sort:
+    by: "score"
+    order: "desc"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(
+            r#"[
+                {"id":"a","active":true,"score":2},
+                {"id":"b","active":false,"score":5},
+                {"id":"c","active":true,"score":3}
+            ]"#,
+        ),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(
+        traced.output,
+        json!([
+            {"id":"c","active":true,"score":3},
+            {"id":"a","active":true,"score":2}
+        ])
+    );
+    let finalize_events = traced.trace.finalize.as_ref().expect("finalize trace");
+    assert!(
+        finalize_events.iter().any(|event| {
+            event.kind == TraceEventKind::FinalizeFilter
+                && attr_number(event, "item_index") == Some(1)
+                && attr_bool(event, "kept") == Some(false)
+        }),
+        "finalize.filter should emit per-item kept decisions"
+    );
+    assert!(
+        finalize_events.iter().any(|event| {
+            event.kind == TraceEventKind::FinalizeSort
+                && attr_number(event, "from_index") == Some(1)
+                && attr_number(event, "to_index") == Some(0)
+        }),
+        "finalize.sort should emit item movement decisions"
+    );
+    assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_v2_operator_fixture_table_covers_valid_inventory_representatives() {
+    let cases = [
+        ("concat", r#"["@input.s", {"concat": "!"}]"#),
+        ("to_string", r#"["@input.n", "to_string"]"#),
+        ("trim", r#"["@input.spaced", "trim"]"#),
+        ("lowercase", r#"["@input.upper", "lowercase"]"#),
+        ("uppercase", r#"["@input.s", "uppercase"]"#),
+        (
+            "replace",
+            r#"["@input.text", {"replace": ["world", "there"]}]"#,
+        ),
+        ("split", r#"["@input.csv", {"split": ","}]"#),
+        ("pad_start", r#"["@input.pad", {"pad_start": [3, "0"]}]"#),
+        ("pad_end", r#"["@input.pad", {"pad_end": [3, "0"]}]"#),
+        (
+            "coalesce",
+            r#"["@input.missing", {"coalesce": "@input.s"}]"#,
+        ),
+        (
+            "lookup",
+            r#"["@input.lookup_rows", {"lookup": ["id", "b"]}]"#,
+        ),
+        (
+            "lookup_first",
+            r#"["@input.lookup_rows", {"lookup_first": ["id", "b"]}]"#,
+        ),
+        ("+", r#"["@input.n", {"+": 2}]"#),
+        ("-", r#"["@input.n", {"-": 1}]"#),
+        ("*", r#"["@input.n", {"*": 2}]"#),
+        ("/", r#"["@input.n", {"/": 2}]"#),
+        ("multiply", r#"["@input.n", {"multiply": 2}]"#),
+        ("add", r#"["@input.n", {"add": 2}]"#),
+        ("subtract", r#"["@input.n", {"subtract": 1}]"#),
+        ("divide", r#"["@input.n", {"divide": 2}]"#),
+        ("round", r#"["@input.float", {"round": 2}]"#),
+        ("to_base", r#"["@input.base", {"to_base": 16}]"#),
+        (
+            "date_format",
+            r#"["@input.date", {"date_format": "%Y/%m/%d"}]"#,
+        ),
+        ("to_unixtime", r#"["@input.unix", "to_unixtime"]"#),
+        ("and", r#"["@input.truth", {"and": true}]"#),
+        ("or", r#"["@input.falsehood", {"or": true}]"#),
+        ("not", r#"["@input.falsehood", "not"]"#),
+        ("==", r#"["@input.n", {"==": 3}]"#),
+        ("!=", r#"["@input.n", {"!=": 4}]"#),
+        ("<", r#"["@input.n", {"<": 4}]"#),
+        ("<=", r#"["@input.n", {"<=": 3}]"#),
+        (">", r#"["@input.n", {">": 2}]"#),
+        (">=", r#"["@input.n", {">=": 3}]"#),
+        ("~=", r#"["@input.s", {"~=": "^h"}]"#),
+        ("eq", r#"["@input.n", {"eq": 3}]"#),
+        ("ne", r#"["@input.n", {"ne": 4}]"#),
+        ("lt", r#"["@input.n", {"lt": 4}]"#),
+        ("lte", r#"["@input.n", {"lte": 3}]"#),
+        ("gt", r#"["@input.n", {"gt": 2}]"#),
+        ("gte", r#"["@input.n", {"gte": 3}]"#),
+        ("match", r#"["@input.s", {"match": "^h"}]"#),
+        ("merge", r#"["@input.obj", {"merge": {"b":2}}]"#),
+        (
+            "deep_merge",
+            r#"["@input.deep_left", {"deep_merge": "@input.deep_right"}]"#,
+        ),
+        ("get", r#"["@input.obj", {"get": "a"}]"#),
+        ("pick", r#"["@input.obj", {"pick": "a"}]"#),
+        ("omit", r#"["@input.obj", {"omit": "b"}]"#),
+        ("keys", r#"["@input.obj", "keys"]"#),
+        ("values", r#"["@input.obj", "values"]"#),
+        ("entries", r#"["@input.obj", "entries"]"#),
+        ("len", r#"["@input.arr", "len"]"#),
+        ("from_entries", r#"["@input.entries", "from_entries"]"#),
+        (
+            "object_flatten",
+            r#"["@input.deep_left", "object_flatten"]"#,
+        ),
+        (
+            "object_unflatten",
+            r#"["@input.flat_obj", "object_unflatten"]"#,
+        ),
+        ("map", r#"["@input.arr", {"map": ["@item", {"add": 1}]}]"#),
+        ("filter", r#"["@input.items", {"filter": "@item.keep"}]"#),
+        (
+            "flat_map",
+            r#"["@input.items", {"flat_map": "@item.tags"}]"#,
+        ),
+        ("flatten", r#"["@input.nested", {"flatten": 2}]"#),
+        ("take", r#"["@input.arr", {"take": 2}]"#),
+        ("drop", r#"["@input.arr", {"drop": 1}]"#),
+        ("slice", r#"["@input.arr", {"slice": [1, 3]}]"#),
+        ("chunk", r#"["@input.arr", {"chunk": 2}]"#),
+        ("zip", r#"["@input.arr", {"zip": "@input.arr2"}]"#),
+        (
+            "zip_with",
+            r#"["@input.arr", {"zip_with": ["@input.arr2", "@item"]}]"#,
+        ),
+        ("unzip", r#"["@input.pairs", "unzip"]"#),
+        (
+            "group_by",
+            r#"["@input.items", {"group_by": "@item.role"}]"#,
+        ),
+        ("key_by", r#"["@input.items", {"key_by": "@item.id"}]"#),
+        (
+            "partition",
+            r#"["@input.items", {"partition": "@item.keep"}]"#,
+        ),
+        ("unique", r#"["@input.dups", "unique"]"#),
+        (
+            "distinct_by",
+            r#"["@input.items", {"distinct_by": "@item.role"}]"#,
+        ),
+        ("sort_by", r#"["@input.items", {"sort_by": "@item.v"}]"#),
+        ("find", r#"["@input.items", {"find": "@item.keep"}]"#),
+        (
+            "find_index",
+            r#"["@input.items", {"find_index": "@item.keep"}]"#,
+        ),
+        ("index_of", r#"["@input.arr", {"index_of": 2}]"#),
+        ("contains", r#"["@input.arr", {"contains": 3}]"#),
+        ("sum", r#"["@input.arr", "sum"]"#),
+        ("avg", r#"["@input.arr", "avg"]"#),
+        ("min", r#"["@input.arr", "min"]"#),
+        ("max", r#"["@input.arr", "max"]"#),
+        (
+            "reduce",
+            r#"["@input.arr", {"reduce": [["@acc", {"+": "@item"}]]}]"#,
+        ),
+        (
+            "fold",
+            r#"["@input.arr", {"fold": [0, ["@acc", {"+": "@item"}]]}]"#,
+        ),
+        ("first", r#"["@input.arr", "first"]"#),
+        ("last", r#"["@input.arr", "last"]"#),
+        ("string", r#"["@input.n", "string"]"#),
+        ("int", r#"["@input.int_text", "int"]"#),
+        ("float", r#"["@input.float_text", "float"]"#),
+        ("bool", r#"["@input.bool_text", "bool"]"#),
+    ];
+    let expected_inventory = [
+        "concat",
+        "to_string",
+        "trim",
+        "lowercase",
+        "uppercase",
+        "replace",
+        "split",
+        "pad_start",
+        "pad_end",
+        "coalesce",
+        "lookup",
+        "lookup_first",
+        "+",
+        "-",
+        "*",
+        "/",
+        "multiply",
+        "add",
+        "subtract",
+        "divide",
+        "round",
+        "to_base",
+        "date_format",
+        "to_unixtime",
+        "and",
+        "or",
+        "not",
+        "==",
+        "!=",
+        "<",
+        "<=",
+        ">",
+        ">=",
+        "~=",
+        "eq",
+        "ne",
+        "lt",
+        "lte",
+        "gt",
+        "gte",
+        "match",
+        "merge",
+        "deep_merge",
+        "get",
+        "pick",
+        "omit",
+        "keys",
+        "values",
+        "entries",
+        "len",
+        "from_entries",
+        "object_flatten",
+        "object_unflatten",
+        "map",
+        "filter",
+        "flat_map",
+        "flatten",
+        "take",
+        "drop",
+        "slice",
+        "chunk",
+        "zip",
+        "zip_with",
+        "unzip",
+        "group_by",
+        "key_by",
+        "partition",
+        "unique",
+        "distinct_by",
+        "sort_by",
+        "find",
+        "find_index",
+        "index_of",
+        "contains",
+        "sum",
+        "avg",
+        "min",
+        "max",
+        "reduce",
+        "fold",
+        "first",
+        "last",
+        "string",
+        "int",
+        "float",
+        "bool",
+    ];
+    assert_eq!(
+        cases
+            .iter()
+            .map(|(op, _)| *op)
+            .collect::<std::collections::BTreeSet<_>>(),
+        expected_inventory
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>(),
+        "trace fixture table must drift with valid v2 operator inventory"
+    );
+    let input = r#"[{
+        "s":"hi",
+        "spaced":" hi ",
+        "upper":"HI",
+        "text":"hello world",
+        "csv":"a,b",
+        "pad":"7",
+        "n":3,
+        "float":1.2345,
+        "base":255,
+        "date":"2024-01-02 03:04:05",
+        "unix":"1970-01-01T00:00:01Z",
+        "truth":true,
+        "falsehood":false,
+        "obj":{"a":1,"b":2},
+        "deep_left":{"a":1,"nested":{"x":1}},
+        "deep_right":{"nested":{"y":2},"c":3},
+        "flat_obj":{"a.b":1,"c":2},
+        "entries":[["a",1],["b",2]],
+        "arr":[1,2,3],
+        "arr2":[4,5,6],
+        "nested":[1,[2,[3]],4],
+        "pairs":[[1,"a"],[2,"b"]],
+        "dups":["a","b","a"],
+        "items":[
+            {"id":"a","role":"admin","keep":true,"v":2,"tags":["x"]},
+            {"id":"b","role":"member","keep":false,"v":1,"tags":["y","z"]},
+            {"id":"c","role":"admin","keep":true,"v":3,"tags":[]}
+        ],
+        "lookup_rows":[{"id":"a","value":1},{"id":"b","value":2}],
+        "int_text":"42",
+        "float_text":"1.5",
+        "bool_text":"true"
+    }]"#;
+
+    for (operator, expr) in cases {
+        let yaml = format!(
+            r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "out"
+    expr: {expr}
+"#
+        );
+        let rule = parse_rule_file(&yaml).unwrap_or_else(|err| panic!("{operator} parse: {err:?}"));
+        let normal = transform(&rule, input, None)
+            .unwrap_or_else(|err| panic!("{operator} normal transform: {err:?}"));
+        let traced = transform_input_with_trace(
+            &rule,
+            InputData::Text(input),
+            None,
+            &TransformTraceOptions::raw(),
+        )
+        .unwrap_or_else(|err| panic!("{operator} traced transform: {err:?}"));
+
+        assert_eq!(traced.output, normal, "{operator}");
+        let events = iter_trace_events(&traced.trace);
+        assert!(
+            events.iter().any(|event| {
+                event.kind == TraceEventKind::OpStart && event.operator.as_deref() == Some(operator)
+            }),
+            "{operator} missing op_start"
+        );
+        assert!(
+            events.iter().any(|event| {
+                event.kind == TraceEventKind::OpEnd && event.operator.as_deref() == Some(operator)
+            }),
+            "{operator} missing op_end"
+        );
+        assert_trace_shape(&traced.trace);
+    }
 }
 
 #[test]
@@ -320,11 +1029,30 @@ mappings:
       - coalesce: ["@input.secondary", "@item.name"]
 "#;
 
-    assert_traced_output_matches_normal(
-        yaml,
-        r#"[{"secondary":"fallback"}]"#,
-        json!([{ "name": "fallback" }]),
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"secondary":"fallback"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert_eq!(traced.output, json!([{ "name": "fallback" }]));
+    let arg_eval_indexes = iter_trace_events(&traced.trace)
+        .into_iter()
+        .filter(|event| {
+            event.kind == TraceEventKind::ArgEval && event.operator.as_deref() == Some("coalesce")
+        })
+        .filter_map(|event| event.attributes.get("arg_index"))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        arg_eval_indexes,
+        vec![TraceAttributeValue::Number(0.into())],
+        "coalesce should trace evaluated fallback args but not short-circuited args"
     );
+    assert_trace_shape(&traced.trace);
 }
 
 #[test]

--- a/crates/rulemorph/tests/transform_trace_semantics.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics.rs
@@ -1,6 +1,6 @@
 use rulemorph::{
     InputData, TraceEvent, TraceEventKind, TransformTrace, TransformTraceOptions, parse_rule_file,
-    transform, transform_input_with_trace,
+    transform, transform_input_with_trace, transform_record, transform_record_with_trace,
 };
 use serde_json::{Value as JsonValue, json};
 
@@ -82,6 +82,42 @@ fn assert_traced_output_matches_normal(yaml: &str, input: &str, expected: JsonVa
 }
 
 #[test]
+fn trace_output_write_uses_output_snapshot_not_input_slot() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "name"
+    source: "name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"name":"alice"}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    let output_write = iter_trace_events(&traced.trace)
+        .into_iter()
+        .find(|event| event.kind == TraceEventKind::OutputWrite)
+        .expect("output_write event");
+    assert!(
+        output_write.inputs.is_empty(),
+        "output_write must not put the written value in inputs"
+    );
+    assert_eq!(
+        output_write
+            .output
+            .as_ref()
+            .and_then(|snapshot| snapshot.value.as_ref()),
+        Some(&json!("alice"))
+    );
+}
+
+#[test]
 fn trace_v2_and_short_circuits_false_pipe_without_evaluating_invalid_arg() {
     let yaml = r#"
 version: 2
@@ -134,6 +170,35 @@ mappings:
 }
 
 #[test]
+fn trace_v2_short_circuited_args_are_not_reported_as_arg_eval() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "flag"
+    expr:
+      - "@input.enabled"
+      - and: ["@item.enabled"]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"[{"enabled":false}]"#),
+        None,
+        &TransformTraceOptions::raw(),
+    )
+    .expect("traced transform");
+
+    assert!(
+        iter_trace_events(&traced.trace)
+            .into_iter()
+            .all(|event| event.kind != TraceEventKind::ArgEval),
+        "short-circuited v2 args must not be reported as evaluated"
+    );
+}
+
+#[test]
 fn trace_v2_non_short_circuited_invalid_arg_errors_like_normal() {
     let yaml = r#"
 version: 2
@@ -159,6 +224,65 @@ mappings:
 
     assert_eq!(traced.error, normal);
     assert_trace_shape(&traced.trace);
+}
+
+#[test]
+fn trace_v2_map_nested_error_closes_collection_and_map_spans() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "items"
+    expr:
+      - "@input.items"
+      - map:
+          - divide: [0]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        transform_input_with_trace(
+            &rule,
+            InputData::Text(r#"[{"items":[1]}]"#),
+            None,
+            &TransformTraceOptions::raw(),
+        )
+    }));
+
+    assert!(result.is_ok(), "map nested error must not leave open spans");
+    let err = result.expect("no panic").expect_err("traced error");
+    assert_eq!(err.error.kind, rulemorph::TransformErrorKind::ExprError);
+    assert_trace_shape(&err.trace);
+}
+
+#[test]
+fn trace_record_api_matches_normal_finalize_behavior() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "name"
+    source: "name"
+finalize:
+  wrap:
+    data: "@out"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let record = json!({"name":"alice"});
+
+    let normal = transform_record(&rule, &record, None).expect("normal record transform");
+    let traced = transform_record_with_trace(&rule, &record, None, &TransformTraceOptions::raw())
+        .expect("traced record transform");
+
+    assert_eq!(normal, Some(json!({"data":[{"name":"alice"}]})));
+    assert_eq!(traced.output, normal);
+    assert!(
+        iter_trace_events(&traced.trace)
+            .into_iter()
+            .any(|event| event.kind == TraceEventKind::FinalizeStart),
+        "single-record trace API must mirror normal finalize behavior"
+    );
 }
 
 #[test]

--- a/docs/rules_spec_en.md
+++ b/docs/rules_spec_en.md
@@ -39,6 +39,38 @@ For a first rule, read the sections in this order:
 
 Use `mappings` for straightforward transformations. Use `steps` when the rule needs validation, branching, or multiple ordered phases.
 
+## Semantic Trace API
+
+The core library provides opt-in semantic trace APIs:
+
+- `transform_input_with_trace(...)`
+- `transform_input_with_trace_with_base_dir_and_options(...)`
+- `transform_record_with_trace(...)`
+
+A trace observes normalized records as they pass through `record_when`, `mappings` / `steps`, `expr`, operators, branches, and `finalize`, then returns the events as `TransformTrace`. Enabling trace must not change the output or warnings of the normal `transform` / `transform_input` / `transform_record` APIs.
+
+`TransformTraceOptions::default()` uses `Raw` mode. Because the trace API is explicitly requested to inspect values, raw input / output / context values are included in value snapshots by default. The core does not automatically persist, log, send over the network, postMessage, or share raw traces.
+
+Value handling is controlled by `TraceValueMode`.
+
+| mode | Behavior | Typical use |
+| --- | --- | --- |
+| `Raw` | Include raw values in snapshots | Local transparency UI and debugging |
+| `Redacted` | Drop values for secret-like paths or oversized snapshots | Safer human review |
+| `MetadataOnly` | Return only state/type/bytes metadata without values | Default for export / share / network / postMessage adapters |
+
+For `Redacted`, `redaction_reason` uses `"secret_like_path"` for secret-like paths. Composite object / array snapshots are metadata-only in the initial implementation.
+
+Each value snapshot has enum `state` and `type` fields, so `missing`, `null`, and empty string stay distinct. `default` applies only when the value is `missing`. Use `coalesce` rather than `default` when a rule should fall back for `null`.
+
+Trace `input_path` / `output_path` values use canonical forms. Input-side paths are `@input.*`, `@item.*`, `@acc.*`, `@context.*`, or `@out.*`; output-side paths are `$.*`. Bracket notation is preserved, for example `@input["@id"]`, `@input[0].name`, `@item[0].name`, and `$.items[0].name`.
+
+Traces can be bounded with `max_events`, `max_trace_bytes`, and `max_snapshot_bytes`. If the event stream is truncated, `complete=false` and `truncation.reason` are set. `max_snapshot_bytes` drops only snapshot values and does not relax event parent/child structure.
+
+Trace errors are returned as `TransformTraceError` with a partial trace. Its `Debug` / `Display` / `std::error::Error` output does not include the raw trace body or the underlying `TransformError` full message. External adapters should default to `MetadataOnly` and verify `contains_raw_values == false` before crossing export, share, network, or `postMessage` boundaries.
+
+The planned WASM binding shape is `wasm_transform_trace({ rule, input, inputFormat?, traceMode? })`. `traceMode` is `"raw" | "redacted" | "metadata_only"`; local animation may use `raw`, while export / share / `postMessage` defaults to `metadata_only`.
+
 ## Rule File Structure
 
 ```yaml

--- a/docs/rules_spec_ja.md
+++ b/docs/rules_spec_ja.md
@@ -42,6 +42,38 @@ raw input
 
 `mappings` と `steps` はどちらも出力を作るための構文です。単純な変換では `mappings` を使い、途中で assert や branch を挟みたい場合に `steps` を使います。
 
+## Semantic trace API
+
+core library は opt-in の semantic trace API を提供します。
+
+- `transform_input_with_trace(...)`
+- `transform_input_with_trace_with_base_dir_and_options(...)`
+- `transform_record_with_trace(...)`
+
+trace は正規化済み record から `record_when`、`mappings` / `steps`、`expr`、operator、branch、`finalize` までの評価イベントを `TransformTrace` として返します。通常の `transform` / `transform_input` / `transform_record` の出力や warning は trace 有効化で変わってはいけません。
+
+`TransformTraceOptions::default()` は `Raw` mode です。trace API は値を観測する目的で明示的に呼び出す API なので、既定では input / output / context 由来の raw 値を snapshot に含めます。raw trace を保存、ログ出力、network 送信、`postMessage`、共有 URL へ出す処理は core には含めません。
+
+値の扱いは `TraceValueMode` で選択します。
+
+| mode | 挙動 | 主な用途 |
+| --- | --- | --- |
+| `Raw` | raw 値を snapshot に含める | ローカル UI の透明性表示、デバッグ |
+| `Redacted` | secret-like path や上限超過値を値なし snapshot に落とす | 人間確認用の安全寄り表示 |
+| `MetadataOnly` | 値を持たず state/type/bytes などのメタデータだけ返す | export / share / network / postMessage の既定 |
+
+`Redacted` の `redaction_reason` は secret-like path では `"secret_like_path"` を使います。object / array の composite snapshot は初期実装では metadata-only として扱います。
+
+各 value snapshot は `state` と `type` を持ち、`missing` / `null` / empty string を区別します。`default` は `missing` の場合だけ適用されます。`null` fallback を表現したい場合は `default` ではなく `coalesce` を使います。
+
+trace event の `input_path` / `output_path` は canonical form を使います。入力側は `@input.*`、`@item.*`、`@acc.*`、`@context.*`、`@out.*`、出力側は `$.*` です。bracket notation は `@input["@id"]`、`@input[0].name`、`@item[0].name`、`$.items[0].name` のように保持されます。
+
+trace は `max_events` / `max_trace_bytes` / `max_snapshot_bytes` で明示的に制限できます。event stream が打ち切られた場合は `complete=false` と `truncation.reason` が設定されます。`max_snapshot_bytes` は snapshot value のみを落とす制限であり、event の親子構造は維持されます。
+
+trace API の error は `TransformTraceError` として partial trace を返します。ただし `Debug` / `Display` / `std::error::Error` は raw trace 本体や underlying `TransformError` の full message を出しません。外部 surface に trace を渡す adapter は `MetadataOnly` を既定にし、`contains_raw_values == false` を確認してください。
+
+WASM binding follow-up の想定 shape は `wasm_transform_trace({ rule, input, inputFormat?, traceMode? })` です。`traceMode` は `"raw" | "redacted" | "metadata_only"` とし、local animation は `raw`、export / share / `postMessage` は `metadata_only` を既定にします。
+
 ## ルールファイル構成
 
 ```yaml


### PR DESCRIPTION
## Summary
- Stop traced v2 operator handling from pre-evaluating arguments, preserving item/acc scopes and short-circuit behavior.
- Carry traced v2 let bindings into later pipe steps and close record_when spans on errors.
- Add trace semantics coverage before refactoring, including and/or/coalesce short-circuiting, collection scopes, fold, nested let, and unselected if branches.

## Validation
- cargo fmt
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test