### PR TITLE
Refactor MCP argument readers

### DIFF
--- a/crates/rulemorph_mcp/src/args.rs
+++ b/crates/rulemorph_mcp/src/args.rs
@@ -1,0 +1,71 @@
+use serde_json::{Map, Value};
+
+pub(crate) fn get_optional_string(
+    args: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, String> {
+    match args.get(key) {
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(Value::Null) => Ok(None),
+        Some(_) => Err(format!("{} must be a string", key)),
+        None => Ok(None),
+    }
+}
+
+pub(crate) fn get_optional_bool(
+    args: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<bool>, String> {
+    match args.get(key) {
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(Value::Null) => Ok(None),
+        Some(_) => Err(format!("{} must be a boolean", key)),
+        None => Ok(None),
+    }
+}
+
+pub(crate) fn get_optional_usize(
+    args: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<usize>, String> {
+    match args.get(key) {
+        Some(Value::Number(value)) => value
+            .as_u64()
+            .and_then(|value| {
+                if value > 0 {
+                    Some(value as usize)
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| format!("{} must be a positive integer", key))
+            .map(Some),
+        Some(Value::Null) => Ok(None),
+        Some(_) => Err(format!("{} must be a positive integer", key)),
+        None => Ok(None),
+    }
+}
+
+pub(crate) fn get_optional_json_value(
+    args: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<Value>, String> {
+    match args.get(key) {
+        Some(Value::Array(_)) | Some(Value::Object(_)) => Ok(args.get(key).cloned()),
+        Some(Value::Null) => Ok(None),
+        Some(_) => Err(format!("{} must be an object or array", key)),
+        None => Ok(None),
+    }
+}
+
+pub(crate) fn get_optional_object(
+    args: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<Value>, String> {
+    match args.get(key) {
+        Some(Value::Object(_)) => Ok(args.get(key).cloned()),
+        Some(Value::Null) => Ok(None),
+        Some(_) => Err(format!("{} must be an object", key)),
+        None => Ok(None),
+    }
+}

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -15,6 +15,7 @@ use rulemorph::{
 use serde_json::{Map, Value, json};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 
+mod args;
 mod errors;
 mod prompts;
 mod protocol;
@@ -22,6 +23,10 @@ mod resources;
 mod schemas;
 mod tools;
 
+use self::args::{
+    get_optional_bool, get_optional_json_value, get_optional_object, get_optional_string,
+    get_optional_usize,
+};
 use self::errors::{CallError, tool_error_result};
 use self::prompts::{prompts_get_result, prompts_list_result};
 use self::protocol::{OutputMode, read_message, write_message};
@@ -1145,61 +1150,6 @@ fn run_generate_rules_from_dto_tool(args: &Map<String, Value>) -> Result<Value, 
         ],
         "meta": meta
     }))
-}
-
-fn get_optional_string(args: &Map<String, Value>, key: &str) -> Result<Option<String>, String> {
-    match args.get(key) {
-        Some(Value::String(value)) => Ok(Some(value.clone())),
-        Some(Value::Null) => Ok(None),
-        Some(_) => Err(format!("{} must be a string", key)),
-        None => Ok(None),
-    }
-}
-
-fn get_optional_bool(args: &Map<String, Value>, key: &str) -> Result<Option<bool>, String> {
-    match args.get(key) {
-        Some(Value::Bool(value)) => Ok(Some(*value)),
-        Some(Value::Null) => Ok(None),
-        Some(_) => Err(format!("{} must be a boolean", key)),
-        None => Ok(None),
-    }
-}
-
-fn get_optional_usize(args: &Map<String, Value>, key: &str) -> Result<Option<usize>, String> {
-    match args.get(key) {
-        Some(Value::Number(value)) => value
-            .as_u64()
-            .and_then(|value| {
-                if value > 0 {
-                    Some(value as usize)
-                } else {
-                    None
-                }
-            })
-            .ok_or_else(|| format!("{} must be a positive integer", key))
-            .map(Some),
-        Some(Value::Null) => Ok(None),
-        Some(_) => Err(format!("{} must be a positive integer", key)),
-        None => Ok(None),
-    }
-}
-
-fn get_optional_json_value(args: &Map<String, Value>, key: &str) -> Result<Option<Value>, String> {
-    match args.get(key) {
-        Some(Value::Array(_)) | Some(Value::Object(_)) => Ok(args.get(key).cloned()),
-        Some(Value::Null) => Ok(None),
-        Some(_) => Err(format!("{} must be an object or array", key)),
-        None => Ok(None),
-    }
-}
-
-fn get_optional_object(args: &Map<String, Value>, key: &str) -> Result<Option<Value>, String> {
-    match args.get(key) {
-        Some(Value::Object(_)) => Ok(args.get(key).cloned()),
-        Some(Value::Null) => Ok(None),
-        Some(_) => Err(format!("{} must be an object", key)),
-        None => Ok(None),
-    }
 }
 
 fn load_rule_from_source(

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -695,6 +695,32 @@ fn tools_call_invalid_params_returns_error() {
 }
 
 #[test]
+fn tools_call_invalid_argument_type_returns_json_rpc_error() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 41,
+        "method": "tools/call",
+        "params": {
+            "name": "transform",
+            "arguments": {
+                "rules_text": "version: 1\ninput:\n  format: json\n  json: {}\nmappings: []",
+                "input_json": { "id": 1 },
+                "ndjson": "yes"
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    assert_eq!(response["error"]["code"], -32602);
+    assert_eq!(response["error"]["message"], "ndjson must be a boolean");
+
+    server.shutdown();
+}
+
+#[test]
 fn tools_call_missing_files_returns_tool_error() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- Add characterization coverage for invalid typed MCP tool arguments returning JSON-RPC `-32602`
- Move optional argument reader helpers into `args.rs`
- Keep InvalidParams messages, tool argument parsing, tools, schemas, resources, prompts, and sandbox behavior unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio tools_call_invalid_argument_type_returns_json_rpc_error
- cargo test -p rulemorph_mcp --test stdio tools_call_invalid_params_returns_error
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet

## Review
- Subagent spec review: PASS for MCP argument parsing contract; new `args.rs` staged