### PR TITLE
Refactor MCP DTO language helpers

### DIFF
--- a/crates/rulemorph_mcp/src/dto_language.rs
+++ b/crates/rulemorph_mcp/src/dto_language.rs
@@ -1,0 +1,62 @@
+use rulemorph::DtoLanguage;
+use serde_json::{Value, json};
+
+pub(crate) fn parse_dto_language(value: &str) -> Result<DtoLanguage, String> {
+    match value.to_lowercase().as_str() {
+        "rust" => Ok(DtoLanguage::Rust),
+        "typescript" => Ok(DtoLanguage::TypeScript),
+        "python" => Ok(DtoLanguage::Python),
+        "go" => Ok(DtoLanguage::Go),
+        "java" => Ok(DtoLanguage::Java),
+        "kotlin" => Ok(DtoLanguage::Kotlin),
+        "swift" => Ok(DtoLanguage::Swift),
+        _ => Err(
+            "language must be one of rust, typescript, python, go, java, kotlin, swift".to_string(),
+        ),
+    }
+}
+
+pub(crate) fn dto_language_to_str(language: DtoLanguage) -> &'static str {
+    match language {
+        DtoLanguage::Rust => "rust",
+        DtoLanguage::TypeScript => "typescript",
+        DtoLanguage::Python => "python",
+        DtoLanguage::Go => "go",
+        DtoLanguage::Java => "java",
+        DtoLanguage::Kotlin => "kotlin",
+        DtoLanguage::Swift => "swift",
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum DtoSourceLanguage {
+    Rust,
+    TypeScript,
+    Python,
+    Go,
+    Java,
+    Kotlin,
+    Swift,
+}
+
+pub(crate) fn parse_dto_source_language(value: &str) -> Result<DtoSourceLanguage, String> {
+    match value.to_lowercase().as_str() {
+        "rust" => Ok(DtoSourceLanguage::Rust),
+        "typescript" => Ok(DtoSourceLanguage::TypeScript),
+        "python" => Ok(DtoSourceLanguage::Python),
+        "go" => Ok(DtoSourceLanguage::Go),
+        "java" => Ok(DtoSourceLanguage::Java),
+        "kotlin" => Ok(DtoSourceLanguage::Kotlin),
+        "swift" => Ok(DtoSourceLanguage::Swift),
+        _ => Err(
+            "dto_language must be rust, typescript, python, go, java, kotlin, or swift".to_string(),
+        ),
+    }
+}
+
+pub(crate) fn dto_error_json(message: &str) -> Value {
+    json!({
+        "type": "dto",
+        "message": message,
+    })
+}

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use csv::ReaderBuilder;
 use rulemorph::serde_guard::parse_json_value_strict;
 use rulemorph::{
-    DtoLanguage, Expr, ExprChain, ExprOp, InputData, InputFormat, RuleError, RuleFile, RuleFormat,
+    Expr, ExprChain, ExprOp, InputData, InputFormat, RuleError, RuleFile, RuleFormat,
     TransformError, TransformErrorKind, TransformWarning, generate_dto,
     parse_rule_file_with_format, transform_input_with_warnings,
     transform_input_with_warnings_with_base_dir, transform_stream_input,
@@ -15,6 +15,7 @@ use serde_json::{Map, Value, json};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 
 mod args;
+mod dto_language;
 mod errors;
 mod path_expr;
 mod prompts;
@@ -27,6 +28,10 @@ mod tools;
 use self::args::{
     get_optional_bool, get_optional_json_value, get_optional_object, get_optional_string,
     get_optional_usize,
+};
+use self::dto_language::{
+    DtoSourceLanguage, dto_error_json, dto_language_to_str, parse_dto_language,
+    parse_dto_source_language,
 };
 use self::errors::{CallError, io_error_json, tool_error_result};
 use self::path_expr::{append_path, get_value_at_path, leaf_from_path};
@@ -1237,66 +1242,6 @@ fn rule_has_file_branch(rule: &RuleFile) -> bool {
     rule.steps
         .as_ref()
         .is_some_and(|steps| steps.iter().any(|step| step.branch.is_some()))
-}
-
-fn parse_dto_language(value: &str) -> Result<DtoLanguage, String> {
-    match value.to_lowercase().as_str() {
-        "rust" => Ok(DtoLanguage::Rust),
-        "typescript" => Ok(DtoLanguage::TypeScript),
-        "python" => Ok(DtoLanguage::Python),
-        "go" => Ok(DtoLanguage::Go),
-        "java" => Ok(DtoLanguage::Java),
-        "kotlin" => Ok(DtoLanguage::Kotlin),
-        "swift" => Ok(DtoLanguage::Swift),
-        _ => Err(
-            "language must be one of rust, typescript, python, go, java, kotlin, swift".to_string(),
-        ),
-    }
-}
-
-fn dto_language_to_str(language: DtoLanguage) -> &'static str {
-    match language {
-        DtoLanguage::Rust => "rust",
-        DtoLanguage::TypeScript => "typescript",
-        DtoLanguage::Python => "python",
-        DtoLanguage::Go => "go",
-        DtoLanguage::Java => "java",
-        DtoLanguage::Kotlin => "kotlin",
-        DtoLanguage::Swift => "swift",
-    }
-}
-
-#[derive(Clone, Copy)]
-enum DtoSourceLanguage {
-    Rust,
-    TypeScript,
-    Python,
-    Go,
-    Java,
-    Kotlin,
-    Swift,
-}
-
-fn parse_dto_source_language(value: &str) -> Result<DtoSourceLanguage, String> {
-    match value.to_lowercase().as_str() {
-        "rust" => Ok(DtoSourceLanguage::Rust),
-        "typescript" => Ok(DtoSourceLanguage::TypeScript),
-        "python" => Ok(DtoSourceLanguage::Python),
-        "go" => Ok(DtoSourceLanguage::Go),
-        "java" => Ok(DtoSourceLanguage::Java),
-        "kotlin" => Ok(DtoSourceLanguage::Kotlin),
-        "swift" => Ok(DtoSourceLanguage::Swift),
-        _ => Err(
-            "dto_language must be rust, typescript, python, go, java, kotlin, or swift".to_string(),
-        ),
-    }
-}
-
-fn dto_error_json(message: &str) -> Value {
-    json!({
-        "type": "dto",
-        "message": message,
-    })
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -1130,6 +1130,43 @@ mappings:
 }
 
 #[test]
+fn generate_dto_invalid_language_returns_json_rpc_error() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let rules_text = r#"version: 1
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "id"
+    source: "id"
+"#;
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 101,
+        "method": "tools/call",
+        "params": {
+            "name": "generate_dto",
+            "arguments": {
+                "rules_text": rules_text,
+                "language": "ruby"
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    assert_eq!(response["error"]["code"], -32602);
+    assert_eq!(
+        response["error"]["message"],
+        "language must be one of rust, typescript, python, go, java, kotlin, swift"
+    );
+
+    server.shutdown();
+}
+
+#[test]
 fn list_ops_success() {
     let mut server = McpServer::start();
     initialize(&mut server);
@@ -1611,6 +1648,37 @@ fn generate_rules_from_dto_success() {
     let rule = parse_rule_file(output_text).expect("parse output rules");
     assert_eq!(rule.mappings[0].source.as_deref(), Some("id"));
     assert_eq!(rule.mappings[1].source.as_deref(), Some("name"));
+
+    server.shutdown();
+}
+
+#[test]
+fn generate_rules_from_dto_invalid_language_returns_json_rpc_error() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1510,
+        "method": "tools/call",
+        "params": {
+            "name": "generate_rules_from_dto",
+            "arguments": {
+                "dto_text": "type Record = { id: string }",
+                "dto_language": "ruby",
+                "input_json": {
+                    "id": 1
+                }
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    assert_eq!(response["error"]["code"], -32602);
+    assert_eq!(
+        response["error"]["message"],
+        "dto_language must be rust, typescript, python, go, java, kotlin, or swift"
+    );
 
     server.shutdown();
 }


### PR DESCRIPTION
## Summary
- move MCP DTO language parsing and DTO error JSON helpers into an internal module
- add characterization coverage for invalid DTO language JSON-RPC errors
- keep generate_dto and generate_rules_from_dto behavior unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio generate_dto_typescript
- cargo test -p rulemorph_mcp --test stdio generate_dto_invalid_language_returns_json_rpc_error
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_success
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_invalid_language_returns_json_rpc_error
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet