### PR TITLE
[codex] Extract server trace route helpers

### DIFF
--- a/crates/rulemorph_server/src/server.rs
+++ b/crates/rulemorph_server/src/server.rs
@@ -7,30 +7,22 @@ use axum::{
     extract::{DefaultBodyLimit, Extension, FromRequest, Multipart, Path as AxumPath, State},
     http::{HeaderMap, Method, Request, StatusCode},
     middleware::{Next, from_fn_with_state},
-    response::{
-        IntoResponse,
-        sse::{Event, Sse},
-    },
+    response::IntoResponse,
     routing::{any, get, post},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
-use std::convert::Infallible;
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, OnceCell, broadcast};
-use tokio_stream::{StreamExt, wrappers::BroadcastStream};
 use tower_http::services::{ServeDir, ServeFile};
 
-use crate::api_graph::{ApiGraphResponse, build_api_graph};
 use crate::{ApiKeyInfo, ApiKeyIssueResult, ApiKeyStore};
 use crate::{TenantContext, TenantLayout, TenantResolver, validate_tenant_id};
 use rulemorph_endpoint::{
     ApiMode, EndpointEngine, EngineConfig, RequestContext, validate_rules_dir,
 };
-use rulemorph_trace::{
-    ImportResult, TraceManifest, TraceMeta, TraceNodeChunkEntry, TraceStore, start_trace_watcher,
-};
+use rulemorph_trace::{ImportResult, TraceStore, start_trace_watcher};
 
 #[cfg(feature = "embedded-ui")]
 use axum::extract::OriginalUri;
@@ -42,6 +34,7 @@ static UI_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../rulemorph_ui/ui/di
 
 mod auth;
 mod import_zip;
+mod trace_routes;
 
 #[cfg(test)]
 use self::auth::pre_auth_rate_limit_key;
@@ -55,6 +48,10 @@ use self::auth::{
 #[cfg(test)]
 use self::import_zip::copy_zip_entry_bounded;
 use self::import_zip::{extract_zip, resolve_bundle_root, validate_bundle_path};
+use self::trace_routes::{
+    get_api_graph, get_trace, get_trace_finalize, get_trace_manifest, get_trace_nodes_chunk,
+    get_trace_records_chunk, list_traces, stream_traces,
+};
 
 #[derive(Clone)]
 pub enum UiSource {
@@ -620,123 +617,6 @@ async fn inject_default_resources(
     Ok(next.run(request).await)
 }
 
-#[derive(Serialize)]
-struct TraceListResponse {
-    traces: Vec<TraceMeta>,
-}
-
-#[derive(Serialize)]
-struct TraceManifestResponse {
-    manifest: TraceManifest,
-}
-
-#[derive(Serialize)]
-struct TraceRecordsResponse {
-    records: Vec<serde_json::Value>,
-}
-
-#[derive(Serialize)]
-struct TraceNodesResponse {
-    nodes: Vec<TraceNodeChunkEntry>,
-}
-
-#[derive(Serialize)]
-struct TraceFinalizeResponse {
-    finalize: serde_json::Value,
-}
-
-#[derive(Deserialize)]
-struct TraceChunkPath {
-    id: String,
-    chunk: usize,
-}
-
-async fn list_traces(
-    Extension(resources): Extension<Arc<TenantResources>>,
-) -> std::result::Result<Json<TraceListResponse>, ApiError> {
-    let mut traces = resources.store.list().await.map_err(ApiError::internal)?;
-    if traces.is_empty() {
-        resources
-            .store
-            .seed_sample()
-            .await
-            .map_err(ApiError::internal)?;
-        traces = resources.store.list().await.map_err(ApiError::internal)?;
-    }
-    Ok(Json(TraceListResponse { traces }))
-}
-
-async fn get_trace(
-    Extension(resources): Extension<Arc<TenantResources>>,
-    AxumPath(id): AxumPath<String>,
-) -> std::result::Result<Json<serde_json::Value>, ApiError> {
-    let trace = resources.store.get(&id).await.map_err(ApiError::internal)?;
-    match trace {
-        Some(value) => Ok(Json(json!({ "trace": value }))),
-        None => Err(ApiError::not_found("trace not found")),
-    }
-}
-
-async fn get_trace_manifest(
-    Extension(resources): Extension<Arc<TenantResources>>,
-    AxumPath(id): AxumPath<String>,
-) -> std::result::Result<Json<TraceManifestResponse>, ApiError> {
-    let manifest = resources
-        .store
-        .get_manifest(&id)
-        .await
-        .map_err(ApiError::internal)?;
-    match manifest {
-        Some(manifest) => Ok(Json(TraceManifestResponse { manifest })),
-        None => Err(ApiError::not_found("trace manifest not found")),
-    }
-}
-
-async fn get_trace_records_chunk(
-    Extension(resources): Extension<Arc<TenantResources>>,
-    AxumPath(path): AxumPath<TraceChunkPath>,
-) -> std::result::Result<Json<TraceRecordsResponse>, ApiError> {
-    let records = resources
-        .store
-        .get_records_chunk(&path.id, path.chunk)
-        .await
-        .map_err(ApiError::internal)?;
-    match records {
-        Some(records) => Ok(Json(TraceRecordsResponse { records })),
-        None => Err(ApiError::not_found("trace records chunk not found")),
-    }
-}
-
-async fn get_trace_nodes_chunk(
-    Extension(resources): Extension<Arc<TenantResources>>,
-    AxumPath(path): AxumPath<TraceChunkPath>,
-) -> std::result::Result<Json<TraceNodesResponse>, ApiError> {
-    let nodes = resources
-        .store
-        .get_nodes_chunk(&path.id, path.chunk)
-        .await
-        .map_err(ApiError::internal)?;
-    match nodes {
-        Some(nodes) => Ok(Json(TraceNodesResponse { nodes })),
-        None => Err(ApiError::not_found("trace nodes chunk not found")),
-    }
-}
-
-async fn get_trace_finalize(
-    Extension(resources): Extension<Arc<TenantResources>>,
-    AxumPath(id): AxumPath<String>,
-) -> std::result::Result<Json<TraceFinalizeResponse>, ApiError> {
-    let finalize = resources
-        .store
-        .get_finalize_chunk(&id)
-        .await
-        .map_err(ApiError::internal)?;
-    match finalize {
-        Some(finalize) => Ok(Json(TraceFinalizeResponse { finalize })),
-        None => Err(ApiError::not_found("trace finalize not found")),
-    }
-}
-
 #[derive(Deserialize)]
 struct ImportPathRequest {
     bundle_path: String,
@@ -882,27 +762,6 @@ async fn rotate_api_key(
         return Err(ApiError::not_found("api key not found"));
     };
     Ok(Json(issued))
-}
-
-async fn stream_traces(
-    Extension(resources): Extension<Arc<TenantResources>>,
-) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
-    let stream =
-        BroadcastStream::new(resources.trace_events.subscribe()).filter_map(
-            |message| match message {
-                Ok(_) => Some(Ok(Event::default().event("traces").data("updated"))),
-                Err(_) => None,
-            },
-        );
-    Sse::new(stream)
-        .keep_alive(axum::response::sse::KeepAlive::new().interval(Duration::from_secs(15)))
-}
-
-async fn get_api_graph(
-    Extension(resources): Extension<Arc<TenantResources>>,
-) -> std::result::Result<Json<ApiGraphResponse>, ApiError> {
-    let graph = build_api_graph(&resources.rules_dir).map_err(ApiError::internal)?;
-    Ok(Json(graph))
 }
 
 struct ApiError {

--- a/crates/rulemorph_server/src/server/trace_routes.rs
+++ b/crates/rulemorph_server/src/server/trace_routes.rs
@@ -1,0 +1,155 @@
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    Json,
+    extract::{Extension, Path as AxumPath},
+    response::sse::{Event, Sse},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio_stream::{StreamExt, wrappers::BroadcastStream};
+
+use crate::api_graph::{ApiGraphResponse, build_api_graph};
+use rulemorph_trace::{TraceManifest, TraceMeta, TraceNodeChunkEntry};
+
+use super::{ApiError, TenantResources};
+
+#[derive(Serialize)]
+pub(super) struct TraceListResponse {
+    traces: Vec<TraceMeta>,
+}
+
+#[derive(Serialize)]
+pub(super) struct TraceManifestResponse {
+    manifest: TraceManifest,
+}
+
+#[derive(Serialize)]
+pub(super) struct TraceRecordsResponse {
+    records: Vec<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+pub(super) struct TraceNodesResponse {
+    nodes: Vec<TraceNodeChunkEntry>,
+}
+
+#[derive(Serialize)]
+pub(super) struct TraceFinalizeResponse {
+    finalize: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+pub(super) struct TraceChunkPath {
+    id: String,
+    chunk: usize,
+}
+
+pub(super) async fn list_traces(
+    Extension(resources): Extension<Arc<TenantResources>>,
+) -> std::result::Result<Json<TraceListResponse>, ApiError> {
+    let mut traces = resources.store.list().await.map_err(ApiError::internal)?;
+    if traces.is_empty() {
+        resources
+            .store
+            .seed_sample()
+            .await
+            .map_err(ApiError::internal)?;
+        traces = resources.store.list().await.map_err(ApiError::internal)?;
+    }
+    Ok(Json(TraceListResponse { traces }))
+}
+
+pub(super) async fn get_trace(
+    Extension(resources): Extension<Arc<TenantResources>>,
+    AxumPath(id): AxumPath<String>,
+) -> std::result::Result<Json<serde_json::Value>, ApiError> {
+    let trace = resources.store.get(&id).await.map_err(ApiError::internal)?;
+    match trace {
+        Some(value) => Ok(Json(json!({ "trace": value }))),
+        None => Err(ApiError::not_found("trace not found")),
+    }
+}
+
+pub(super) async fn get_trace_manifest(
+    Extension(resources): Extension<Arc<TenantResources>>,
+    AxumPath(id): AxumPath<String>,
+) -> std::result::Result<Json<TraceManifestResponse>, ApiError> {
+    let manifest = resources
+        .store
+        .get_manifest(&id)
+        .await
+        .map_err(ApiError::internal)?;
+    match manifest {
+        Some(manifest) => Ok(Json(TraceManifestResponse { manifest })),
+        None => Err(ApiError::not_found("trace manifest not found")),
+    }
+}
+
+pub(super) async fn get_trace_records_chunk(
+    Extension(resources): Extension<Arc<TenantResources>>,
+    AxumPath(path): AxumPath<TraceChunkPath>,
+) -> std::result::Result<Json<TraceRecordsResponse>, ApiError> {
+    let records = resources
+        .store
+        .get_records_chunk(&path.id, path.chunk)
+        .await
+        .map_err(ApiError::internal)?;
+    match records {
+        Some(records) => Ok(Json(TraceRecordsResponse { records })),
+        None => Err(ApiError::not_found("trace records chunk not found")),
+    }
+}
+
+pub(super) async fn get_trace_nodes_chunk(
+    Extension(resources): Extension<Arc<TenantResources>>,
+    AxumPath(path): AxumPath<TraceChunkPath>,
+) -> std::result::Result<Json<TraceNodesResponse>, ApiError> {
+    let nodes = resources
+        .store
+        .get_nodes_chunk(&path.id, path.chunk)
+        .await
+        .map_err(ApiError::internal)?;
+    match nodes {
+        Some(nodes) => Ok(Json(TraceNodesResponse { nodes })),
+        None => Err(ApiError::not_found("trace nodes chunk not found")),
+    }
+}
+
+pub(super) async fn get_trace_finalize(
+    Extension(resources): Extension<Arc<TenantResources>>,
+    AxumPath(id): AxumPath<String>,
+) -> std::result::Result<Json<TraceFinalizeResponse>, ApiError> {
+    let finalize = resources
+        .store
+        .get_finalize_chunk(&id)
+        .await
+        .map_err(ApiError::internal)?;
+    match finalize {
+        Some(finalize) => Ok(Json(TraceFinalizeResponse { finalize })),
+        None => Err(ApiError::not_found("trace finalize not found")),
+    }
+}
+
+pub(super) async fn stream_traces(
+    Extension(resources): Extension<Arc<TenantResources>>,
+) -> Sse<impl tokio_stream::Stream<Item = std::result::Result<Event, Infallible>>> {
+    let stream =
+        BroadcastStream::new(resources.trace_events.subscribe()).filter_map(
+            |message| match message {
+                Ok(_) => Some(Ok(Event::default().event("traces").data("updated"))),
+                Err(_) => None,
+            },
+        );
+    Sse::new(stream)
+        .keep_alive(axum::response::sse::KeepAlive::new().interval(Duration::from_secs(15)))
+}
+
+pub(super) async fn get_api_graph(
+    Extension(resources): Extension<Arc<TenantResources>>,
+) -> std::result::Result<Json<ApiGraphResponse>, ApiError> {
+    let graph = build_api_graph(&resources.rules_dir).map_err(ApiError::internal)?;
+    Ok(Json(graph))
+}


### PR DESCRIPTION
## Summary
- Move internal trace and API graph route handlers into server/trace_routes.rs
- Keep internal route paths, response wrappers, tenant resource selection, SSE keep-alive, and API graph behavior unchanged
- Preserve server trace/API graph focused tests and full workspace tests

## Tests
- cargo fmt
- cargo test -p rulemorph_server api_graph
- cargo test -p rulemorph_server --test cloud_scenarios cloud_scenario_trace_full_detail_roundtrip
- cargo test -p rulemorph_server --test cloud_scenarios tenant_traces_are_isolated
- cargo test -p rulemorph_server
- cargo test
- cargo fmt --check
- git diff --check