### PR TITLE
[codex] Extract v2 eval reference helpers

### DIFF
--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -8,130 +8,26 @@ use std::collections::{HashMap, HashSet};
 
 use crate::error::{TransformError, TransformErrorKind};
 use crate::model::{Expr, ExprOp, ExprRef};
-use crate::path::{get_path, parse_path};
 use crate::transform::{
     EvalItem as V1EvalItem, EvalLocals as V1EvalLocals, EvalValue as V1EvalValue,
     eval_op as eval_v1_op,
 };
+#[cfg(test)]
+use crate::v2_model::V2Ref;
 use crate::v2_model::{
     V2Comparison, V2ComparisonOp, V2Condition, V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep,
-    V2Pipe, V2Ref, V2Start, V2Step,
+    V2Pipe, V2Start, V2Step,
 };
 
 mod context;
+mod reference;
 
 pub use context::{EvalItem, EvalValue, V2EvalContext};
+pub use reference::{eval_v2_ref, eval_v2_start};
 
 // =============================================================================
 // v2 Reference Evaluation (T13)
 // =============================================================================
-
-/// Helper to get value at path string
-fn get_path_str<'a>(
-    value: &'a JsonValue,
-    path_str: &str,
-    error_path: &str,
-) -> Result<EvalValue, TransformError> {
-    let tokens = parse_path(path_str).map_err(|_| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            format!("invalid path: {}", path_str),
-        )
-        .with_path(error_path)
-    })?;
-    match get_path(value, &tokens) {
-        Some(v) => Ok(EvalValue::Value(v.clone())),
-        None => Ok(EvalValue::Missing),
-    }
-}
-
-/// Evaluate a v2 reference to get its value
-pub fn eval_v2_ref<'a>(
-    v2_ref: &V2Ref,
-    record: &'a JsonValue,
-    context: Option<&'a JsonValue>,
-    out: &'a JsonValue,
-    path: &str,
-    ctx: &V2EvalContext<'a>,
-) -> Result<EvalValue, TransformError> {
-    match v2_ref {
-        V2Ref::Input(ref_path) => {
-            if ref_path.is_empty() {
-                Ok(EvalValue::Value(record.clone()))
-            } else {
-                get_path_str(record, ref_path, path)
-            }
-        }
-        V2Ref::Context(ref_path) => {
-            let ctx_value = match context {
-                Some(value) => value,
-                None => return Ok(EvalValue::Missing),
-            };
-            if ref_path.is_empty() {
-                Ok(EvalValue::Value(ctx_value.clone()))
-            } else {
-                get_path_str(ctx_value, ref_path, path)
-            }
-        }
-        V2Ref::Out(ref_path) => {
-            if ref_path.is_empty() {
-                Ok(EvalValue::Value(out.clone()))
-            } else {
-                get_path_str(out, ref_path, path)
-            }
-        }
-        V2Ref::Item(ref_path) => {
-            let item = ctx.get_item().ok_or_else(|| {
-                TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "@item is only available in map/filter operations",
-                )
-                .with_path(path)
-            })?;
-            if ref_path.is_empty() {
-                Ok(EvalValue::Value(item.value.clone()))
-            } else if ref_path == "index" {
-                Ok(EvalValue::Value(JsonValue::Number(item.index.into())))
-            } else if let Some(rest) = ref_path.strip_prefix("value.") {
-                get_path_str(item.value, rest, path)
-            } else if ref_path == "value" {
-                Ok(EvalValue::Value(item.value.clone()))
-            } else {
-                // Direct path on item value
-                get_path_str(item.value, ref_path, path)
-            }
-        }
-        V2Ref::Acc(ref_path) => {
-            let acc = ctx.get_acc().ok_or_else(|| {
-                TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "@acc is only available in reduce/fold operations",
-                )
-                .with_path(path)
-            })?;
-            if ref_path.is_empty() {
-                Ok(EvalValue::Value(acc.clone()))
-            } else if let Some(rest) = ref_path.strip_prefix("value.") {
-                get_path_str(acc, rest, path)
-            } else if ref_path == "value" {
-                Ok(EvalValue::Value(acc.clone()))
-            } else {
-                // Direct path on acc value
-                get_path_str(acc, ref_path, path)
-            }
-        }
-        V2Ref::Local(var_name) => {
-            let value = ctx.resolve_local(var_name).ok_or_else(|| {
-                TransformError::new(
-                    TransformErrorKind::ExprError,
-                    format!("undefined variable: @{}", var_name),
-                )
-                .with_path(path)
-            })?;
-            Ok(value.clone())
-        }
-    }
-}
 
 // =============================================================================
 // v2 Reference Evaluation Tests (T13)
@@ -377,35 +273,6 @@ mod v2_ref_eval_tests {
 // =============================================================================
 // v2 Start Value Evaluation (T14)
 // =============================================================================
-
-/// Evaluate a v2 start value
-pub fn eval_v2_start<'a>(
-    start: &V2Start,
-    record: &'a JsonValue,
-    context: Option<&'a JsonValue>,
-    out: &'a JsonValue,
-    path: &str,
-    ctx: &V2EvalContext<'a>,
-) -> Result<EvalValue, TransformError> {
-    match start {
-        V2Start::Ref(v2_ref) => eval_v2_ref(v2_ref, record, context, out, path, ctx),
-        V2Start::PipeValue => {
-            // If pipe value is not available, return Missing instead of error
-            // This allows ops like lookup_first that don't use pipe input to work
-            Ok(ctx.get_pipe_value().cloned().unwrap_or(EvalValue::Missing))
-        }
-        V2Start::Literal(value) => Ok(EvalValue::Value(value.clone())),
-        V2Start::V1Expr(_expr) => {
-            // V1 expressions would be evaluated using the existing v1 eval logic
-            // For now, return an error as this is a fallback case
-            Err(TransformError::new(
-                TransformErrorKind::ExprError,
-                "v1 expression fallback not yet implemented",
-            )
-            .with_path(path))
-        }
-    }
-}
 
 // =============================================================================
 // v2 Start Value Evaluation Tests (T14)

--- a/crates/rulemorph/src/v2_eval/reference.rs
+++ b/crates/rulemorph/src/v2_eval/reference.rs
@@ -1,0 +1,142 @@
+use serde_json::Value as JsonValue;
+
+use super::{EvalValue, V2EvalContext};
+use crate::error::{TransformError, TransformErrorKind};
+use crate::path::{get_path, parse_path};
+use crate::v2_model::{V2Ref, V2Start};
+
+/// Helper to get value at path string
+fn get_path_str(
+    value: &JsonValue,
+    path_str: &str,
+    error_path: &str,
+) -> Result<EvalValue, TransformError> {
+    let tokens = parse_path(path_str).map_err(|_| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            format!("invalid path: {}", path_str),
+        )
+        .with_path(error_path)
+    })?;
+    match get_path(value, &tokens) {
+        Some(v) => Ok(EvalValue::Value(v.clone())),
+        None => Ok(EvalValue::Missing),
+    }
+}
+
+/// Evaluate a v2 reference to get its value
+pub fn eval_v2_ref<'a>(
+    v2_ref: &V2Ref,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    match v2_ref {
+        V2Ref::Input(ref_path) => {
+            if ref_path.is_empty() {
+                Ok(EvalValue::Value(record.clone()))
+            } else {
+                get_path_str(record, ref_path, path)
+            }
+        }
+        V2Ref::Context(ref_path) => {
+            let ctx_value = match context {
+                Some(value) => value,
+                None => return Ok(EvalValue::Missing),
+            };
+            if ref_path.is_empty() {
+                Ok(EvalValue::Value(ctx_value.clone()))
+            } else {
+                get_path_str(ctx_value, ref_path, path)
+            }
+        }
+        V2Ref::Out(ref_path) => {
+            if ref_path.is_empty() {
+                Ok(EvalValue::Value(out.clone()))
+            } else {
+                get_path_str(out, ref_path, path)
+            }
+        }
+        V2Ref::Item(ref_path) => {
+            let item = ctx.get_item().ok_or_else(|| {
+                TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "@item is only available in map/filter operations",
+                )
+                .with_path(path)
+            })?;
+            if ref_path.is_empty() {
+                Ok(EvalValue::Value(item.value.clone()))
+            } else if ref_path == "index" {
+                Ok(EvalValue::Value(JsonValue::Number(item.index.into())))
+            } else if let Some(rest) = ref_path.strip_prefix("value.") {
+                get_path_str(item.value, rest, path)
+            } else if ref_path == "value" {
+                Ok(EvalValue::Value(item.value.clone()))
+            } else {
+                // Direct path on item value
+                get_path_str(item.value, ref_path, path)
+            }
+        }
+        V2Ref::Acc(ref_path) => {
+            let acc = ctx.get_acc().ok_or_else(|| {
+                TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "@acc is only available in reduce/fold operations",
+                )
+                .with_path(path)
+            })?;
+            if ref_path.is_empty() {
+                Ok(EvalValue::Value(acc.clone()))
+            } else if let Some(rest) = ref_path.strip_prefix("value.") {
+                get_path_str(acc, rest, path)
+            } else if ref_path == "value" {
+                Ok(EvalValue::Value(acc.clone()))
+            } else {
+                // Direct path on acc value
+                get_path_str(acc, ref_path, path)
+            }
+        }
+        V2Ref::Local(var_name) => {
+            let value = ctx.resolve_local(var_name).ok_or_else(|| {
+                TransformError::new(
+                    TransformErrorKind::ExprError,
+                    format!("undefined variable: @{}", var_name),
+                )
+                .with_path(path)
+            })?;
+            Ok(value.clone())
+        }
+    }
+}
+
+/// Evaluate a v2 start value
+pub fn eval_v2_start<'a>(
+    start: &V2Start,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    match start {
+        V2Start::Ref(v2_ref) => eval_v2_ref(v2_ref, record, context, out, path, ctx),
+        V2Start::PipeValue => {
+            // If pipe value is not available, return Missing instead of error
+            // This allows ops like lookup_first that don't use pipe input to work
+            Ok(ctx.get_pipe_value().cloned().unwrap_or(EvalValue::Missing))
+        }
+        V2Start::Literal(value) => Ok(EvalValue::Value(value.clone())),
+        V2Start::V1Expr(_expr) => {
+            // V1 expressions would be evaluated using the existing v1 eval logic
+            // For now, return an error as this is a fallback case
+            Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "v1 expression fallback not yet implemented",
+            )
+            .with_path(path))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract v2 reference and start-value evaluation into v2_eval/reference.rs
- keep rulemorph::v2_eval::eval_v2_ref and eval_v2_start re-exported from the existing public module path
- leave v2 pipe, operator, condition, trace, and test semantics unchanged

## No behavior changes
- no public API names or signatures changed
- no transform semantics changed
- no trace JSON schema changed
- no tests removed or weakened

## Verification
- cargo fmt
- cargo fmt --check
- cargo test -p rulemorph --lib v2_eval
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph --test v2_transform
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test
- git diff --check