### PR TITLE
[codex] Extract trace store import path helpers

### DIFF
--- a/crates/rulemorph_trace/src/trace_store.rs
+++ b/crates/rulemorph_trace/src/trace_store.rs
@@ -1,7 +1,6 @@
 use std::cmp::Reverse;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
-use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -24,6 +23,12 @@ use crate::trace_schema::{
     TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX,
     TRACE_TOTAL_CHUNK_BYTES_UNCOMPRESSED_HARD_MAX, TraceChunkRef, TraceDetailRef, TraceManifest,
     TraceSummary,
+};
+
+mod import_path;
+
+use self::import_path::{
+    copy_file_create_new, ensure_import_base_dir, ensure_import_target_parent,
 };
 
 const HARD_MAX_CHUNK_BYTES_COMPRESSED: u64 = TRACE_CHUNK_BYTES_COMPRESSED_HARD_MAX as u64;
@@ -815,138 +820,6 @@ async fn delete_trace_path(path: &Path, traces_dir: &Path) -> Result<()> {
             .await
             .with_context(|| format!("failed to remove trace file {}", candidate.display()))?;
     }
-    Ok(())
-}
-
-fn ensure_import_base_dir(base_dir: &Path) -> Result<PathBuf> {
-    std::fs::create_dir_all(base_dir)
-        .with_context(|| format!("failed to create import base dir: {}", base_dir.display()))?;
-    let meta = std::fs::symlink_metadata(base_dir)
-        .with_context(|| format!("failed to stat import base dir: {}", base_dir.display()))?;
-    if meta.file_type().is_symlink() {
-        return Err(anyhow::anyhow!(
-            "bundle destination base is symlink: {}",
-            base_dir.display()
-        ));
-    }
-    if !meta.is_dir() {
-        return Err(anyhow::anyhow!(
-            "bundle destination base is not a directory: {}",
-            base_dir.display()
-        ));
-    }
-    base_dir.canonicalize().with_context(|| {
-        format!(
-            "failed to canonicalize import base dir: {}",
-            base_dir.display()
-        )
-    })
-}
-
-fn ensure_relative_dir_safe(
-    base_dir: &Path,
-    target_dir: &Path,
-    created_dirs: &mut BTreeSet<PathBuf>,
-) -> Result<()> {
-    let relative = target_dir.strip_prefix(base_dir).with_context(|| {
-        format!(
-            "bundle destination escapes base dir: {}",
-            target_dir.display()
-        )
-    })?;
-    let mut current = base_dir.to_path_buf();
-    for component in relative.components() {
-        current.push(component.as_os_str());
-        match std::fs::create_dir(&current) {
-            Ok(()) => {
-                created_dirs.insert(current.clone());
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                let meta = std::fs::symlink_metadata(&current).with_context(|| {
-                    format!("failed to stat bundle destination: {}", current.display())
-                })?;
-                if meta.file_type().is_symlink() {
-                    return Err(anyhow::anyhow!(
-                        "bundle destination contains symlink: {}",
-                        current.display()
-                    ));
-                }
-                if !meta.is_dir() {
-                    return Err(anyhow::anyhow!(
-                        "bundle destination is not a directory: {}",
-                        current.display()
-                    ));
-                }
-            }
-            Err(err) => {
-                return Err(anyhow::anyhow!(
-                    "failed to create bundle destination dir {}: {}",
-                    current.display(),
-                    err
-                ));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn ensure_import_target_parent(
-    base_dir: &Path,
-    base_canon: &Path,
-    target: &Path,
-    created_dirs: &mut BTreeSet<PathBuf>,
-) -> Result<()> {
-    if !target.starts_with(base_dir) {
-        return Err(anyhow::anyhow!(
-            "bundle destination escapes base dir: {}",
-            target.display()
-        ));
-    }
-    let parent = target
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("bundle destination has no parent: {}", target.display()))?;
-    ensure_relative_dir_safe(base_dir, parent, created_dirs)?;
-    let parent_canon = parent.canonicalize().with_context(|| {
-        format!(
-            "failed to canonicalize bundle destination parent: {}",
-            parent.display()
-        )
-    })?;
-    if !parent_canon.starts_with(base_canon) {
-        return Err(anyhow::anyhow!(
-            "bundle destination escapes base dir: {}",
-            target.display()
-        ));
-    }
-    Ok(())
-}
-
-fn copy_file_create_new(source: &Path, target: &Path, base_canon: &Path) -> Result<()> {
-    let mut source_file = std::fs::File::open(source)
-        .with_context(|| format!("failed to open bundle source: {}", source.display()))?;
-    let mut target_file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(target)
-        .with_context(|| format!("failed to create bundle target: {}", target.display()))?;
-    let target_canon = target
-        .canonicalize()
-        .with_context(|| format!("failed to canonicalize bundle target: {}", target.display()))?;
-    if !target_canon.starts_with(base_canon) {
-        drop(target_file);
-        let _ = std::fs::remove_file(target);
-        return Err(anyhow::anyhow!(
-            "bundle target escapes base dir: {}",
-            target.display()
-        ));
-    }
-    std::io::copy(&mut source_file, &mut target_file).with_context(|| {
-        format!(
-            "failed to copy bundle file {} -> {}",
-            source.display(),
-            target.display()
-        )
-    })?;
     Ok(())
 }
 

--- a/crates/rulemorph_trace/src/trace_store/import_path.rs
+++ b/crates/rulemorph_trace/src/trace_store/import_path.rs
@@ -1,0 +1,137 @@
+use std::collections::BTreeSet;
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+pub(super) fn ensure_import_base_dir(base_dir: &Path) -> Result<PathBuf> {
+    std::fs::create_dir_all(base_dir)
+        .with_context(|| format!("failed to create import base dir: {}", base_dir.display()))?;
+    let meta = std::fs::symlink_metadata(base_dir)
+        .with_context(|| format!("failed to stat import base dir: {}", base_dir.display()))?;
+    if meta.file_type().is_symlink() {
+        return Err(anyhow::anyhow!(
+            "bundle destination base is symlink: {}",
+            base_dir.display()
+        ));
+    }
+    if !meta.is_dir() {
+        return Err(anyhow::anyhow!(
+            "bundle destination base is not a directory: {}",
+            base_dir.display()
+        ));
+    }
+    base_dir.canonicalize().with_context(|| {
+        format!(
+            "failed to canonicalize import base dir: {}",
+            base_dir.display()
+        )
+    })
+}
+
+fn ensure_relative_dir_safe(
+    base_dir: &Path,
+    target_dir: &Path,
+    created_dirs: &mut BTreeSet<PathBuf>,
+) -> Result<()> {
+    let relative = target_dir.strip_prefix(base_dir).with_context(|| {
+        format!(
+            "bundle destination escapes base dir: {}",
+            target_dir.display()
+        )
+    })?;
+    let mut current = base_dir.to_path_buf();
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        match std::fs::create_dir(&current) {
+            Ok(()) => {
+                created_dirs.insert(current.clone());
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                let meta = std::fs::symlink_metadata(&current).with_context(|| {
+                    format!("failed to stat bundle destination: {}", current.display())
+                })?;
+                if meta.file_type().is_symlink() {
+                    return Err(anyhow::anyhow!(
+                        "bundle destination contains symlink: {}",
+                        current.display()
+                    ));
+                }
+                if !meta.is_dir() {
+                    return Err(anyhow::anyhow!(
+                        "bundle destination is not a directory: {}",
+                        current.display()
+                    ));
+                }
+            }
+            Err(err) => {
+                return Err(anyhow::anyhow!(
+                    "failed to create bundle destination dir {}: {}",
+                    current.display(),
+                    err
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn ensure_import_target_parent(
+    base_dir: &Path,
+    base_canon: &Path,
+    target: &Path,
+    created_dirs: &mut BTreeSet<PathBuf>,
+) -> Result<()> {
+    if !target.starts_with(base_dir) {
+        return Err(anyhow::anyhow!(
+            "bundle destination escapes base dir: {}",
+            target.display()
+        ));
+    }
+    let parent = target
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("bundle destination has no parent: {}", target.display()))?;
+    ensure_relative_dir_safe(base_dir, parent, created_dirs)?;
+    let parent_canon = parent.canonicalize().with_context(|| {
+        format!(
+            "failed to canonicalize bundle destination parent: {}",
+            parent.display()
+        )
+    })?;
+    if !parent_canon.starts_with(base_canon) {
+        return Err(anyhow::anyhow!(
+            "bundle destination escapes base dir: {}",
+            target.display()
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn copy_file_create_new(source: &Path, target: &Path, base_canon: &Path) -> Result<()> {
+    let mut source_file = std::fs::File::open(source)
+        .with_context(|| format!("failed to open bundle source: {}", source.display()))?;
+    let mut target_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(target)
+        .with_context(|| format!("failed to create bundle target: {}", target.display()))?;
+    let target_canon = target
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize bundle target: {}", target.display()))?;
+    if !target_canon.starts_with(base_canon) {
+        drop(target_file);
+        let _ = std::fs::remove_file(target);
+        return Err(anyhow::anyhow!(
+            "bundle target escapes base dir: {}",
+            target.display()
+        ));
+    }
+    std::io::copy(&mut source_file, &mut target_file).with_context(|| {
+        format!(
+            "failed to copy bundle file {} -> {}",
+            source.display(),
+            target.display()
+        )
+    })?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Extract trace-store import destination path-safety helpers into trace_store/import_path.rs.
- Keep TraceStore::import_bundle orchestration, rollback behavior, symlink/overwrite/path traversal checks, server temp-dir policy boundary, and trace JSON schema unchanged.

## Verification
- cargo fmt
- cargo test -p rulemorph_trace --test trace_store
- cargo test -p rulemorph_trace
- cargo test
- git diff --check