### PR TITLE
Refactor MCP list ops tool

### DIFF
--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -19,6 +19,7 @@ mod prompts;
 mod protocol;
 mod resources;
 mod schemas;
+mod tools;
 
 use self::prompts::{prompts_get_result, prompts_list_result};
 use self::protocol::{OutputMode, read_message, write_message};
@@ -28,6 +29,7 @@ use self::schemas::{
     generate_rules_from_dto_input_schema, list_ops_input_schema, transform_input_schema,
     validate_rules_input_schema,
 };
+use self::tools::list_ops::run_list_ops_tool;
 
 const PROTOCOL_VERSION: &str = "2024-11-05";
 const MCP_MAX_FILE_BYTES: usize = 64 * 1024 * 1024;
@@ -228,7 +230,7 @@ fn handle_tools_call(params: &Value) -> Result<Value, CallError> {
         "transform" => run_transform_tool(args),
         "validate_rules" => run_validate_rules_tool(args),
         "generate_dto" => run_generate_dto_tool(args),
-        "list_ops" => run_list_ops_tool(),
+        "list_ops" => Ok(run_list_ops_tool()),
         "analyze_input" => run_analyze_input_tool(args),
         "generate_rules_from_base" => run_generate_rules_from_base_tool(args),
         "generate_rules_from_dto" => run_generate_rules_from_dto_tool(args),
@@ -588,224 +590,6 @@ fn run_generate_dto_tool(args: &Map<String, Value>) -> Result<Value, CallError> 
             }
         ],
         "meta": meta
-    }))
-}
-
-fn run_list_ops_tool() -> Result<Value, CallError> {
-    let ops = json!({
-        "expr_ops": [
-            "concat",
-            "coalesce",
-            "to_string",
-            "trim",
-            "lowercase",
-            "uppercase",
-            "replace",
-            "split",
-            "pad_start",
-            "pad_end",
-            "lookup",
-            "lookup_first",
-            "merge",
-            "deep_merge",
-            "get",
-            "pick",
-            "omit",
-            "keys",
-            "values",
-            "entries",
-            "len",
-            "from_entries",
-            "object_flatten",
-            "object_unflatten",
-            "map",
-            "filter",
-            "flat_map",
-            "flatten",
-            "take",
-            "drop",
-            "slice",
-            "chunk",
-            "zip",
-            "zip_with",
-            "unzip",
-            "group_by",
-            "key_by",
-            "partition",
-            "unique",
-            "distinct_by",
-            "sort_by",
-            "find",
-            "find_index",
-            "index_of",
-            "contains",
-            "sum",
-            "avg",
-            "min",
-            "max",
-            "reduce",
-            "fold",
-            "+",
-            "-",
-            "*",
-            "/",
-            "round",
-            "to_base",
-            "date_format",
-            "to_unixtime"
-        ],
-        "categories": {
-            "string_ops": [
-                "concat",
-                "to_string",
-                "trim",
-                "lowercase",
-                "uppercase",
-                "replace",
-                "split",
-                "pad_start",
-                "pad_end"
-            ],
-            "json_ops": [
-                "merge",
-                "deep_merge",
-                "get",
-                "pick",
-                "omit",
-                "keys",
-                "values",
-                "entries",
-                "len",
-                "from_entries",
-                "object_flatten",
-                "object_unflatten"
-            ],
-            "array_ops": [
-                "map",
-                "filter",
-                "flat_map",
-                "flatten",
-                "take",
-                "drop",
-                "slice",
-                "chunk",
-                "zip",
-                "zip_with",
-                "unzip",
-                "group_by",
-                "key_by",
-                "partition",
-                "unique",
-                "distinct_by",
-                "sort_by",
-                "find",
-                "find_index",
-                "index_of",
-                "contains",
-                "sum",
-                "avg",
-                "min",
-                "max",
-                "reduce",
-                "fold"
-            ],
-            "numeric_ops": ["+", "-", "*", "/", "round", "to_base", "sum", "avg", "min", "max"],
-            "date_ops": ["date_format", "to_unixtime"]
-        },
-        "category_docs": {
-            "string_ops": {
-                "summary": "String transformations and formatting.",
-                "examples": [
-                    {
-                        "op": "replace",
-                        "expr": { "op": "replace", "args": ["a-b", "-", "_", "all"] }
-                    },
-                    {
-                        "op": "concat",
-                        "expr": {
-                            "op": "concat",
-                            "args": [ { "ref": "input.first" }, " ", { "ref": "input.last" } ]
-                        }
-                    }
-                ]
-            },
-            "json_ops": {
-                "summary": "Object merge and structural helpers.",
-                "examples": [
-                    {
-                        "op": "merge",
-                        "expr": {
-                            "op": "merge",
-                            "args": [ { "ref": "input.base" }, { "ref": "context.override" } ]
-                        }
-                    },
-                    {
-                        "op": "get",
-                        "expr": { "op": "get", "args": [ { "ref": "input.obj" }, "id" ] }
-                    },
-                    {
-                        "op": "pick",
-                        "expr": { "op": "pick", "args": [ { "ref": "input.obj" }, ["id"] ] }
-                    }
-                ]
-            },
-            "array_ops": {
-                "summary": "Array transforms and aggregations.",
-                "examples": [
-                    {
-                        "op": "map",
-                        "expr": {
-                            "op": "map",
-                            "args": [ { "ref": "input.values" }, { "ref": "item.value" } ]
-                        }
-                    },
-                    {
-                        "op": "filter",
-                        "expr": {
-                            "op": "filter",
-                            "args": [
-                                { "ref": "input.values" },
-                                { "op": ">", "args": [ { "ref": "item.value" }, 0 ] }
-                            ]
-                        }
-                    }
-                ]
-            },
-            "numeric_ops": {
-                "summary": "Numeric arithmetic and formatting.",
-                "examples": [
-                    { "op": "+", "expr": { "op": "+", "args": [1, 2, 3] } },
-                    { "op": "round", "expr": { "op": "round", "args": [12.345, 2] } }
-                ]
-            },
-            "date_ops": {
-                "summary": "Date/time parsing and formatting.",
-                "examples": [
-                    {
-                        "op": "date_format",
-                        "expr": { "op": "date_format", "args": ["2024-01-02", "%Y/%m/%d"] }
-                    }
-                ]
-            }
-        },
-        "logical_ops": ["and", "or", "not"],
-        "comparison_ops": ["==", "!=", "<", "<=", ">", ">=", "~="],
-        "type_casts": ["string", "int", "float", "bool"]
-    });
-
-    let text = serde_json::to_string_pretty(&ops)
-        .unwrap_or_else(|_| "{\"error\":\"failed to serialize ops\"}".to_string());
-
-    Ok(json!({
-        "content": [
-            {
-                "type": "text",
-                "text": text
-            }
-        ],
-        "meta": {
-            "ops": ops
-        }
     }))
 }
 

--- a/crates/rulemorph_mcp/src/tools/list_ops.rs
+++ b/crates/rulemorph_mcp/src/tools/list_ops.rs
@@ -1,0 +1,219 @@
+use serde_json::{Value, json};
+
+pub(crate) fn run_list_ops_tool() -> Value {
+    let ops = json!({
+        "expr_ops": [
+            "concat",
+            "coalesce",
+            "to_string",
+            "trim",
+            "lowercase",
+            "uppercase",
+            "replace",
+            "split",
+            "pad_start",
+            "pad_end",
+            "lookup",
+            "lookup_first",
+            "merge",
+            "deep_merge",
+            "get",
+            "pick",
+            "omit",
+            "keys",
+            "values",
+            "entries",
+            "len",
+            "from_entries",
+            "object_flatten",
+            "object_unflatten",
+            "map",
+            "filter",
+            "flat_map",
+            "flatten",
+            "take",
+            "drop",
+            "slice",
+            "chunk",
+            "zip",
+            "zip_with",
+            "unzip",
+            "group_by",
+            "key_by",
+            "partition",
+            "unique",
+            "distinct_by",
+            "sort_by",
+            "find",
+            "find_index",
+            "index_of",
+            "contains",
+            "sum",
+            "avg",
+            "min",
+            "max",
+            "reduce",
+            "fold",
+            "+",
+            "-",
+            "*",
+            "/",
+            "round",
+            "to_base",
+            "date_format",
+            "to_unixtime"
+        ],
+        "categories": {
+            "string_ops": [
+                "concat",
+                "to_string",
+                "trim",
+                "lowercase",
+                "uppercase",
+                "replace",
+                "split",
+                "pad_start",
+                "pad_end"
+            ],
+            "json_ops": [
+                "merge",
+                "deep_merge",
+                "get",
+                "pick",
+                "omit",
+                "keys",
+                "values",
+                "entries",
+                "len",
+                "from_entries",
+                "object_flatten",
+                "object_unflatten"
+            ],
+            "array_ops": [
+                "map",
+                "filter",
+                "flat_map",
+                "flatten",
+                "take",
+                "drop",
+                "slice",
+                "chunk",
+                "zip",
+                "zip_with",
+                "unzip",
+                "group_by",
+                "key_by",
+                "partition",
+                "unique",
+                "distinct_by",
+                "sort_by",
+                "find",
+                "find_index",
+                "index_of",
+                "contains",
+                "sum",
+                "avg",
+                "min",
+                "max",
+                "reduce",
+                "fold"
+            ],
+            "numeric_ops": ["+", "-", "*", "/", "round", "to_base", "sum", "avg", "min", "max"],
+            "date_ops": ["date_format", "to_unixtime"]
+        },
+        "category_docs": {
+            "string_ops": {
+                "summary": "String transformations and formatting.",
+                "examples": [
+                    {
+                        "op": "replace",
+                        "expr": { "op": "replace", "args": ["a-b", "-", "_", "all"] }
+                    },
+                    {
+                        "op": "concat",
+                        "expr": {
+                            "op": "concat",
+                            "args": [ { "ref": "input.first" }, " ", { "ref": "input.last" } ]
+                        }
+                    }
+                ]
+            },
+            "json_ops": {
+                "summary": "Object merge and structural helpers.",
+                "examples": [
+                    {
+                        "op": "merge",
+                        "expr": {
+                            "op": "merge",
+                            "args": [ { "ref": "input.base" }, { "ref": "context.override" } ]
+                        }
+                    },
+                    {
+                        "op": "get",
+                        "expr": { "op": "get", "args": [ { "ref": "input.obj" }, "id" ] }
+                    },
+                    {
+                        "op": "pick",
+                        "expr": { "op": "pick", "args": [ { "ref": "input.obj" }, ["id"] ] }
+                    }
+                ]
+            },
+            "array_ops": {
+                "summary": "Array transforms and aggregations.",
+                "examples": [
+                    {
+                        "op": "map",
+                        "expr": {
+                            "op": "map",
+                            "args": [ { "ref": "input.values" }, { "ref": "item.value" } ]
+                        }
+                    },
+                    {
+                        "op": "filter",
+                        "expr": {
+                            "op": "filter",
+                            "args": [
+                                { "ref": "input.values" },
+                                { "op": ">", "args": [ { "ref": "item.value" }, 0 ] }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "numeric_ops": {
+                "summary": "Numeric arithmetic and formatting.",
+                "examples": [
+                    { "op": "+", "expr": { "op": "+", "args": [1, 2, 3] } },
+                    { "op": "round", "expr": { "op": "round", "args": [12.345, 2] } }
+                ]
+            },
+            "date_ops": {
+                "summary": "Date/time parsing and formatting.",
+                "examples": [
+                    {
+                        "op": "date_format",
+                        "expr": { "op": "date_format", "args": ["2024-01-02", "%Y/%m/%d"] }
+                    }
+                ]
+            }
+        },
+        "logical_ops": ["and", "or", "not"],
+        "comparison_ops": ["==", "!=", "<", "<=", ">", ">=", "~="],
+        "type_casts": ["string", "int", "float", "bool"]
+    });
+
+    let text = serde_json::to_string_pretty(&ops)
+        .unwrap_or_else(|_| "{\"error\":\"failed to serialize ops\"}".to_string());
+
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text
+            }
+        ],
+        "meta": {
+            "ops": ops
+        }
+    })
+}

--- a/crates/rulemorph_mcp/src/tools/mod.rs
+++ b/crates/rulemorph_mcp/src/tools/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod list_ops;

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -1040,6 +1040,97 @@ fn list_ops_success() {
     assert!(
         response["result"]["meta"]["ops"]["category_docs"]["string_ops"]["examples"].is_array()
     );
+    assert_eq!(
+        response["result"]["meta"]["ops"]["logical_ops"],
+        json!(["and", "or", "not"])
+    );
+    assert_eq!(
+        response["result"]["meta"]["ops"]["comparison_ops"],
+        json!(["==", "!=", "<", "<=", ">", ">=", "~="])
+    );
+    assert_eq!(
+        response["result"]["meta"]["ops"]["type_casts"],
+        json!(["string", "int", "float", "bool"])
+    );
+    assert_eq!(
+        response["result"]["meta"]["ops"]["categories"]["numeric_ops"],
+        json!([
+            "+", "-", "*", "/", "round", "to_base", "sum", "avg", "min", "max"
+        ])
+    );
+    assert_eq!(
+        response["result"]["meta"]["ops"]["categories"]["date_ops"],
+        json!(["date_format", "to_unixtime"])
+    );
+    assert_eq!(
+        response["result"]["meta"]["ops"]["expr_ops"],
+        json!([
+            "concat",
+            "coalesce",
+            "to_string",
+            "trim",
+            "lowercase",
+            "uppercase",
+            "replace",
+            "split",
+            "pad_start",
+            "pad_end",
+            "lookup",
+            "lookup_first",
+            "merge",
+            "deep_merge",
+            "get",
+            "pick",
+            "omit",
+            "keys",
+            "values",
+            "entries",
+            "len",
+            "from_entries",
+            "object_flatten",
+            "object_unflatten",
+            "map",
+            "filter",
+            "flat_map",
+            "flatten",
+            "take",
+            "drop",
+            "slice",
+            "chunk",
+            "zip",
+            "zip_with",
+            "unzip",
+            "group_by",
+            "key_by",
+            "partition",
+            "unique",
+            "distinct_by",
+            "sort_by",
+            "find",
+            "find_index",
+            "index_of",
+            "contains",
+            "sum",
+            "avg",
+            "min",
+            "max",
+            "reduce",
+            "fold",
+            "+",
+            "-",
+            "*",
+            "/",
+            "round",
+            "to_base",
+            "date_format",
+            "to_unixtime"
+        ])
+    );
+    let text = response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("ops text");
+    let text_ops: Value = serde_json::from_str(text).expect("ops text json");
+    assert_eq!(text_ops, response["result"]["meta"]["ops"]);
 
     server.shutdown();
 }


### PR DESCRIPTION
## Summary
- Strengthen `list_ops_success` characterization for operator inventory, categories, casts, comparisons, and text/meta parity
- Split MCP `list_ops` response generation into `tools/list_ops.rs`
- Keep MCP tool schema/name, response JSON, resources/prompts, sandbox behavior, and other tools unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio list_ops_success
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet

## Review
- Subagent spec review: PASS for MCP contract; new `tools/` module staged