### PR TITLE
Refactor MCP call errors

### DIFF
--- a/crates/rulemorph_mcp/src/errors.rs
+++ b/crates/rulemorph_mcp/src/errors.rs
@@ -1,0 +1,27 @@
+use serde_json::{Value, json};
+
+pub(crate) enum CallError {
+    InvalidParams(String),
+    Tool {
+        message: String,
+        errors: Option<Vec<Value>>,
+    },
+}
+
+pub(crate) fn tool_error_result(message: &str, errors: Option<Vec<Value>>) -> Value {
+    let mut result = json!({
+        "content": [
+            {
+                "type": "text",
+                "text": message
+            }
+        ],
+        "isError": true
+    });
+
+    if let Some(errors) = errors {
+        result["meta"] = json!({ "errors": errors });
+    }
+
+    result
+}

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -15,12 +15,14 @@ use rulemorph::{
 use serde_json::{Map, Value, json};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 
+mod errors;
 mod prompts;
 mod protocol;
 mod resources;
 mod schemas;
 mod tools;
 
+use self::errors::{CallError, tool_error_result};
 use self::prompts::{prompts_get_result, prompts_list_result};
 use self::protocol::{OutputMode, read_message, write_message};
 use self::resources::{resources_list_result, resources_read_result};
@@ -201,14 +203,6 @@ fn tools_list_result() -> Value {
             }
         ]
     })
-}
-
-enum CallError {
-    InvalidParams(String),
-    Tool {
-        message: String,
-        errors: Option<Vec<Value>>,
-    },
 }
 
 fn handle_tools_call(params: &Value) -> Result<Value, CallError> {
@@ -1151,24 +1145,6 @@ fn run_generate_rules_from_dto_tool(args: &Map<String, Value>) -> Result<Value, 
         ],
         "meta": meta
     }))
-}
-
-fn tool_error_result(message: &str, errors: Option<Vec<Value>>) -> Value {
-    let mut result = json!({
-        "content": [
-            {
-                "type": "text",
-                "text": message
-            }
-        ],
-        "isError": true
-    });
-
-    if let Some(errors) = errors {
-        result["meta"] = json!({ "errors": errors });
-    }
-
-    result
 }
 
 fn get_optional_string(args: &Map<String, Value>, key: &str) -> Result<Option<String>, String> {

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -917,6 +917,35 @@ mappings:
 }
 
 #[test]
+fn tools_call_unknown_tool_returns_tool_error_payload() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 6,
+        "method": "tools/call",
+        "params": {
+            "name": "unknown_tool",
+            "arguments": {}
+        }
+    });
+
+    let response = server.send(&request);
+    assert_eq!(response["result"]["isError"], true);
+    assert_eq!(
+        response["result"]["content"][0],
+        json!({
+            "type": "text",
+            "text": "unknown tool: unknown_tool"
+        })
+    );
+    assert!(response["result"]["meta"].is_null());
+
+    server.shutdown();
+}
+
+#[test]
 fn validate_rules_success() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- Add characterization coverage for unknown tool errors as MCP tool-result errors
- Move `CallError` and `tool_error_result` into `errors.rs`
- Keep JSON-RPC invalid params errors, tool error payloads, tools, schemas, resources, prompts, and sandbox behavior unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio tools_call_invalid_params_returns_error
- cargo test -p rulemorph_mcp --test stdio tools_call_missing_files_returns_tool_error
- cargo test -p rulemorph_mcp --test stdio tools_call_unknown_tool_returns_tool_error_payload
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet

## Review
- Subagent spec review: PASS for MCP error contract; new `errors.rs` staged