### PR TITLE
Split v2 eval v1 bridge helpers

### DIFF
--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -4,14 +4,9 @@
 //! including pipe value tracking, let bindings, and item/acc scopes.
 
 use serde_json::Value as JsonValue;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::error::{TransformError, TransformErrorKind};
-use crate::model::{Expr, ExprOp, ExprRef};
-use crate::transform::{
-    EvalItem as V1EvalItem, EvalLocals as V1EvalLocals, EvalValue as V1EvalValue,
-    eval_op as eval_v1_op,
-};
 use crate::v2_model::{V2Expr, V2OpStep, V2Pipe, V2Start};
 
 mod condition;
@@ -20,6 +15,7 @@ mod control;
 mod reference;
 #[cfg(test)]
 mod tests;
+mod v1_bridge;
 
 use condition::compare_values_eq;
 pub use condition::eval_v2_condition;
@@ -28,6 +24,7 @@ pub use control::{
     eval_v2_expr, eval_v2_if_step, eval_v2_let_step, eval_v2_map_step, eval_v2_pipe,
 };
 pub use reference::{eval_v2_ref, eval_v2_start};
+use v1_bridge::eval_v2_op_with_v1_fallback;
 
 // =============================================================================
 // v2 Reference Evaluation (T13)
@@ -340,91 +337,6 @@ fn eval_v2_array_from_eval_value(
             }
         }
     }
-}
-fn v2_eval_to_v1_eval(value: &EvalValue) -> V1EvalValue {
-    match value {
-        EvalValue::Missing => V1EvalValue::Missing,
-        EvalValue::Value(v) => V1EvalValue::Value(v.clone()),
-    }
-}
-
-fn v1_eval_to_v2_eval(value: V1EvalValue) -> EvalValue {
-    match value {
-        V1EvalValue::Missing => EvalValue::Missing,
-        V1EvalValue::Value(v) => EvalValue::Value(v),
-    }
-}
-
-fn map_v2_op_name(op: &str) -> &str {
-    match op {
-        "add" => "+",
-        "subtract" => "-",
-        "multiply" => "*",
-        "divide" => "/",
-        _ => op,
-    }
-}
-
-fn eval_v2_op_with_v1_fallback<'a>(
-    op_step: &V2OpStep,
-    pipe_value: EvalValue,
-    record: &'a JsonValue,
-    context: Option<&'a JsonValue>,
-    out: &'a JsonValue,
-    path: &str,
-    ctx: &V2EvalContext<'a>,
-) -> Result<EvalValue, TransformError> {
-    let mut v1_locals_map: HashMap<String, V1EvalValue> = ctx
-        .let_bindings()
-        .map(|(k, v)| (k.clone(), v2_eval_to_v1_eval(v)))
-        .collect();
-    let mut arg_refs = Vec::with_capacity(op_step.args.len());
-    for (index, arg) in op_step.args.iter().enumerate() {
-        let arg_path = format!("{}.args[{}]", path, index);
-        let value = eval_v2_expr(arg, record, context, out, &arg_path, ctx)?;
-        let mut key = format!("__v2_arg{}", index);
-        if v1_locals_map.contains_key(&key) {
-            let mut suffix = 1usize;
-            while v1_locals_map.contains_key(&format!("{}{}", key, suffix)) {
-                suffix += 1;
-            }
-            key = format!("{}{}", key, suffix);
-        }
-        v1_locals_map.insert(key.clone(), v2_eval_to_v1_eval(&value));
-        arg_refs.push(Expr::Ref(ExprRef {
-            ref_path: format!("local.{}", key),
-        }));
-    }
-
-    let expr_op = ExprOp {
-        op: map_v2_op_name(&op_step.op).to_string(),
-        args: arg_refs,
-    };
-
-    let v1_pipe = v2_eval_to_v1_eval(&pipe_value);
-    let v1_item = ctx.get_item().map(|item| V1EvalItem {
-        value: item.value,
-        index: item.index,
-    });
-    let v1_locals = V1EvalLocals {
-        item: v1_item,
-        acc: ctx.get_acc(),
-        pipe: Some(&v1_pipe),
-        locals: Some(&v1_locals_map),
-        precomputed_op_args: None,
-    };
-
-    let result = eval_v1_op(
-        &expr_op,
-        record,
-        context,
-        out,
-        path,
-        Some(&v1_pipe),
-        Some(&v1_locals),
-    )?;
-
-    Ok(v1_eval_to_v2_eval(result))
 }
 
 fn number_to_string(number: &serde_json::Number) -> String {

--- a/crates/rulemorph/src/v2_eval/v1_bridge.rs
+++ b/crates/rulemorph/src/v2_eval/v1_bridge.rs
@@ -1,0 +1,97 @@
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+use super::{EvalValue, V2EvalContext, eval_v2_expr};
+use crate::error::TransformError;
+use crate::model::{Expr, ExprOp, ExprRef};
+use crate::transform::{
+    EvalItem as V1EvalItem, EvalLocals as V1EvalLocals, EvalValue as V1EvalValue,
+    eval_op as eval_v1_op,
+};
+use crate::v2_model::V2OpStep;
+
+fn v2_eval_to_v1_eval(value: &EvalValue) -> V1EvalValue {
+    match value {
+        EvalValue::Missing => V1EvalValue::Missing,
+        EvalValue::Value(v) => V1EvalValue::Value(v.clone()),
+    }
+}
+
+fn v1_eval_to_v2_eval(value: V1EvalValue) -> EvalValue {
+    match value {
+        V1EvalValue::Missing => EvalValue::Missing,
+        V1EvalValue::Value(v) => EvalValue::Value(v),
+    }
+}
+
+fn map_v2_op_name(op: &str) -> &str {
+    match op {
+        "add" => "+",
+        "subtract" => "-",
+        "multiply" => "*",
+        "divide" => "/",
+        _ => op,
+    }
+}
+
+pub(super) fn eval_v2_op_with_v1_fallback<'a>(
+    op_step: &V2OpStep,
+    pipe_value: EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    let mut v1_locals_map: HashMap<String, V1EvalValue> = ctx
+        .let_bindings()
+        .map(|(k, v)| (k.clone(), v2_eval_to_v1_eval(v)))
+        .collect();
+    let mut arg_refs = Vec::with_capacity(op_step.args.len());
+    for (index, arg) in op_step.args.iter().enumerate() {
+        let arg_path = format!("{}.args[{}]", path, index);
+        let value = eval_v2_expr(arg, record, context, out, &arg_path, ctx)?;
+        let mut key = format!("__v2_arg{}", index);
+        if v1_locals_map.contains_key(&key) {
+            let mut suffix = 1usize;
+            while v1_locals_map.contains_key(&format!("{}{}", key, suffix)) {
+                suffix += 1;
+            }
+            key = format!("{}{}", key, suffix);
+        }
+        v1_locals_map.insert(key.clone(), v2_eval_to_v1_eval(&value));
+        arg_refs.push(Expr::Ref(ExprRef {
+            ref_path: format!("local.{}", key),
+        }));
+    }
+
+    let expr_op = ExprOp {
+        op: map_v2_op_name(&op_step.op).to_string(),
+        args: arg_refs,
+    };
+
+    let v1_pipe = v2_eval_to_v1_eval(&pipe_value);
+    let v1_item = ctx.get_item().map(|item| V1EvalItem {
+        value: item.value,
+        index: item.index,
+    });
+    let v1_locals = V1EvalLocals {
+        item: v1_item,
+        acc: ctx.get_acc(),
+        pipe: Some(&v1_pipe),
+        locals: Some(&v1_locals_map),
+        precomputed_op_args: None,
+    };
+
+    let result = eval_v1_op(
+        &expr_op,
+        record,
+        context,
+        out,
+        path,
+        Some(&v1_pipe),
+        Some(&v1_locals),
+    )?;
+
+    Ok(v1_eval_to_v2_eval(result))
+}


### PR DESCRIPTION
## Summary
- move v2 eval v1 fallback bridge helpers into internal sibling module
- keep public v2_eval facade exports and eval_v2_op_step signature unchanged
- leave transform semantics and trace JSON schema unchanged

## Verification
- cargo fmt
- cargo fmt --check
- cargo test -p rulemorph --lib v2_eval
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph --test v2_transform
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test -p rulemorph --test transform_golden tv31_v2_json_ops_pick_omit_reduce_fold
- cargo test -p rulemorph --test transform_golden t13_expr_extended
- cargo test
- git diff --check
- git diff --cached --check