### PR TITLE
[codex] Extract API key file lock

### DIFF
--- a/crates/rulemorph_server/src/api_keys.rs
+++ b/crates/rulemorph_server/src/api_keys.rs
@@ -1,8 +1,6 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::thread;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -21,12 +19,10 @@ const SECRET_BYTES: usize = 32;
 const SALT_BYTES: usize = 16;
 const ID_BYTES: usize = 12;
 const PREFIX_VISIBLE_CHARS: usize = 8;
-const API_KEY_LOCK_STALE_AFTER: Duration = Duration::from_secs(300);
 
-#[cfg(unix)]
-unsafe extern "C" {
-    fn kill(pid: i32, sig: i32) -> i32;
-}
+mod file_lock;
+
+use self::file_lock::ApiKeyFileLock;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ApiKeyRecord {
@@ -283,118 +279,6 @@ impl ApiKeyStore {
     }
 }
 
-struct ApiKeyFileLock {
-    path: PathBuf,
-}
-
-impl ApiKeyFileLock {
-    fn acquire(path: &Path) -> Result<Self> {
-        let lock_path = lock_path(path);
-        if let Some(parent) = lock_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create api key lock dir: {}", parent.display())
-            })?;
-        }
-        let mut last_err = None;
-        for _ in 0..250 {
-            match OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&lock_path)
-            {
-                Ok(mut handle) => {
-                    writeln!(handle, "{}", std::process::id()).ok();
-                    return Ok(Self { path: lock_path });
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if remove_stale_lock_if_needed(&lock_path)? {
-                        continue;
-                    }
-                    last_err = Some(err);
-                    thread::sleep(Duration::from_millis(20));
-                }
-                Err(err) => {
-                    return Err(err).with_context(|| {
-                        format!("failed to create api key lock: {}", lock_path.display())
-                    });
-                }
-            }
-        }
-        Err(last_err.unwrap_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::TimedOut, "api key lock timeout")
-        }))
-        .with_context(|| {
-            format!(
-                "timed out waiting for api key lock: {}",
-                lock_path.display()
-            )
-        })
-    }
-}
-
-fn remove_stale_lock_if_needed(path: &Path) -> Result<bool> {
-    match fs::read_to_string(path) {
-        Ok(contents) => {
-            if let Ok(pid) = contents.trim().parse::<u32>() {
-                if pid != std::process::id() && !process_is_running(pid) {
-                    remove_lock_file(path)?;
-                    return Ok(true);
-                }
-            }
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
-        Err(_) => {}
-    }
-
-    let is_old = fs::metadata(path)
-        .and_then(|metadata| metadata.modified())
-        .ok()
-        .and_then(|modified| modified.elapsed().ok())
-        .is_some_and(|age| age >= API_KEY_LOCK_STALE_AFTER);
-    if is_old {
-        remove_lock_file(path)?;
-        return Ok(true);
-    }
-    Ok(false)
-}
-
-fn remove_lock_file(path: &Path) -> Result<()> {
-    match fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => {
-            Err(err).with_context(|| format!("failed to remove stale lock: {}", path.display()))
-        }
-    }
-}
-
-#[cfg(unix)]
-fn process_is_running(pid: u32) -> bool {
-    let Ok(pid) = i32::try_from(pid) else {
-        return false;
-    };
-    let rc = unsafe { kill(pid, 0) };
-    if rc == 0 {
-        return true;
-    }
-    match std::io::Error::last_os_error().raw_os_error() {
-        Some(1) => true,
-        Some(3) => false,
-        _ => true,
-    }
-}
-
-#[cfg(not(unix))]
-fn process_is_running(_pid: u32) -> bool {
-    true
-}
-
-impl Drop for ApiKeyFileLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
-    }
-}
-
 pub fn parse_api_key(value: &str) -> Option<ParsedApiKey> {
     let trimmed = value.trim();
     if !trimmed.starts_with(API_KEY_PREFIX) {
@@ -422,14 +306,6 @@ fn tmp_path(path: &Path) -> PathBuf {
     let suffix = random_base64(6);
     let tmp_name = format!("{}.tmp-{}", file_name, suffix);
     path.with_file_name(tmp_name)
-}
-
-fn lock_path(path: &Path) -> PathBuf {
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("api_keys.json");
-    path.with_file_name(format!("{}.lock", file_name))
 }
 
 fn replace_file(temp_path: &Path, target_path: &Path) -> Result<()> {
@@ -497,7 +373,7 @@ mod tests {
     use anyhow::Result;
     use tempfile::tempdir;
 
-    use super::{ApiKeyStore, lock_path};
+    use super::{ApiKeyStore, file_lock::lock_path};
 
     #[test]
     fn api_key_store_persists_multiple_updates() -> Result<()> {

--- a/crates/rulemorph_server/src/api_keys/file_lock.rs
+++ b/crates/rulemorph_server/src/api_keys/file_lock.rs
@@ -1,0 +1,134 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+const API_KEY_LOCK_STALE_AFTER: Duration = Duration::from_secs(300);
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
+
+pub(super) struct ApiKeyFileLock {
+    path: PathBuf,
+}
+
+impl ApiKeyFileLock {
+    pub(super) fn acquire(path: &Path) -> Result<Self> {
+        let lock_path = lock_path(path);
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create api key lock dir: {}", parent.display())
+            })?;
+        }
+        let mut last_err = None;
+        for _ in 0..250 {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path)
+            {
+                Ok(mut handle) => {
+                    writeln!(handle, "{}", std::process::id()).ok();
+                    return Ok(Self { path: lock_path });
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if remove_stale_lock_if_needed(&lock_path)? {
+                        continue;
+                    }
+                    last_err = Some(err);
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(err) => {
+                    return Err(err).with_context(|| {
+                        format!("failed to create api key lock: {}", lock_path.display())
+                    });
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "api key lock timeout")
+        }))
+        .with_context(|| {
+            format!(
+                "timed out waiting for api key lock: {}",
+                lock_path.display()
+            )
+        })
+    }
+}
+
+fn remove_stale_lock_if_needed(path: &Path) -> Result<bool> {
+    match fs::read_to_string(path) {
+        Ok(contents) => {
+            if let Ok(pid) = contents.trim().parse::<u32>() {
+                if pid != std::process::id() && !process_is_running(pid) {
+                    remove_lock_file(path)?;
+                    return Ok(true);
+                }
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(_) => {}
+    }
+
+    let is_old = fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|age| age >= API_KEY_LOCK_STALE_AFTER);
+    if is_old {
+        remove_lock_file(path)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn remove_lock_file(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => {
+            Err(err).with_context(|| format!("failed to remove stale lock: {}", path.display()))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    let rc = unsafe { kill(pid, 0) };
+    if rc == 0 {
+        return true;
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(1) => true,
+        Some(3) => false,
+        _ => true,
+    }
+}
+
+#[cfg(not(unix))]
+fn process_is_running(_pid: u32) -> bool {
+    true
+}
+
+impl Drop for ApiKeyFileLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub(super) fn lock_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("api_keys.json");
+    path.with_file_name(format!("{}.lock", file_name))
+}


### PR DESCRIPTION
## Summary
- Extract API key file lock acquisition and stale-lock recovery into api_keys/file_lock.rs.
- Keep API key issue/list/revoke/rotate/verify behavior, tenant resolver behavior, response redaction, and public API names unchanged.
- Preserve lock path semantics, dead-process stale lock recovery, and atomic store save behavior.

## Verification
- cargo fmt
- cargo test -p rulemorph_server api_keys
- cargo test -p rulemorph_server --test cloud_scenarios internal_api_key_issue_is_serialized_per_store
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo test -p rulemorph_server
- cargo test
- git diff --check