### PR TITLE
Refactor MCP resources and prompts

### DIFF
--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -15,17 +15,15 @@ use rulemorph::{
 use serde_json::{Map, Value, json};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 
+mod prompts;
 mod protocol;
+mod resources;
 
+use self::prompts::{prompts_get_result, prompts_list_result};
 use self::protocol::{OutputMode, read_message, write_message};
+use self::resources::{resources_list_result, resources_read_result};
 
 const PROTOCOL_VERSION: &str = "2024-11-05";
-const RESOURCE_URI_RULES_SPEC_EN: &str = "rulemorph://docs/rules_spec_en";
-const RESOURCE_URI_RULES_SPEC_JA: &str = "rulemorph://docs/rules_spec_ja";
-const RESOURCE_URI_README: &str = "rulemorph://docs/readme";
-const RESOURCE_RULES_SPEC_EN: &str = include_str!("../../../docs/rules_spec_en.md");
-const RESOURCE_RULES_SPEC_JA: &str = include_str!("../../../docs/rules_spec_ja.md");
-const RESOURCE_README: &str = include_str!("../../../README.md");
 const MCP_MAX_FILE_BYTES: usize = 64 * 1024 * 1024;
 
 fn main() {
@@ -195,179 +193,6 @@ fn tools_list_result() -> Value {
             }
         ]
     })
-}
-
-fn resources_list_result() -> Value {
-    json!({
-        "resources": [
-            {
-                "uri": RESOURCE_URI_RULES_SPEC_EN,
-                "name": "rules_spec_en",
-                "description": "Rule specification (English).",
-                "mimeType": "text/markdown"
-            },
-            {
-                "uri": RESOURCE_URI_RULES_SPEC_JA,
-                "name": "rules_spec_ja",
-                "description": "ルール仕様 (日本語).",
-                "mimeType": "text/markdown"
-            },
-            {
-                "uri": RESOURCE_URI_README,
-                "name": "readme",
-                "description": "Project README.",
-                "mimeType": "text/markdown"
-            }
-        ]
-    })
-}
-
-fn resources_read_result(params: &Value) -> Result<Value, String> {
-    let obj = params
-        .as_object()
-        .ok_or_else(|| "params must be an object".to_string())?;
-    let uri = obj
-        .get("uri")
-        .and_then(|value| value.as_str())
-        .ok_or_else(|| "params.uri is required".to_string())?;
-    let text = match uri {
-        RESOURCE_URI_RULES_SPEC_EN => RESOURCE_RULES_SPEC_EN,
-        RESOURCE_URI_RULES_SPEC_JA => RESOURCE_RULES_SPEC_JA,
-        RESOURCE_URI_README => RESOURCE_README,
-        _ => return Err("unknown resource uri".to_string()),
-    };
-
-    Ok(json!({
-        "contents": [
-            {
-                "uri": uri,
-                "mimeType": "text/markdown",
-                "text": text
-            }
-        ]
-    }))
-}
-
-fn prompts_list_result() -> Value {
-    json!({
-        "prompts": [
-            {
-                "name": "rule_from_input_base",
-                "description": "Generate rules from base rules and input samples.",
-                "arguments": [
-                    { "name": "rules_text", "description": "Base rules YAML.", "required": true },
-                    { "name": "input_sample", "description": "Input sample (JSON/CSV).", "required": true },
-                    { "name": "format", "description": "Sample format for rule generation (json or csv).", "required": false },
-                    { "name": "records_path", "description": "Records path for JSON input.", "required": false }
-                ]
-            },
-            {
-                "name": "rule_from_dto",
-                "description": "Generate rules from DTO schema and input samples.",
-                "arguments": [
-                    { "name": "dto_text", "description": "DTO source text.", "required": true },
-                    { "name": "dto_language", "description": "DTO language (rust/typescript).", "required": true },
-                    { "name": "input_sample", "description": "Input sample (JSON/CSV).", "required": true },
-                    { "name": "format", "description": "Sample format for rule generation (json or csv).", "required": false },
-                    { "name": "records_path", "description": "Records path for JSON input.", "required": false }
-                ]
-            },
-            {
-                "name": "explain_errors",
-                "description": "Explain validation/transform errors and suggest fixes.",
-                "arguments": [
-                    { "name": "errors_json", "description": "Errors array from tool output.", "required": true },
-                    { "name": "rules_text", "description": "Optional rules YAML for context.", "required": false }
-                ]
-            }
-        ]
-    })
-}
-
-fn prompts_get_result(params: &Value) -> Result<Value, String> {
-    let obj = params
-        .as_object()
-        .ok_or_else(|| "params must be an object".to_string())?;
-    let name = obj
-        .get("name")
-        .and_then(|value| value.as_str())
-        .ok_or_else(|| "params.name is required".to_string())?;
-    let args = obj.get("arguments").and_then(|value| value.as_object());
-
-    let (description, template) = match name {
-        "rule_from_input_base" => (
-            "Generate rules from base rules and input samples.",
-            r#"You are generating a rulemorph YAML file.
-The base rules define the output shape. Keep existing expr/value/default/required unless mapping is unresolved.
-Use the input sample to map sources. Unmapped targets must use value: null and required: false.
-Return YAML only.
-
-Base rules:
-{{rules_text}}
-
-Input sample:
-{{input_sample}}
-
-Optional format: {{format}}
-Optional records_path: {{records_path}}
-"#,
-        ),
-        "rule_from_dto" => (
-            "Generate rules from DTO schema and input samples.",
-            r#"You are generating a rulemorph YAML file whose output matches the DTO schema.
-Use the input sample to map sources. Unmapped targets must use value: null and required: false.
-Return YAML only.
-
-DTO:
-{{dto_text}}
-
-DTO language: {{dto_language}}
-
-Input sample:
-{{input_sample}}
-
-Optional format: {{format}}
-Optional records_path: {{records_path}}
-"#,
-        ),
-        "explain_errors" => (
-            "Explain validation/transform errors and suggest fixes.",
-            r#"Explain the following validation/transform errors and suggest fixes.
-
-Errors:
-{{errors_json}}
-
-Rules (optional):
-{{rules_text}}
-"#,
-        ),
-        _ => return Err("unknown prompt name".to_string()),
-    };
-
-    let content = apply_prompt_args(template, args);
-    Ok(json!({
-        "description": description,
-        "messages": [
-            {
-                "role": "user",
-                "content": content
-            }
-        ]
-    }))
-}
-
-fn apply_prompt_args(template: &str, args: Option<&Map<String, Value>>) -> String {
-    let mut content = template.to_string();
-    if let Some(args) = args {
-        for (key, value) in args {
-            let replacement = match value {
-                Value::String(value) => value.clone(),
-                _ => value.to_string(),
-            };
-            content = content.replace(&format!("{{{{{}}}}}", key), &replacement);
-        }
-    }
-    content
 }
 
 fn transform_input_schema() -> Value {

--- a/crates/rulemorph_mcp/src/prompts.rs
+++ b/crates/rulemorph_mcp/src/prompts.rs
@@ -1,0 +1,123 @@
+use serde_json::{Map, Value, json};
+
+pub(crate) fn prompts_list_result() -> Value {
+    json!({
+        "prompts": [
+            {
+                "name": "rule_from_input_base",
+                "description": "Generate rules from base rules and input samples.",
+                "arguments": [
+                    { "name": "rules_text", "description": "Base rules YAML.", "required": true },
+                    { "name": "input_sample", "description": "Input sample (JSON/CSV).", "required": true },
+                    { "name": "format", "description": "Sample format for rule generation (json or csv).", "required": false },
+                    { "name": "records_path", "description": "Records path for JSON input.", "required": false }
+                ]
+            },
+            {
+                "name": "rule_from_dto",
+                "description": "Generate rules from DTO schema and input samples.",
+                "arguments": [
+                    { "name": "dto_text", "description": "DTO source text.", "required": true },
+                    { "name": "dto_language", "description": "DTO language (rust/typescript).", "required": true },
+                    { "name": "input_sample", "description": "Input sample (JSON/CSV).", "required": true },
+                    { "name": "format", "description": "Sample format for rule generation (json or csv).", "required": false },
+                    { "name": "records_path", "description": "Records path for JSON input.", "required": false }
+                ]
+            },
+            {
+                "name": "explain_errors",
+                "description": "Explain validation/transform errors and suggest fixes.",
+                "arguments": [
+                    { "name": "errors_json", "description": "Errors array from tool output.", "required": true },
+                    { "name": "rules_text", "description": "Optional rules YAML for context.", "required": false }
+                ]
+            }
+        ]
+    })
+}
+
+pub(crate) fn prompts_get_result(params: &Value) -> Result<Value, String> {
+    let obj = params
+        .as_object()
+        .ok_or_else(|| "params must be an object".to_string())?;
+    let name = obj
+        .get("name")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "params.name is required".to_string())?;
+    let args = obj.get("arguments").and_then(|value| value.as_object());
+
+    let (description, template) = match name {
+        "rule_from_input_base" => (
+            "Generate rules from base rules and input samples.",
+            r#"You are generating a rulemorph YAML file.
+The base rules define the output shape. Keep existing expr/value/default/required unless mapping is unresolved.
+Use the input sample to map sources. Unmapped targets must use value: null and required: false.
+Return YAML only.
+
+Base rules:
+{{rules_text}}
+
+Input sample:
+{{input_sample}}
+
+Optional format: {{format}}
+Optional records_path: {{records_path}}
+"#,
+        ),
+        "rule_from_dto" => (
+            "Generate rules from DTO schema and input samples.",
+            r#"You are generating a rulemorph YAML file whose output matches the DTO schema.
+Use the input sample to map sources. Unmapped targets must use value: null and required: false.
+Return YAML only.
+
+DTO:
+{{dto_text}}
+
+DTO language: {{dto_language}}
+
+Input sample:
+{{input_sample}}
+
+Optional format: {{format}}
+Optional records_path: {{records_path}}
+"#,
+        ),
+        "explain_errors" => (
+            "Explain validation/transform errors and suggest fixes.",
+            r#"Explain the following validation/transform errors and suggest fixes.
+
+Errors:
+{{errors_json}}
+
+Rules (optional):
+{{rules_text}}
+"#,
+        ),
+        _ => return Err("unknown prompt name".to_string()),
+    };
+
+    let content = apply_prompt_args(template, args);
+    Ok(json!({
+        "description": description,
+        "messages": [
+            {
+                "role": "user",
+                "content": content
+            }
+        ]
+    }))
+}
+
+fn apply_prompt_args(template: &str, args: Option<&Map<String, Value>>) -> String {
+    let mut content = template.to_string();
+    if let Some(args) = args {
+        for (key, value) in args {
+            let replacement = match value {
+                Value::String(value) => value.clone(),
+                _ => value.to_string(),
+            };
+            content = content.replace(&format!("{{{{{}}}}}", key), &replacement);
+        }
+    }
+    content
+}

--- a/crates/rulemorph_mcp/src/resources.rs
+++ b/crates/rulemorph_mcp/src/resources.rs
@@ -1,0 +1,59 @@
+use serde_json::{Value, json};
+
+const RESOURCE_URI_RULES_SPEC_EN: &str = "rulemorph://docs/rules_spec_en";
+const RESOURCE_URI_RULES_SPEC_JA: &str = "rulemorph://docs/rules_spec_ja";
+const RESOURCE_URI_README: &str = "rulemorph://docs/readme";
+const RESOURCE_RULES_SPEC_EN: &str = include_str!("../../../docs/rules_spec_en.md");
+const RESOURCE_RULES_SPEC_JA: &str = include_str!("../../../docs/rules_spec_ja.md");
+const RESOURCE_README: &str = include_str!("../../../README.md");
+
+pub(crate) fn resources_list_result() -> Value {
+    json!({
+        "resources": [
+            {
+                "uri": RESOURCE_URI_RULES_SPEC_EN,
+                "name": "rules_spec_en",
+                "description": "Rule specification (English).",
+                "mimeType": "text/markdown"
+            },
+            {
+                "uri": RESOURCE_URI_RULES_SPEC_JA,
+                "name": "rules_spec_ja",
+                "description": "ルール仕様 (日本語).",
+                "mimeType": "text/markdown"
+            },
+            {
+                "uri": RESOURCE_URI_README,
+                "name": "readme",
+                "description": "Project README.",
+                "mimeType": "text/markdown"
+            }
+        ]
+    })
+}
+
+pub(crate) fn resources_read_result(params: &Value) -> Result<Value, String> {
+    let obj = params
+        .as_object()
+        .ok_or_else(|| "params must be an object".to_string())?;
+    let uri = obj
+        .get("uri")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "params.uri is required".to_string())?;
+    let text = match uri {
+        RESOURCE_URI_RULES_SPEC_EN => RESOURCE_RULES_SPEC_EN,
+        RESOURCE_URI_RULES_SPEC_JA => RESOURCE_RULES_SPEC_JA,
+        RESOURCE_URI_README => RESOURCE_README,
+        _ => return Err("unknown resource uri".to_string()),
+    };
+
+    Ok(json!({
+        "contents": [
+            {
+                "uri": uri,
+                "mimeType": "text/markdown",
+                "text": text
+            }
+        ]
+    }))
+}


### PR DESCRIPTION
## Summary
- Split MCP resources/list and resources/read helpers into `resources.rs`
- Split MCP prompts/list and prompts/get helpers into `prompts.rs`
- Keep MCP resource/prompt JSON shapes, error text, tool schemas, and tool execution unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio resources_list_and_read
- cargo test -p rulemorph_mcp --test stdio prompts_list_and_get
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet

## Review
- Subagent spec review: PASS for MCP public contract; unrelated untracked artifacts intentionally excluded from staging
- Subagent quality review: PASS for target files and dependency direction