### PR TITLE
[codex] Extract transform expr JSON helpers

### DIFF
--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -20,10 +20,7 @@ use crate::v2_eval::{
     eval_v2_expr, eval_v2_let_step, eval_v2_op_step, eval_v2_pipe, eval_v2_ref, eval_v2_start,
 };
 use crate::v2_model::{V2ComparisonOp, V2Condition, V2Pipe, V2Ref, V2Start, V2Step};
-use crate::v2_parser::{
-    is_literal_escape, is_pipe_value, is_v2_ref, parse_v2_condition, parse_v2_expr,
-    parse_v2_pipe_from_value,
-};
+use crate::v2_parser::{parse_v2_condition, parse_v2_expr, parse_v2_pipe_from_value};
 
 const REGEX_CACHE_CAPACITY: usize = 128;
 const BRANCH_MAX_DEPTH: usize = 64;
@@ -55,6 +52,7 @@ fn cached_regex(pattern: &str, path: &str) -> Result<Regex, TransformError> {
 
 mod api;
 mod branch;
+mod expr_json;
 mod finalize;
 mod operators;
 mod path_ops;
@@ -69,6 +67,7 @@ mod v2_trace;
 
 use self::api::transform_record_with_warnings_inner;
 use self::branch::{BranchContext, load_rule_from_path, merge_branch_output};
+use self::expr_json::{expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe, literal_string};
 use self::finalize::{apply_finalize, apply_finalize_traced, sort_key_from_value};
 pub(crate) use self::operators::eval_op;
 use self::operators::{
@@ -291,103 +290,5 @@ fn canonical_source_path(source: &str) -> String {
         Ok((Namespace::Context, path)) => canonical_context_path(path),
         Ok((Namespace::Out, path)) => canonical_out_path(path),
         _ => canonical_input_path(source),
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn literal_string(expr: &Expr) -> Option<&str> {
-    match expr {
-        Expr::Literal(value) => value.as_str(),
-        _ => None,
-    }
-}
-
-/// Convert an Expr to JSON value for v2 pipe parsing.
-/// Returns Some if the expr looks like a v2 pipe expression:
-/// - Literal(Array) -> direct array
-/// - Ref where ref_path starts with @ -> single element array
-/// - Chain where first element starts with @ -> convert to array
-/// Returns None if it looks like v1 expression and should be handled by v1 eval.
-fn expr_to_json_for_v2_pipe(expr: &Expr) -> Option<JsonValue> {
-    match expr {
-        Expr::Literal(JsonValue::Array(arr)) => {
-            // Direct array - v2 pipe
-            Some(JsonValue::Array(arr.clone()))
-        }
-        Expr::Literal(JsonValue::String(s)) => {
-            if is_v2_ref(s) || is_pipe_value(s) || is_literal_escape(s) {
-                Some(JsonValue::String(s.clone()))
-            } else {
-                None
-            }
-        }
-        Expr::Ref(expr_ref)
-            if expr_ref.ref_path.starts_with('@') || is_literal_escape(&expr_ref.ref_path) =>
-        {
-            // Single v2 reference or literal escape (serde collapsed 1-element array)
-            // Wrap it as single-element array
-            Some(JsonValue::Array(vec![JsonValue::String(
-                expr_ref.ref_path.clone(),
-            )]))
-        }
-        Expr::Chain(chain) => {
-            // Check if first element is a v2 ref
-            if let Some(first) = chain.chain.first() {
-                if let Expr::Ref(r) = first {
-                    if r.ref_path.starts_with('@') {
-                        // Convert chain to array
-                        let arr: Vec<JsonValue> =
-                            chain.chain.iter().map(|e| expr_to_json_value(e)).collect();
-                        return Some(JsonValue::Array(arr));
-                    }
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-/// Convert an Expr to JSON value for v2 condition parsing.
-/// Accepts literal values and v2-looking refs/chains while avoiding v1-only forms.
-fn expr_to_json_for_v2_condition(expr: &Expr) -> Option<JsonValue> {
-    match expr {
-        Expr::Literal(value) => Some(value.clone()),
-        Expr::Ref(ref_expr)
-            if ref_expr.ref_path.starts_with('@') || is_literal_escape(&ref_expr.ref_path) =>
-        {
-            Some(JsonValue::String(ref_expr.ref_path.clone()))
-        }
-        Expr::Chain(chain) => {
-            if let Some(first) = chain.chain.first() {
-                if let Expr::Ref(r) = first {
-                    if r.ref_path.starts_with('@') {
-                        let arr: Vec<JsonValue> =
-                            chain.chain.iter().map(expr_to_json_value).collect();
-                        return Some(JsonValue::Array(arr));
-                    }
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-/// Helper to convert Expr to JsonValue (for Chain conversion)
-fn expr_to_json_value(expr: &Expr) -> JsonValue {
-    match expr {
-        Expr::Ref(r) => JsonValue::String(r.ref_path.clone()),
-        Expr::Literal(v) => v.clone(),
-        Expr::Op(op) => {
-            let mut obj = serde_json::Map::new();
-            let args: Vec<JsonValue> = op.args.iter().map(expr_to_json_value).collect();
-            obj.insert(op.op.clone(), JsonValue::Array(args));
-            JsonValue::Object(obj)
-        }
-        Expr::Chain(chain) => {
-            let arr: Vec<JsonValue> = chain.chain.iter().map(expr_to_json_value).collect();
-            JsonValue::Array(arr)
-        }
     }
 }

--- a/crates/rulemorph/src/transform/expr_json.rs
+++ b/crates/rulemorph/src/transform/expr_json.rs
@@ -1,0 +1,101 @@
+use serde_json::{Map, Value as JsonValue};
+
+use crate::model::Expr;
+use crate::v2_parser::{is_literal_escape, is_pipe_value, is_v2_ref};
+
+pub(super) fn literal_string(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Literal(value) => value.as_str(),
+        _ => None,
+    }
+}
+
+/// Convert an Expr to JSON value for v2 pipe parsing.
+/// Returns Some if the expr looks like a v2 pipe expression:
+/// - Literal(Array) -> direct array
+/// - Ref where ref_path starts with @ -> single element array
+/// - Chain where first element starts with @ -> convert to array
+/// Returns None if it looks like v1 expression and should be handled by v1 eval.
+pub(super) fn expr_to_json_for_v2_pipe(expr: &Expr) -> Option<JsonValue> {
+    match expr {
+        Expr::Literal(JsonValue::Array(arr)) => {
+            // Direct array - v2 pipe
+            Some(JsonValue::Array(arr.clone()))
+        }
+        Expr::Literal(JsonValue::String(s)) => {
+            if is_v2_ref(s) || is_pipe_value(s) || is_literal_escape(s) {
+                Some(JsonValue::String(s.clone()))
+            } else {
+                None
+            }
+        }
+        Expr::Ref(expr_ref)
+            if expr_ref.ref_path.starts_with('@') || is_literal_escape(&expr_ref.ref_path) =>
+        {
+            // Single v2 reference or literal escape (serde collapsed 1-element array)
+            // Wrap it as single-element array
+            Some(JsonValue::Array(vec![JsonValue::String(
+                expr_ref.ref_path.clone(),
+            )]))
+        }
+        Expr::Chain(chain) => {
+            // Check if first element is a v2 ref
+            if let Some(first) = chain.chain.first() {
+                if let Expr::Ref(r) = first {
+                    if r.ref_path.starts_with('@') {
+                        // Convert chain to array
+                        let arr: Vec<JsonValue> =
+                            chain.chain.iter().map(|e| expr_to_json_value(e)).collect();
+                        return Some(JsonValue::Array(arr));
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Convert an Expr to JSON value for v2 condition parsing.
+/// Accepts literal values and v2-looking refs/chains while avoiding v1-only forms.
+pub(super) fn expr_to_json_for_v2_condition(expr: &Expr) -> Option<JsonValue> {
+    match expr {
+        Expr::Literal(value) => Some(value.clone()),
+        Expr::Ref(ref_expr)
+            if ref_expr.ref_path.starts_with('@') || is_literal_escape(&ref_expr.ref_path) =>
+        {
+            Some(JsonValue::String(ref_expr.ref_path.clone()))
+        }
+        Expr::Chain(chain) => {
+            if let Some(first) = chain.chain.first() {
+                if let Expr::Ref(r) = first {
+                    if r.ref_path.starts_with('@') {
+                        let arr: Vec<JsonValue> =
+                            chain.chain.iter().map(expr_to_json_value).collect();
+                        return Some(JsonValue::Array(arr));
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Helper to convert Expr to JsonValue (for Chain conversion)
+fn expr_to_json_value(expr: &Expr) -> JsonValue {
+    match expr {
+        Expr::Ref(r) => JsonValue::String(r.ref_path.clone()),
+        Expr::Literal(v) => v.clone(),
+        Expr::Op(op) => {
+            let mut obj = Map::new();
+            let args: Vec<JsonValue> = op.args.iter().map(expr_to_json_value).collect();
+            obj.insert(op.op.clone(), JsonValue::Array(args));
+            JsonValue::Object(obj)
+        }
+        Expr::Chain(chain) => {
+            let arr: Vec<JsonValue> = chain.chain.iter().map(expr_to_json_value).collect();
+            JsonValue::Array(arr)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract private v2 expression JSON bridge helpers from transform.rs into transform/expr_json.rs.
- Keep transform semantics, trace semantics, public API names/exports, and trace JSON schema unchanged.
- Keep ignored planning/log files out of this PR.

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden
- cargo test -p rulemorph --test transform_trace
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test
- git diff --check