### PR TITLE
[codex] Extract trace store id path helpers

### DIFF
--- a/crates/rulemorph_trace/src/trace_store.rs
+++ b/crates/rulemorph_trace/src/trace_store.rs
@@ -14,7 +14,7 @@ use tracing::warn;
 use walkdir::WalkDir;
 
 use crate::trace_backend::TraceBackend;
-use crate::trace_id::{sanitize_trace_id, trace_id_is_insufficient, trace_id_is_placeholder};
+use crate::trace_id::{sanitize_trace_id, trace_id_is_placeholder};
 use crate::trace_schema::{
     RuleMeta, TRACE_CHUNK_BYTES_UNCOMPRESSED_HARD_MAX, TRACE_CHUNK_COUNT_HARD_MAX,
     TRACE_JSON_MAX_BYTES, TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX,
@@ -24,6 +24,7 @@ use crate::trace_schema::{
 
 mod chunk_read;
 mod import_path;
+mod trace_id_path;
 
 #[cfg(test)]
 use self::chunk_read::resolve_chunk_path;
@@ -33,6 +34,9 @@ use self::chunk_read::{
 };
 use self::import_path::{
     copy_file_create_new, ensure_import_base_dir, ensure_import_target_parent,
+};
+use self::trace_id_path::{
+    fallback_trace_id_for_path, hash_trace_id_for_path, path_hash_for_trace_id,
 };
 
 const IMPORT_MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
@@ -846,61 +850,6 @@ fn rollback_import(copied_paths: &[PathBuf], created_dirs: &BTreeSet<PathBuf>) {
             }
         }
     }
-}
-
-fn fnv1a_hash(bytes: &[u8]) -> u64 {
-    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
-    const FNV_PRIME: u64 = 0x100000001b3;
-    let mut hash = FNV_OFFSET_BASIS;
-    for byte in bytes {
-        hash ^= *byte as u64;
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    hash
-}
-
-fn relative_trace_path(path: &Path) -> Option<PathBuf> {
-    for ancestor in path.ancestors() {
-        if ancestor.file_name().and_then(|name| name.to_str()) == Some("traces") {
-            if let Ok(rel) = path.strip_prefix(ancestor) {
-                if !rel.as_os_str().is_empty() {
-                    return Some(rel.to_path_buf());
-                }
-            }
-        }
-    }
-    None
-}
-
-#[cfg(unix)]
-fn path_bytes_for_hash(path: &Path) -> Vec<u8> {
-    use std::os::unix::ffi::OsStrExt;
-    let candidate = relative_trace_path(path).unwrap_or_else(|| path.to_path_buf());
-    candidate.as_os_str().as_bytes().to_vec()
-}
-
-#[cfg(not(unix))]
-fn path_bytes_for_hash(path: &Path) -> Vec<u8> {
-    let candidate = relative_trace_path(path).unwrap_or_else(|| path.to_path_buf());
-    candidate.to_string_lossy().into_owned().into_bytes()
-}
-
-fn path_hash_for_trace_id(path: &Path) -> u64 {
-    fnv1a_hash(&path_bytes_for_hash(path))
-}
-
-fn hash_trace_id_for_path(path: &Path) -> String {
-    let hash = path_hash_for_trace_id(path);
-    format!("trace-{hash:x}")
-}
-
-fn fallback_trace_id_for_path(path: &Path) -> String {
-    let stem = path.file_stem().and_then(|s| s.to_str());
-    let sanitized = stem.map(sanitize_trace_id).unwrap_or_default();
-    if !trace_id_is_insufficient(&sanitized) {
-        return sanitized;
-    }
-    hash_trace_id_for_path(path)
 }
 
 #[cfg(test)]

--- a/crates/rulemorph_trace/src/trace_store/trace_id_path.rs
+++ b/crates/rulemorph_trace/src/trace_store/trace_id_path.rs
@@ -1,0 +1,58 @@
+use std::path::{Path, PathBuf};
+
+use crate::trace_id::{sanitize_trace_id, trace_id_is_insufficient};
+
+fn fnv1a_hash(bytes: &[u8]) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+fn relative_trace_path(path: &Path) -> Option<PathBuf> {
+    for ancestor in path.ancestors() {
+        if ancestor.file_name().and_then(|name| name.to_str()) == Some("traces") {
+            if let Ok(rel) = path.strip_prefix(ancestor) {
+                if !rel.as_os_str().is_empty() {
+                    return Some(rel.to_path_buf());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn path_bytes_for_hash(path: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    let candidate = relative_trace_path(path).unwrap_or_else(|| path.to_path_buf());
+    candidate.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(not(unix))]
+fn path_bytes_for_hash(path: &Path) -> Vec<u8> {
+    let candidate = relative_trace_path(path).unwrap_or_else(|| path.to_path_buf());
+    candidate.to_string_lossy().into_owned().into_bytes()
+}
+
+pub(super) fn path_hash_for_trace_id(path: &Path) -> u64 {
+    fnv1a_hash(&path_bytes_for_hash(path))
+}
+
+pub(super) fn hash_trace_id_for_path(path: &Path) -> String {
+    let hash = path_hash_for_trace_id(path);
+    format!("trace-{hash:x}")
+}
+
+pub(super) fn fallback_trace_id_for_path(path: &Path) -> String {
+    let stem = path.file_stem().and_then(|s| s.to_str());
+    let sanitized = stem.map(sanitize_trace_id).unwrap_or_default();
+    if !trace_id_is_insufficient(&sanitized) {
+        return sanitized;
+    }
+    hash_trace_id_for_path(path)
+}


### PR DESCRIPTION
## Summary
- Move trace-store path hashing and fallback trace-id helpers into trace_store/trace_id_path.rs
- Keep collision handling, legacy trace fallback, manifest trace fallback, and public APIs unchanged
- Preserve existing trace-store tests and full workspace behavior

## Tests
- cargo fmt
- cargo test -p rulemorph_trace --test trace_store
- cargo test -p rulemorph_trace
- cargo test
- cargo fmt --check
- git diff --check