### PR TITLE
Split endpoint error helpers

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine.rs
@@ -31,10 +31,12 @@ use uuid::Uuid;
 
 use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
 
+mod error;
 mod multipart_import;
 mod trace_graph;
 mod validation;
 
+use self::error::{EndpointError, EndpointErrorKind};
 use self::multipart_import::build_multipart_import_body;
 #[cfg(test)]
 use self::multipart_import::{copy_zip_entry_bounded, extract_zip};
@@ -1748,108 +1750,6 @@ impl CatchSpec {
             }
         }
         map.get("default").map(PathBuf::from)
-    }
-}
-
-#[derive(Debug, Clone)]
-struct EndpointError {
-    kind: EndpointErrorKind,
-    status: Option<u16>,
-    message: String,
-    path: Option<PathBuf>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum EndpointErrorKind {
-    Timeout,
-    HttpStatus,
-    Network,
-    Transform,
-    Invalid,
-}
-
-impl EndpointError {
-    fn timeout() -> Self {
-        Self {
-            kind: EndpointErrorKind::Timeout,
-            status: None,
-            message: "timeout".to_string(),
-            path: None,
-        }
-    }
-
-    fn http_status(status: u16) -> Self {
-        Self {
-            kind: EndpointErrorKind::HttpStatus,
-            status: Some(status),
-            message: format!("http status {}", status),
-            path: None,
-        }
-    }
-
-    fn network(message: String) -> Self {
-        Self {
-            kind: EndpointErrorKind::Network,
-            status: None,
-            message,
-            path: None,
-        }
-    }
-
-    fn invalid(message: impl Into<String>) -> Self {
-        Self {
-            kind: EndpointErrorKind::Invalid,
-            status: None,
-            message: message.into(),
-            path: None,
-        }
-    }
-
-    fn bad_request(message: impl Into<String>) -> Self {
-        Self {
-            kind: EndpointErrorKind::Invalid,
-            status: Some(StatusCode::BAD_REQUEST.as_u16()),
-            message: message.into(),
-            path: None,
-        }
-    }
-
-    fn payload_too_large(limit: usize) -> Self {
-        Self {
-            kind: EndpointErrorKind::Invalid,
-            status: Some(StatusCode::PAYLOAD_TOO_LARGE.as_u16()),
-            message: format!("payload too large (limit {} bytes)", limit),
-            path: None,
-        }
-    }
-
-    fn from_transform(err: TransformError) -> Self {
-        Self {
-            kind: EndpointErrorKind::Transform,
-            status: None,
-            message: err.to_string(),
-            path: None,
-        }
-    }
-
-    fn with_path(mut self, path: PathBuf) -> Self {
-        self.path = Some(path);
-        self
-    }
-
-    fn to_json(&self) -> JsonValue {
-        json!({
-            "kind": format!("{:?}", self.kind),
-            "status": self.status,
-            "message": self.message,
-            "path": self.path.as_ref().map(|p| p.display().to_string()),
-        })
-    }
-}
-
-impl std::fmt::Display for EndpointError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
     }
 }
 

--- a/crates/rulemorph_endpoint/src/endpoint_engine/error.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/error.rs
@@ -1,0 +1,107 @@
+use std::path::PathBuf;
+
+use axum::http::StatusCode;
+use rulemorph::TransformError;
+use serde_json::{Value as JsonValue, json};
+
+#[derive(Debug, Clone)]
+pub(super) struct EndpointError {
+    pub(super) kind: EndpointErrorKind,
+    pub(super) status: Option<u16>,
+    pub(super) message: String,
+    pub(super) path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum EndpointErrorKind {
+    Timeout,
+    HttpStatus,
+    Network,
+    Transform,
+    Invalid,
+}
+
+impl EndpointError {
+    pub(super) fn timeout() -> Self {
+        Self {
+            kind: EndpointErrorKind::Timeout,
+            status: None,
+            message: "timeout".to_string(),
+            path: None,
+        }
+    }
+
+    pub(super) fn http_status(status: u16) -> Self {
+        Self {
+            kind: EndpointErrorKind::HttpStatus,
+            status: Some(status),
+            message: format!("http status {}", status),
+            path: None,
+        }
+    }
+
+    pub(super) fn network(message: String) -> Self {
+        Self {
+            kind: EndpointErrorKind::Network,
+            status: None,
+            message,
+            path: None,
+        }
+    }
+
+    pub(super) fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            kind: EndpointErrorKind::Invalid,
+            status: None,
+            message: message.into(),
+            path: None,
+        }
+    }
+
+    pub(super) fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            kind: EndpointErrorKind::Invalid,
+            status: Some(StatusCode::BAD_REQUEST.as_u16()),
+            message: message.into(),
+            path: None,
+        }
+    }
+
+    pub(super) fn payload_too_large(limit: usize) -> Self {
+        Self {
+            kind: EndpointErrorKind::Invalid,
+            status: Some(StatusCode::PAYLOAD_TOO_LARGE.as_u16()),
+            message: format!("payload too large (limit {} bytes)", limit),
+            path: None,
+        }
+    }
+
+    pub(super) fn from_transform(err: TransformError) -> Self {
+        Self {
+            kind: EndpointErrorKind::Transform,
+            status: None,
+            message: err.to_string(),
+            path: None,
+        }
+    }
+
+    pub(super) fn with_path(mut self, path: PathBuf) -> Self {
+        self.path = Some(path);
+        self
+    }
+
+    pub(super) fn to_json(&self) -> JsonValue {
+        json!({
+            "kind": format!("{:?}", self.kind),
+            "status": self.status,
+            "message": self.message,
+            "path": self.path.as_ref().map(|p| p.display().to_string()),
+        })
+    }
+}
+
+impl std::fmt::Display for EndpointError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}


### PR DESCRIPTION
## Summary
- move private endpoint error types and constructors into endpoint_engine/error.rs
- keep EndpointError/EndpointErrorKind private to endpoint_engine and sibling modules
- preserve endpoint behavior, HTTP contracts, trace JSON shape, and public exports

## Verification
- cargo fmt
- cargo test -p rulemorph_endpoint endpoint_engine::
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo test
- cargo fmt --check
- git diff --check
- git diff --cached --check