### PR TITLE
Split v2 eval comparison helpers

### DIFF
--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -10,6 +10,7 @@ use crate::error::{TransformError, TransformErrorKind};
 use crate::v2_model::{V2Expr, V2OpStep, V2Pipe, V2Start};
 
 mod cast;
+mod comparison;
 mod condition;
 mod context;
 mod control;
@@ -19,6 +20,7 @@ mod tests;
 mod v1_bridge;
 
 use cast::eval_type_cast;
+use comparison::eval_comparison_op;
 use condition::compare_values_eq;
 pub use condition::eval_v2_condition;
 pub use context::{EvalItem, EvalValue, V2EvalContext};
@@ -98,80 +100,6 @@ fn value_as_bool(value: &JsonValue, path: &str) -> Result<bool, TransformError> 
                 .with_path(path),
         ),
     }
-}
-
-fn value_as_string(value: &JsonValue, path: &str) -> Result<String, TransformError> {
-    match value {
-        JsonValue::String(value) => Ok(value.clone()),
-        _ => Err(
-            TransformError::new(TransformErrorKind::ExprError, "value must be a string")
-                .with_path(path),
-        ),
-    }
-}
-
-fn value_to_number(value: &JsonValue, path: &str, message: &str) -> Result<f64, TransformError> {
-    match value {
-        JsonValue::Number(n) => n.as_f64().filter(|f| f.is_finite()).ok_or_else(|| {
-            TransformError::new(TransformErrorKind::ExprError, message).with_path(path)
-        }),
-        JsonValue::String(s) => s
-            .parse::<f64>()
-            .ok()
-            .filter(|f| f.is_finite())
-            .ok_or_else(|| {
-                TransformError::new(TransformErrorKind::ExprError, message).with_path(path)
-            }),
-        _ => Err(TransformError::new(TransformErrorKind::ExprError, message).with_path(path)),
-    }
-}
-
-fn compare_eq_v1(
-    left: &JsonValue,
-    right: &JsonValue,
-    left_path: &str,
-    right_path: &str,
-) -> Result<bool, TransformError> {
-    if left.is_null() || right.is_null() {
-        return Ok(left.is_null() && right.is_null());
-    }
-
-    let left_value = value_to_string(left, left_path)?;
-    let right_value = value_to_string(right, right_path)?;
-    Ok(left_value == right_value)
-}
-
-fn compare_numbers_v1<F>(
-    left: &JsonValue,
-    right: &JsonValue,
-    left_path: &str,
-    right_path: &str,
-    compare: F,
-) -> Result<bool, TransformError>
-where
-    F: FnOnce(f64, f64) -> bool,
-{
-    let left_value = value_to_number(left, left_path, "comparison operand must be a number")?;
-    let right_value = value_to_number(right, right_path, "comparison operand must be a number")?;
-    Ok(compare(left_value, right_value))
-}
-
-fn match_regex_v1(
-    left: &JsonValue,
-    right: &JsonValue,
-    left_path: &str,
-    right_path: &str,
-) -> Result<bool, TransformError> {
-    let value = value_as_string(left, left_path)?;
-    let pattern = value_as_string(right, right_path)?;
-    let regex = regex::Regex::new(&pattern).map_err(|e| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            format!("invalid regex pattern: {}", e),
-        )
-        .with_path(right_path)
-    })?;
-    Ok(regex.is_match(&value))
 }
 
 fn eval_v2_expr_or_null<'a>(
@@ -1150,48 +1078,7 @@ pub fn eval_v2_op_step<'a>(
         }
         "==" | "!=" | "<" | "<=" | ">" | ">=" | "~=" | "eq" | "ne" | "lt" | "lte" | "gt"
         | "gte" | "match" => {
-            if op_step.args.len() != 1 {
-                return Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "expr.args must contain exactly one item",
-                )
-                .with_path(format!("{}.args", path)));
-            }
-            let left = match pipe_value {
-                EvalValue::Missing => JsonValue::Null,
-                EvalValue::Value(value) => value,
-            };
-            let right_path = format!("{}.args[0]", path);
-            let right = eval_v2_expr_or_null(
-                &op_step.args[0],
-                record,
-                context,
-                out,
-                &right_path,
-                &step_ctx,
-            )?;
-            let left_path = path.to_string();
-            let op = match op_step.op.as_str() {
-                "eq" => "==",
-                "ne" => "!=",
-                "lt" => "<",
-                "lte" => "<=",
-                "gt" => ">",
-                "gte" => ">=",
-                "match" => "~=",
-                other => other,
-            };
-            let result = match op {
-                "==" => compare_eq_v1(&left, &right, &left_path, &right_path)?,
-                "!=" => !compare_eq_v1(&left, &right, &left_path, &right_path)?,
-                "<" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l < r)?,
-                "<=" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l <= r)?,
-                ">" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l > r)?,
-                ">=" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l >= r)?,
-                "~=" => match_regex_v1(&left, &right, &left_path, &right_path)?,
-                _ => false,
-            };
-            Ok(EvalValue::Value(JsonValue::Bool(result)))
+            eval_comparison_op(op_step, pipe_value, record, context, out, path, &step_ctx)
         }
         "pick" | "omit" => {
             if op_step.args.is_empty() {

--- a/crates/rulemorph/src/v2_eval/comparison.rs
+++ b/crates/rulemorph/src/v2_eval/comparison.rs
@@ -1,0 +1,125 @@
+use serde_json::Value as JsonValue;
+
+use super::{EvalValue, V2EvalContext, eval_v2_expr_or_null, value_to_string};
+use crate::error::{TransformError, TransformErrorKind};
+use crate::v2_model::V2OpStep;
+
+fn value_as_string(value: &JsonValue, path: &str) -> Result<String, TransformError> {
+    match value {
+        JsonValue::String(value) => Ok(value.clone()),
+        _ => Err(
+            TransformError::new(TransformErrorKind::ExprError, "value must be a string")
+                .with_path(path),
+        ),
+    }
+}
+
+fn value_to_number(value: &JsonValue, path: &str, message: &str) -> Result<f64, TransformError> {
+    match value {
+        JsonValue::Number(n) => n.as_f64().filter(|f| f.is_finite()).ok_or_else(|| {
+            TransformError::new(TransformErrorKind::ExprError, message).with_path(path)
+        }),
+        JsonValue::String(s) => s
+            .parse::<f64>()
+            .ok()
+            .filter(|f| f.is_finite())
+            .ok_or_else(|| {
+                TransformError::new(TransformErrorKind::ExprError, message).with_path(path)
+            }),
+        _ => Err(TransformError::new(TransformErrorKind::ExprError, message).with_path(path)),
+    }
+}
+
+fn compare_eq_v1(
+    left: &JsonValue,
+    right: &JsonValue,
+    left_path: &str,
+    right_path: &str,
+) -> Result<bool, TransformError> {
+    if left.is_null() || right.is_null() {
+        return Ok(left.is_null() && right.is_null());
+    }
+
+    let left_value = value_to_string(left, left_path)?;
+    let right_value = value_to_string(right, right_path)?;
+    Ok(left_value == right_value)
+}
+
+fn compare_numbers_v1<F>(
+    left: &JsonValue,
+    right: &JsonValue,
+    left_path: &str,
+    right_path: &str,
+    compare: F,
+) -> Result<bool, TransformError>
+where
+    F: FnOnce(f64, f64) -> bool,
+{
+    let left_value = value_to_number(left, left_path, "comparison operand must be a number")?;
+    let right_value = value_to_number(right, right_path, "comparison operand must be a number")?;
+    Ok(compare(left_value, right_value))
+}
+
+fn match_regex_v1(
+    left: &JsonValue,
+    right: &JsonValue,
+    left_path: &str,
+    right_path: &str,
+) -> Result<bool, TransformError> {
+    let value = value_as_string(left, left_path)?;
+    let pattern = value_as_string(right, right_path)?;
+    let regex = regex::Regex::new(&pattern).map_err(|e| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            format!("invalid regex pattern: {}", e),
+        )
+        .with_path(right_path)
+    })?;
+    Ok(regex.is_match(&value))
+}
+
+pub(super) fn eval_comparison_op<'a>(
+    op_step: &V2OpStep,
+    pipe_value: EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    if op_step.args.len() != 1 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly one item",
+        )
+        .with_path(format!("{}.args", path)));
+    }
+    let left = match pipe_value {
+        EvalValue::Missing => JsonValue::Null,
+        EvalValue::Value(value) => value,
+    };
+    let right_path = format!("{}.args[0]", path);
+    let right = eval_v2_expr_or_null(&op_step.args[0], record, context, out, &right_path, ctx)?;
+    let left_path = path.to_string();
+    let op = match op_step.op.as_str() {
+        "eq" => "==",
+        "ne" => "!=",
+        "lt" => "<",
+        "lte" => "<=",
+        "gt" => ">",
+        "gte" => ">=",
+        "match" => "~=",
+        other => other,
+    };
+    let result = match op {
+        "==" => compare_eq_v1(&left, &right, &left_path, &right_path)?,
+        "!=" => !compare_eq_v1(&left, &right, &left_path, &right_path)?,
+        "<" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l < r)?,
+        "<=" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l <= r)?,
+        ">" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l > r)?,
+        ">=" => compare_numbers_v1(&left, &right, &left_path, &right_path, |l, r| l >= r)?,
+        "~=" => match_regex_v1(&left, &right, &left_path, &right_path)?,
+        _ => false,
+    };
+    Ok(EvalValue::Value(JsonValue::Bool(result)))
+}

--- a/crates/rulemorph/src/v2_eval/tests.rs
+++ b/crates/rulemorph/src/v2_eval/tests.rs
@@ -913,6 +913,115 @@ mod v2_op_step_eval_tests {
     }
 
     #[test]
+    fn test_eval_op_comparison_symbols() {
+        let ctx = V2EvalContext::new();
+        let cases = [
+            ("==", json!(1), json!("1"), true),
+            ("!=", json!(1), json!(2), true),
+            ("<", json!(5), json!(10), true),
+            ("<=", json!(10), json!(10), true),
+            (">", json!(10), json!(5), true),
+            (">=", json!(10), json!(10), true),
+            ("~=", json!("apple"), json!("^a.*"), true),
+        ];
+
+        for (op, left, right, expected) in cases {
+            let op_step = V2OpStep {
+                op: op.to_string(),
+                args: vec![lit(right)],
+            };
+            let result = eval_v2_op_step(
+                &op_step,
+                EvalValue::Value(left),
+                &json!({}),
+                None,
+                &json!({}),
+                "test",
+                &ctx,
+            );
+            assert!(
+                matches!(result, Ok(EvalValue::Value(v)) if v == json!(expected)),
+                "op {}",
+                op
+            );
+        }
+    }
+
+    #[test]
+    fn test_eval_op_comparison_missing_null_semantics() {
+        let ctx = V2EvalContext::new();
+        let missing_eq_null = V2OpStep {
+            op: "eq".to_string(),
+            args: vec![lit(json!(null))],
+        };
+        let result = eval_v2_op_step(
+            &missing_eq_null,
+            EvalValue::Missing,
+            &json!({}),
+            None,
+            &json!({}),
+            "test",
+            &ctx,
+        );
+        assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(true)));
+
+        let missing_ne_value = V2OpStep {
+            op: "ne".to_string(),
+            args: vec![lit(json!("value"))],
+        };
+        let result = eval_v2_op_step(
+            &missing_ne_value,
+            EvalValue::Missing,
+            &json!({}),
+            None,
+            &json!({}),
+            "test",
+            &ctx,
+        );
+        assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(true)));
+    }
+
+    #[test]
+    fn test_eval_op_comparison_error_paths() {
+        let ctx = V2EvalContext::new();
+        let non_numeric_compare = V2OpStep {
+            op: "<".to_string(),
+            args: vec![lit(json!(1))],
+        };
+        let err = eval_v2_op_step(
+            &non_numeric_compare,
+            EvalValue::Value(json!("not-a-number")),
+            &json!({}),
+            None,
+            &json!({}),
+            "test",
+            &ctx,
+        )
+        .expect_err("non-numeric comparison should error");
+        assert_eq!(err.kind, TransformErrorKind::ExprError);
+        assert_eq!(err.message, "comparison operand must be a number");
+        assert_eq!(err.path.as_deref(), Some("test"));
+
+        let invalid_regex = V2OpStep {
+            op: "~=".to_string(),
+            args: vec![lit(json!("["))],
+        };
+        let err = eval_v2_op_step(
+            &invalid_regex,
+            EvalValue::Value(json!("apple")),
+            &json!({}),
+            None,
+            &json!({}),
+            "test",
+            &ctx,
+        )
+        .expect_err("invalid regex should error");
+        assert_eq!(err.kind, TransformErrorKind::ExprError);
+        assert!(err.message.starts_with("invalid regex pattern:"));
+        assert_eq!(err.path.as_deref(), Some("test.args[0]"));
+    }
+
+    #[test]
     fn test_eval_op_pick_multiple_paths() {
         let op = V2OpStep {
             op: "pick".to_string(),


### PR DESCRIPTION
## Summary
- split v2 op-step comparison helpers into an internal v2_eval/comparison module
- add characterization tests for comparison symbol spellings, missing/null behavior, and error paths
- keep eval_v2_op_step facade, transform semantics, and trace schema unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --lib v2_eval::tests::v2_op_step_eval_tests::test_eval_op_comparison
- cargo test -p rulemorph --lib v2_eval
- cargo test -p rulemorph --test v2_conditions
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test -p rulemorph --test transform_golden
- cargo check -p rulemorph_endpoint
- cargo fmt --check
- git diff --check
- cargo test --quiet