### PR TITLE
Split v2 eval cast helpers

### DIFF
--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use crate::error::{TransformError, TransformErrorKind};
 use crate::v2_model::{V2Expr, V2OpStep, V2Pipe, V2Start};
 
+mod cast;
 mod condition;
 mod context;
 mod control;
@@ -17,6 +18,7 @@ mod reference;
 mod tests;
 mod v1_bridge;
 
+use cast::eval_type_cast;
 use condition::compare_values_eq;
 pub use condition::eval_v2_condition;
 pub use context::{EvalItem, EvalValue, V2EvalContext};
@@ -371,93 +373,6 @@ fn value_to_string(value: &JsonValue, path: &str) -> Result<String, TransformErr
             "value must be string/number/bool",
         )
         .with_path(path)),
-    }
-}
-
-fn cast_to_int(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
-    match value {
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Ok(JsonValue::Number(i.into()))
-            } else if let Some(f) = n.as_f64() {
-                if (f.fract()).abs() < f64::EPSILON {
-                    Ok(JsonValue::Number((f as i64).into()))
-                } else {
-                    Err(type_cast_error("int", path))
-                }
-            } else {
-                Err(type_cast_error("int", path))
-            }
-        }
-        JsonValue::String(s) => s
-            .parse::<i64>()
-            .map(|i| JsonValue::Number(i.into()))
-            .map_err(|_| type_cast_error("int", path)),
-        _ => Err(type_cast_error("int", path)),
-    }
-}
-
-fn cast_to_float(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
-    match value {
-        JsonValue::Number(n) => n
-            .as_f64()
-            .ok_or_else(|| type_cast_error("float", path))
-            .and_then(|f| {
-                serde_json::Number::from_f64(f)
-                    .map(JsonValue::Number)
-                    .ok_or_else(|| type_cast_error("float", path))
-            }),
-        JsonValue::String(s) => s
-            .parse::<f64>()
-            .map_err(|_| type_cast_error("float", path))
-            .and_then(|f| {
-                serde_json::Number::from_f64(f)
-                    .map(JsonValue::Number)
-                    .ok_or_else(|| type_cast_error("float", path))
-            }),
-        _ => Err(type_cast_error("float", path)),
-    }
-}
-
-fn cast_to_bool(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
-    match value {
-        JsonValue::Bool(b) => Ok(JsonValue::Bool(*b)),
-        JsonValue::String(s) => match s.to_lowercase().as_str() {
-            "true" => Ok(JsonValue::Bool(true)),
-            "false" => Ok(JsonValue::Bool(false)),
-            _ => Err(type_cast_error("bool", path)),
-        },
-        _ => Err(type_cast_error("bool", path)),
-    }
-}
-
-fn type_cast_error(type_name: &str, path: &str) -> TransformError {
-    TransformError::new(
-        TransformErrorKind::ExprError,
-        format!("failed to cast to {}", type_name),
-    )
-    .with_path(path)
-}
-
-fn eval_type_cast(op: &str, value: &EvalValue, path: &str) -> Result<EvalValue, TransformError> {
-    match value {
-        EvalValue::Missing => Ok(EvalValue::Missing),
-        EvalValue::Value(v) => {
-            let casted = match op {
-                "string" => JsonValue::String(value_to_string(v, path)?),
-                "int" => cast_to_int(v, path)?,
-                "float" => cast_to_float(v, path)?,
-                "bool" => cast_to_bool(v, path)?,
-                _ => {
-                    return Err(TransformError::new(
-                        TransformErrorKind::ExprError,
-                        "unknown cast op",
-                    )
-                    .with_path(path));
-                }
-            };
-            Ok(EvalValue::Value(casted))
-        }
     }
 }
 

--- a/crates/rulemorph/src/v2_eval/cast.rs
+++ b/crates/rulemorph/src/v2_eval/cast.rs
@@ -1,0 +1,95 @@
+use serde_json::Value as JsonValue;
+
+use super::{EvalValue, value_to_string};
+use crate::error::{TransformError, TransformErrorKind};
+
+fn cast_to_int(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
+    match value {
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(JsonValue::Number(i.into()))
+            } else if let Some(f) = n.as_f64() {
+                if (f.fract()).abs() < f64::EPSILON {
+                    Ok(JsonValue::Number((f as i64).into()))
+                } else {
+                    Err(type_cast_error("int", path))
+                }
+            } else {
+                Err(type_cast_error("int", path))
+            }
+        }
+        JsonValue::String(s) => s
+            .parse::<i64>()
+            .map(|i| JsonValue::Number(i.into()))
+            .map_err(|_| type_cast_error("int", path)),
+        _ => Err(type_cast_error("int", path)),
+    }
+}
+
+fn cast_to_float(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
+    match value {
+        JsonValue::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| type_cast_error("float", path))
+            .and_then(|f| {
+                serde_json::Number::from_f64(f)
+                    .map(JsonValue::Number)
+                    .ok_or_else(|| type_cast_error("float", path))
+            }),
+        JsonValue::String(s) => s
+            .parse::<f64>()
+            .map_err(|_| type_cast_error("float", path))
+            .and_then(|f| {
+                serde_json::Number::from_f64(f)
+                    .map(JsonValue::Number)
+                    .ok_or_else(|| type_cast_error("float", path))
+            }),
+        _ => Err(type_cast_error("float", path)),
+    }
+}
+
+fn cast_to_bool(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
+    match value {
+        JsonValue::Bool(b) => Ok(JsonValue::Bool(*b)),
+        JsonValue::String(s) => match s.to_lowercase().as_str() {
+            "true" => Ok(JsonValue::Bool(true)),
+            "false" => Ok(JsonValue::Bool(false)),
+            _ => Err(type_cast_error("bool", path)),
+        },
+        _ => Err(type_cast_error("bool", path)),
+    }
+}
+
+fn type_cast_error(type_name: &str, path: &str) -> TransformError {
+    TransformError::new(
+        TransformErrorKind::ExprError,
+        format!("failed to cast to {}", type_name),
+    )
+    .with_path(path)
+}
+
+pub(super) fn eval_type_cast(
+    op: &str,
+    value: &EvalValue,
+    path: &str,
+) -> Result<EvalValue, TransformError> {
+    match value {
+        EvalValue::Missing => Ok(EvalValue::Missing),
+        EvalValue::Value(v) => {
+            let casted = match op {
+                "string" => JsonValue::String(value_to_string(v, path)?),
+                "int" => cast_to_int(v, path)?,
+                "float" => cast_to_float(v, path)?,
+                "bool" => cast_to_bool(v, path)?,
+                _ => {
+                    return Err(TransformError::new(
+                        TransformErrorKind::ExprError,
+                        "unknown cast op",
+                    )
+                    .with_path(path));
+                }
+            };
+            Ok(EvalValue::Value(casted))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move v2 type-cast helpers into an internal sibling module
- keep shared value_to_string/number_to_string in the parent module because they are used outside casts
- keep public v2_eval facade exports and eval_v2_op_step signature unchanged
- leave transform semantics and trace JSON schema unchanged

## Verification
- cargo fmt
- cargo fmt --check
- cargo test -p rulemorph v2_eval::tests::v2_op_step_eval_tests::test_eval_op_type_casts
- cargo test -p rulemorph --lib v2_eval
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph --test transform_golden t13_expr_extended
- cargo test -p rulemorph --test transform_golden tv27_v1_compat
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test
- git diff --check
- git diff --cached --check