### PR TITLE
Refactor MCP path expression helpers

### DIFF
--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -16,6 +16,7 @@ use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 
 mod args;
 mod errors;
+mod path_expr;
 mod prompts;
 mod protocol;
 mod resources;
@@ -28,6 +29,7 @@ use self::args::{
     get_optional_usize,
 };
 use self::errors::{CallError, io_error_json, tool_error_result};
+use self::path_expr::{append_path, get_value_at_path, leaf_from_path};
 use self::prompts::{prompts_get_result, prompts_list_result};
 use self::protocol::{OutputMode, read_message, write_message};
 use self::resources::{resources_list_result, resources_read_result};
@@ -1320,16 +1322,17 @@ fn json_records_from_value(
     records_path: Option<&str>,
 ) -> Result<Vec<Value>, CallError> {
     let target = if let Some(path) = records_path {
-        let tokens = parse_path_tokens(path).map_err(|message| {
-            CallError::InvalidParams(format!("records_path is invalid: {}", message))
-        })?;
-        get_value_by_tokens(value, &tokens).ok_or_else(|| CallError::Tool {
-            message: "records_path did not match any value".to_string(),
-            errors: Some(vec![parse_error_json(
-                "records_path did not match any value",
-                None,
-            )]),
-        })?
+        get_value_at_path(value, path)
+            .map_err(|message| {
+                CallError::InvalidParams(format!("records_path is invalid: {}", message))
+            })?
+            .ok_or_else(|| CallError::Tool {
+                message: "records_path did not match any value".to_string(),
+                errors: Some(vec![parse_error_json(
+                    "records_path did not match any value",
+                    None,
+                )]),
+            })?
     } else {
         value
     };
@@ -1538,20 +1541,6 @@ fn build_input_paths(stats: &HashMap<String, PathStats>) -> Vec<InputPathInfo> {
         });
     }
     paths
-}
-
-fn leaf_from_path(path: &str) -> Option<String> {
-    match parse_path_tokens(path) {
-        Ok(tokens) => {
-            for token in tokens.iter().rev() {
-                if let PathToken::Key(key) = token {
-                    return Some(key.clone());
-                }
-            }
-            None
-        }
-        Err(_) => Some(path.to_string()),
-    }
 }
 
 fn split_tokens(value: &str) -> Vec<String> {
@@ -3456,188 +3445,6 @@ fn is_primitive(value: &Value) -> bool {
         value,
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
     )
-}
-
-fn append_path(prefix: &str, key: &str) -> String {
-    let needs_quote = key
-        .chars()
-        .any(|ch| ch == '.' || ch == '[' || ch == ']' || ch == '"' || ch == '\'' || ch == '\\');
-    let segment = if needs_quote {
-        let escaped = key.replace('\\', "\\\\").replace('"', "\\\"");
-        format!("[\"{}\"]", escaped)
-    } else {
-        key.to_string()
-    };
-    if prefix.is_empty() {
-        segment
-    } else if segment.starts_with('[') {
-        format!("{}{}", prefix, segment)
-    } else {
-        format!("{}.{}", prefix, segment)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum PathToken {
-    Key(String),
-    Index(usize),
-}
-
-fn parse_path_tokens(path: &str) -> Result<Vec<PathToken>, String> {
-    if path.is_empty() {
-        return Err("path is empty".to_string());
-    }
-
-    let chars: Vec<char> = path.chars().collect();
-    let mut tokens = Vec::new();
-    let mut index = 0;
-
-    while index < chars.len() {
-        if chars[index] == '.' {
-            return Err("path segment is empty".to_string());
-        }
-
-        if chars[index] == '[' {
-            let (token, next) = parse_bracket(&chars, index)?;
-            tokens.push(token);
-            index = next;
-        } else {
-            let start = index;
-            while index < chars.len() && chars[index] != '.' && chars[index] != '[' {
-                index += 1;
-            }
-            if start == index {
-                return Err("path segment is empty".to_string());
-            }
-            let key: String = chars[start..index].iter().collect();
-            if key.is_empty() {
-                return Err("path segment is empty".to_string());
-            }
-            tokens.push(PathToken::Key(key));
-        }
-
-        while index < chars.len() && chars[index] == '[' {
-            let (token, next) = parse_bracket(&chars, index)?;
-            tokens.push(token);
-            index = next;
-        }
-
-        if index < chars.len() {
-            if chars[index] == '.' {
-                index += 1;
-                if index == chars.len() {
-                    return Err("path syntax is invalid".to_string());
-                }
-            } else {
-                return Err("path syntax is invalid".to_string());
-            }
-        }
-    }
-
-    Ok(tokens)
-}
-
-fn parse_bracket(chars: &[char], start: usize) -> Result<(PathToken, usize), String> {
-    if chars.get(start) != Some(&'[') {
-        return Err("path syntax is invalid".to_string());
-    }
-    let index = start + 1;
-    if index >= chars.len() {
-        return Err("path syntax is invalid".to_string());
-    }
-
-    match chars[index] {
-        '"' | '\'' => parse_quoted(chars, index),
-        c if c.is_ascii_digit() => parse_index(chars, index),
-        _ => Err("path syntax is invalid".to_string()),
-    }
-}
-
-fn parse_index(chars: &[char], start: usize) -> Result<(PathToken, usize), String> {
-    let mut index = start;
-    let mut value: usize = 0;
-    let mut has_digit = false;
-
-    while index < chars.len() && chars[index].is_ascii_digit() {
-        has_digit = true;
-        value = value
-            .saturating_mul(10)
-            .saturating_add(chars[index].to_digit(10).unwrap_or(0) as usize);
-        index += 1;
-    }
-
-    if !has_digit {
-        return Err("path syntax is invalid".to_string());
-    }
-    if chars.get(index) != Some(&']') {
-        return Err("path syntax is invalid".to_string());
-    }
-    index += 1;
-    Ok((PathToken::Index(value), index))
-}
-
-fn parse_quoted(chars: &[char], start: usize) -> Result<(PathToken, usize), String> {
-    let quote = chars[start];
-    let mut index = start + 1;
-    let mut value = String::new();
-
-    while index < chars.len() {
-        let ch = chars[index];
-        if ch == '\\' {
-            index += 1;
-            if index >= chars.len() {
-                return Err("path escape is invalid".to_string());
-            }
-            let escaped = chars[index];
-            if escaped == '\\' || escaped == quote {
-                value.push(escaped);
-                index += 1;
-                continue;
-            }
-            return Err("path escape is invalid".to_string());
-        }
-
-        if ch == '[' || ch == ']' {
-            return Err("path syntax is invalid".to_string());
-        }
-
-        if ch == quote {
-            index += 1;
-            break;
-        }
-
-        value.push(ch);
-        index += 1;
-    }
-
-    if value.is_empty() {
-        return Err("path segment is empty".to_string());
-    }
-    if chars.get(index - 1) != Some(&quote) {
-        return Err("path syntax is invalid".to_string());
-    }
-    if chars.get(index) != Some(&']') {
-        return Err("path syntax is invalid".to_string());
-    }
-    index += 1;
-    Ok((PathToken::Key(value), index))
-}
-
-fn get_value_by_tokens<'a>(value: &'a Value, tokens: &[PathToken]) -> Option<&'a Value> {
-    let mut current = value;
-    for token in tokens {
-        match token {
-            PathToken::Key(key) => match current {
-                Value::Object(map) => current = map.get(key)?,
-                _ => return None,
-            },
-            PathToken::Index(index) => match current {
-                Value::Array(items) => current = items.get(*index)?,
-                _ => return None,
-            },
-        }
-    }
-    Some(current)
 }
 
 fn update_yaml_input_spec(root: &mut YamlValue, format: Option<&str>, records_path: Option<&str>) {

--- a/crates/rulemorph_mcp/src/path_expr.rs
+++ b/crates/rulemorph_mcp/src/path_expr.rs
@@ -1,0 +1,204 @@
+use serde_json::Value;
+
+pub(crate) fn append_path(prefix: &str, key: &str) -> String {
+    let needs_quote = key
+        .chars()
+        .any(|ch| ch == '.' || ch == '[' || ch == ']' || ch == '"' || ch == '\'' || ch == '\\');
+    let segment = if needs_quote {
+        let escaped = key.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("[\"{}\"]", escaped)
+    } else {
+        key.to_string()
+    };
+    if prefix.is_empty() {
+        segment
+    } else if segment.starts_with('[') {
+        format!("{}{}", prefix, segment)
+    } else {
+        format!("{}.{}", prefix, segment)
+    }
+}
+
+pub(crate) fn leaf_from_path(path: &str) -> Option<String> {
+    match parse_path_tokens(path) {
+        Ok(tokens) => {
+            for token in tokens.iter().rev() {
+                if let PathToken::Key(key) = token {
+                    return Some(key.clone());
+                }
+            }
+            None
+        }
+        Err(_) => Some(path.to_string()),
+    }
+}
+
+pub(crate) fn get_value_at_path<'a>(
+    value: &'a Value,
+    path: &str,
+) -> Result<Option<&'a Value>, String> {
+    let tokens = parse_path_tokens(path)?;
+    Ok(get_value_by_tokens(value, &tokens))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathToken {
+    Key(String),
+    Index(usize),
+}
+
+fn parse_path_tokens(path: &str) -> Result<Vec<PathToken>, String> {
+    if path.is_empty() {
+        return Err("path is empty".to_string());
+    }
+
+    let chars: Vec<char> = path.chars().collect();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+
+    while index < chars.len() {
+        if chars[index] == '.' {
+            return Err("path segment is empty".to_string());
+        }
+
+        if chars[index] == '[' {
+            let (token, next) = parse_bracket(&chars, index)?;
+            tokens.push(token);
+            index = next;
+        } else {
+            let start = index;
+            while index < chars.len() && chars[index] != '.' && chars[index] != '[' {
+                index += 1;
+            }
+            if start == index {
+                return Err("path segment is empty".to_string());
+            }
+            let key: String = chars[start..index].iter().collect();
+            if key.is_empty() {
+                return Err("path segment is empty".to_string());
+            }
+            tokens.push(PathToken::Key(key));
+        }
+
+        while index < chars.len() && chars[index] == '[' {
+            let (token, next) = parse_bracket(&chars, index)?;
+            tokens.push(token);
+            index = next;
+        }
+
+        if index < chars.len() {
+            if chars[index] == '.' {
+                index += 1;
+                if index == chars.len() {
+                    return Err("path syntax is invalid".to_string());
+                }
+            } else {
+                return Err("path syntax is invalid".to_string());
+            }
+        }
+    }
+
+    Ok(tokens)
+}
+
+fn parse_bracket(chars: &[char], start: usize) -> Result<(PathToken, usize), String> {
+    if chars.get(start) != Some(&'[') {
+        return Err("path syntax is invalid".to_string());
+    }
+    let index = start + 1;
+    if index >= chars.len() {
+        return Err("path syntax is invalid".to_string());
+    }
+
+    match chars[index] {
+        '"' | '\'' => parse_quoted(chars, index),
+        c if c.is_ascii_digit() => parse_index(chars, index),
+        _ => Err("path syntax is invalid".to_string()),
+    }
+}
+
+fn parse_index(chars: &[char], start: usize) -> Result<(PathToken, usize), String> {
+    let mut index = start;
+    let mut value: usize = 0;
+    let mut has_digit = false;
+
+    while index < chars.len() && chars[index].is_ascii_digit() {
+        has_digit = true;
+        value = value
+            .saturating_mul(10)
+            .saturating_add(chars[index].to_digit(10).unwrap_or(0) as usize);
+        index += 1;
+    }
+
+    if !has_digit {
+        return Err("path syntax is invalid".to_string());
+    }
+    if chars.get(index) != Some(&']') {
+        return Err("path syntax is invalid".to_string());
+    }
+    index += 1;
+    Ok((PathToken::Index(value), index))
+}
+
+fn parse_quoted(chars: &[char], start: usize) -> Result<(PathToken, usize), String> {
+    let quote = chars[start];
+    let mut index = start + 1;
+    let mut value = String::new();
+    while index < chars.len() {
+        let ch = chars[index];
+        if ch == '\\' {
+            index += 1;
+            if index >= chars.len() {
+                return Err("path escape is invalid".to_string());
+            }
+            let escaped = chars[index];
+            if escaped == '\\' || escaped == quote {
+                value.push(escaped);
+                index += 1;
+                continue;
+            }
+            return Err("path escape is invalid".to_string());
+        }
+
+        if ch == '[' || ch == ']' {
+            return Err("path syntax is invalid".to_string());
+        }
+
+        if ch == quote {
+            index += 1;
+            break;
+        }
+
+        value.push(ch);
+        index += 1;
+    }
+
+    if value.is_empty() {
+        return Err("path segment is empty".to_string());
+    }
+    if chars.get(index - 1) != Some(&quote) {
+        return Err("path syntax is invalid".to_string());
+    }
+    if chars.get(index) != Some(&']') {
+        return Err("path syntax is invalid".to_string());
+    }
+    index += 1;
+    Ok((PathToken::Key(value), index))
+}
+
+fn get_value_by_tokens<'a>(value: &'a Value, tokens: &[PathToken]) -> Option<&'a Value> {
+    let mut current = value;
+    for token in tokens {
+        match token {
+            PathToken::Key(key) => match current {
+                Value::Object(map) => current = map.get(key)?,
+                _ => return None,
+            },
+            PathToken::Index(index) => match current {
+                Value::Array(items) => current = items.get(*index)?,
+                _ => return None,
+            },
+        }
+    }
+    Some(current)
+}

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -1278,6 +1278,44 @@ fn analyze_input_json_success() {
 }
 
 #[test]
+fn analyze_input_records_path_supports_quoted_segments() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 121,
+        "method": "tools/call",
+        "params": {
+            "name": "analyze_input",
+            "arguments": {
+                "input_json": {
+                    "payload": {
+                        "items.with.dot": [
+                            {
+                                "user.name": "Ada",
+                                "age": 37
+                            }
+                        ]
+                    }
+                },
+                "records_path": "payload[\"items.with.dot\"]"
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    let paths = response["result"]["meta"]["paths"]
+        .as_array()
+        .expect("paths array");
+    assert!(paths.iter().any(|item| item["path"] == "[\"user.name\"]"));
+    assert!(paths.iter().any(|item| item["path"] == "age"));
+    assert_eq!(response["result"]["meta"]["summary"]["records"], json!(1));
+
+    server.shutdown();
+}
+
+#[test]
 fn raw_json_input_text_rejects_duplicate_keys_for_analysis_and_generation() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- move MCP path expression parsing, lookup, leaf extraction, and path formatting helpers into an internal module
- add characterization coverage for quoted records_path segments and quoted generated path output
- keep analyze/generation MCP behavior unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio analyze_input_json_success
- cargo test -p rulemorph_mcp --test stdio analyze_input_records_path_supports_quoted_segments
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_base_success
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_success
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet