### PR TITLE
[codex] Extract MCP protocol framing

### DIFF
--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use csv::ReaderBuilder;
@@ -15,6 +15,10 @@ use rulemorph::{
 use serde_json::{Map, Value, json};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 
+mod protocol;
+
+use self::protocol::{OutputMode, read_message, write_message};
+
 const PROTOCOL_VERSION: &str = "2024-11-05";
 const RESOURCE_URI_RULES_SPEC_EN: &str = "rulemorph://docs/rules_spec_en";
 const RESOURCE_URI_RULES_SPEC_JA: &str = "rulemorph://docs/rules_spec_ja";
@@ -22,8 +26,6 @@ const RESOURCE_URI_README: &str = "rulemorph://docs/readme";
 const RESOURCE_RULES_SPEC_EN: &str = include_str!("../../../docs/rules_spec_en.md");
 const RESOURCE_RULES_SPEC_JA: &str = include_str!("../../../docs/rules_spec_ja.md");
 const RESOURCE_README: &str = include_str!("../../../README.md");
-const MCP_MAX_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
-const MCP_MAX_HEADER_LINE_BYTES: usize = 8 * 1024;
 const MCP_MAX_FILE_BYTES: usize = 64 * 1024 * 1024;
 
 fn main() {
@@ -31,12 +33,6 @@ fn main() {
         eprintln!("fatal: {}", err);
         std::process::exit(1);
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum OutputMode {
-    Line,
-    ContentLength,
 }
 
 fn run() -> Result<(), String> {
@@ -67,106 +63,6 @@ fn run() -> Result<(), String> {
     }
 
     Ok(())
-}
-
-fn read_message(
-    reader: &mut impl BufRead,
-    output_mode: &mut OutputMode,
-) -> io::Result<Option<String>> {
-    let mut line: String;
-    loop {
-        line = match read_line_bounded(reader, MCP_MAX_HEADER_LINE_BYTES)? {
-            Some(line) => line,
-            None => return Ok(None),
-        };
-
-        if let Some(length) = line.strip_prefix("Content-Length:") {
-            let length = length.trim().parse::<usize>().map_err(|_| {
-                io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length")
-            })?;
-            if length > MCP_MAX_MESSAGE_BYTES {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Content-Length exceeds MCP message limit",
-                ));
-            }
-
-            loop {
-                line = match read_line_bounded(reader, MCP_MAX_HEADER_LINE_BYTES)? {
-                    Some(line) => line,
-                    None => return Ok(None),
-                };
-                if line == "\r\n" || line == "\n" {
-                    break;
-                }
-            }
-
-            let mut buffer = vec![0u8; length];
-            reader.read_exact(&mut buffer)?;
-            *output_mode = OutputMode::ContentLength;
-            return Ok(Some(String::from_utf8_lossy(&buffer).to_string()));
-        }
-
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() {
-            continue;
-        }
-        *output_mode = OutputMode::Line;
-        return Ok(Some(trimmed.to_string()));
-    }
-}
-
-fn read_line_bounded(reader: &mut impl BufRead, max_bytes: usize) -> io::Result<Option<String>> {
-    let mut bytes = Vec::new();
-    loop {
-        let available = reader.fill_buf()?;
-        if available.is_empty() {
-            if bytes.is_empty() {
-                return Ok(None);
-            }
-            break;
-        }
-
-        let take_len = match available.iter().position(|byte| *byte == b'\n') {
-            Some(index) => index + 1,
-            None => available.len(),
-        };
-        if bytes.len().saturating_add(take_len) > max_bytes {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "line exceeds MCP message limit",
-            ));
-        }
-        bytes.extend_from_slice(&available[..take_len]);
-        reader.consume(take_len);
-        if bytes.last() == Some(&b'\n') {
-            break;
-        }
-    }
-
-    String::from_utf8(bytes)
-        .map(Some)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
-}
-
-fn write_message(
-    writer: &mut impl Write,
-    output_mode: OutputMode,
-    message: &Value,
-) -> io::Result<()> {
-    let text = serde_json::to_string(message)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-
-    match output_mode {
-        OutputMode::Line => {
-            writeln!(writer, "{}", text)?;
-        }
-        OutputMode::ContentLength => {
-            write!(writer, "Content-Length: {}\r\n\r\n{}", text.len(), text)?;
-        }
-    }
-
-    writer.flush()
 }
 
 fn handle_message(message: Value) -> Option<Value> {
@@ -5146,40 +5042,11 @@ fn transform_kind_to_str(kind: &TransformErrorKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
     use std::sync::{Mutex, OnceLock};
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
-    }
-
-    #[test]
-    fn bounded_line_reader_rejects_oversized_line() {
-        let mut reader = BufReader::new(Cursor::new(b"{\"jsonrpc\":\"2.0\"}\n".to_vec()));
-        let err = read_line_bounded(&mut reader, 8).expect_err("oversized line should fail");
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    }
-
-    #[test]
-    fn bounded_line_reader_reads_complete_line() {
-        let mut reader = BufReader::new(Cursor::new(b"{\"jsonrpc\":\"2.0\"}\n".to_vec()));
-        let line = read_line_bounded(&mut reader, 64)
-            .expect("read line")
-            .expect("line");
-        assert_eq!(line, "{\"jsonrpc\":\"2.0\"}\n");
-    }
-
-    #[test]
-    fn read_message_rejects_oversized_initial_header_line() {
-        let mut input = b"Content-Length: ".to_vec();
-        input.extend(std::iter::repeat_n(b'1', MCP_MAX_HEADER_LINE_BYTES));
-        input.extend_from_slice(b"\r\n\r\n{}");
-        let mut reader = BufReader::new(Cursor::new(input));
-        let mut output_mode = OutputMode::Line;
-        let err = read_message(&mut reader, &mut output_mode)
-            .expect_err("oversized initial header should fail");
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/rulemorph_mcp/src/protocol.rs
+++ b/crates/rulemorph_mcp/src/protocol.rs
@@ -1,0 +1,146 @@
+use std::io::{self, BufRead, Write};
+
+use serde_json::Value;
+
+const MCP_MAX_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
+const MCP_MAX_HEADER_LINE_BYTES: usize = 8 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OutputMode {
+    Line,
+    ContentLength,
+}
+
+pub(crate) fn read_message(
+    reader: &mut impl BufRead,
+    output_mode: &mut OutputMode,
+) -> io::Result<Option<String>> {
+    let mut line: String;
+    loop {
+        line = match read_line_bounded(reader, MCP_MAX_HEADER_LINE_BYTES)? {
+            Some(line) => line,
+            None => return Ok(None),
+        };
+
+        if let Some(length) = line.strip_prefix("Content-Length:") {
+            let length = length.trim().parse::<usize>().map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length")
+            })?;
+            if length > MCP_MAX_MESSAGE_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Content-Length exceeds MCP message limit",
+                ));
+            }
+
+            loop {
+                line = match read_line_bounded(reader, MCP_MAX_HEADER_LINE_BYTES)? {
+                    Some(line) => line,
+                    None => return Ok(None),
+                };
+                if line == "\r\n" || line == "\n" {
+                    break;
+                }
+            }
+
+            let mut buffer = vec![0u8; length];
+            reader.read_exact(&mut buffer)?;
+            *output_mode = OutputMode::ContentLength;
+            return Ok(Some(String::from_utf8_lossy(&buffer).to_string()));
+        }
+
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            continue;
+        }
+        *output_mode = OutputMode::Line;
+        return Ok(Some(trimmed.to_string()));
+    }
+}
+
+fn read_line_bounded(reader: &mut impl BufRead, max_bytes: usize) -> io::Result<Option<String>> {
+    let mut bytes = Vec::new();
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            break;
+        }
+
+        let take_len = match available.iter().position(|byte| *byte == b'\n') {
+            Some(index) => index + 1,
+            None => available.len(),
+        };
+        if bytes.len().saturating_add(take_len) > max_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "line exceeds MCP message limit",
+            ));
+        }
+        bytes.extend_from_slice(&available[..take_len]);
+        reader.consume(take_len);
+        if bytes.last() == Some(&b'\n') {
+            break;
+        }
+    }
+
+    String::from_utf8(bytes)
+        .map(Some)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+}
+
+pub(crate) fn write_message(
+    writer: &mut impl Write,
+    output_mode: OutputMode,
+    message: &Value,
+) -> io::Result<()> {
+    let text = serde_json::to_string(message)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+    match output_mode {
+        OutputMode::Line => {
+            writeln!(writer, "{}", text)?;
+        }
+        OutputMode::ContentLength => {
+            write!(writer, "Content-Length: {}\r\n\r\n{}", text.len(), text)?;
+        }
+    }
+
+    writer.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    #[test]
+    fn bounded_line_reader_rejects_oversized_line() {
+        let mut reader = BufReader::new(Cursor::new(b"{\"jsonrpc\":\"2.0\"}\n".to_vec()));
+        let err = read_line_bounded(&mut reader, 8).expect_err("oversized line should fail");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn bounded_line_reader_reads_complete_line() {
+        let mut reader = BufReader::new(Cursor::new(b"{\"jsonrpc\":\"2.0\"}\n".to_vec()));
+        let line = read_line_bounded(&mut reader, 64)
+            .expect("read line")
+            .expect("line");
+        assert_eq!(line, "{\"jsonrpc\":\"2.0\"}\n");
+    }
+
+    #[test]
+    fn read_message_rejects_oversized_initial_header_line() {
+        let mut input = b"Content-Length: ".to_vec();
+        input.extend(std::iter::repeat_n(b'1', MCP_MAX_HEADER_LINE_BYTES));
+        input.extend_from_slice(b"\r\n\r\n{}");
+        let mut reader = BufReader::new(Cursor::new(input));
+        let mut output_mode = OutputMode::Line;
+        let err = read_message(&mut reader, &mut output_mode)
+            .expect_err("oversized initial header should fail");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract MCP stdio message framing into protocol.rs.
- Keep line-mode and Content-Length behavior, message size limits, tool/resource/prompt schemas, and MCP tool contracts unchanged.
- Move existing protocol unit tests with the moved helpers.

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp
- cargo test -p rulemorph_mcp --test stdio
- cargo test
- git diff --check