### PR TITLE
Refactor MCP input record helpers

### DIFF
--- a/crates/rulemorph_mcp/src/input_records.rs
+++ b/crates/rulemorph_mcp/src/input_records.rs
@@ -1,0 +1,129 @@
+use csv::ReaderBuilder;
+use rulemorph::serde_guard::parse_json_value_strict;
+use serde_json::{Map, Value};
+
+use crate::errors::CallError;
+use crate::parse_error_json;
+use crate::path_expr::get_value_at_path;
+
+#[derive(Clone, Copy)]
+pub(crate) enum InputDataFormat {
+    Json,
+    Csv,
+}
+
+pub(crate) fn normalize_format(format: Option<&str>, input_text: &str) -> InputDataFormat {
+    match format.map(|value| value.to_lowercase()) {
+        Some(value) if value == "csv" => InputDataFormat::Csv,
+        Some(value) if value == "json" => InputDataFormat::Json,
+        Some(_) => InputDataFormat::Json,
+        None => match input_text.trim_start().chars().next() {
+            Some('{') | Some('[') => InputDataFormat::Json,
+            _ => InputDataFormat::Csv,
+        },
+    }
+}
+
+pub(crate) fn json_records_from_value(
+    value: &Value,
+    records_path: Option<&str>,
+) -> Result<Vec<Value>, CallError> {
+    let target = if let Some(path) = records_path {
+        get_value_at_path(value, path)
+            .map_err(|message| {
+                CallError::InvalidParams(format!("records_path is invalid: {}", message))
+            })?
+            .ok_or_else(|| CallError::Tool {
+                message: "records_path did not match any value".to_string(),
+                errors: Some(vec![parse_error_json(
+                    "records_path did not match any value",
+                    None,
+                )]),
+            })?
+    } else {
+        value
+    };
+
+    match target {
+        Value::Array(items) => Ok(items.clone()),
+        Value::Object(_) => Ok(vec![target.clone()]),
+        _ => Err(CallError::Tool {
+            message: "records_path must resolve to an object or array".to_string(),
+            errors: Some(vec![parse_error_json(
+                "records_path must resolve to an object or array",
+                None,
+            )]),
+        }),
+    }
+}
+
+pub(crate) fn parse_json_records_strict(
+    input_text: &str,
+    records_path: Option<&str>,
+    input_path: Option<&str>,
+) -> Result<Vec<Value>, CallError> {
+    let value = parse_json_value_strict(input_text).map_err(|err| {
+        let message = format!("failed to parse input JSON: {}", err);
+        CallError::Tool {
+            message: message.clone(),
+            errors: Some(vec![parse_error_json(&message, input_path)]),
+        }
+    })?;
+    json_records_from_value(&value, records_path)
+}
+
+pub(crate) fn parse_csv_records(text: &str) -> Result<Vec<Value>, String> {
+    let mut reader = ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(text.as_bytes());
+    let headers = reader
+        .headers()
+        .map_err(|err| err.to_string())?
+        .iter()
+        .enumerate()
+        .map(|(index, name)| {
+            let trimmed = name.trim();
+            if trimmed.is_empty() {
+                format!("column_{}", index + 1)
+            } else {
+                trimmed.to_string()
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut records = Vec::new();
+    for result in reader.records() {
+        let record = result.map_err(|err| err.to_string())?;
+        let mut obj = Map::new();
+        for (index, value) in record.iter().enumerate() {
+            if let Some(key) = headers.get(index) {
+                obj.insert(key.clone(), csv_cell_to_value(value));
+            }
+        }
+        records.push(Value::Object(obj));
+    }
+    Ok(records)
+}
+
+fn csv_cell_to_value(value: &str) -> Value {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Value::Null;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower == "true" {
+        return Value::Bool(true);
+    }
+    if lower == "false" {
+        return Value::Bool(false);
+    }
+    if let Ok(number) = trimmed.parse::<i64>() {
+        return Value::Number(number.into());
+    }
+    if let Ok(number) = trimmed.parse::<f64>() {
+        if let Some(number) = serde_json::Number::from_f64(number) {
+            return Value::Number(number);
+        }
+    }
+    Value::String(trimmed.to_string())
+}

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -2,8 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 
-use csv::ReaderBuilder;
-use rulemorph::serde_guard::parse_json_value_strict;
 use rulemorph::{
     Expr, ExprChain, ExprOp, InputData, InputFormat, RuleError, RuleFile, RuleFormat,
     TransformError, TransformErrorKind, TransformWarning, generate_dto,
@@ -17,6 +15,7 @@ use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 mod args;
 mod dto_language;
 mod errors;
+mod input_records;
 mod path_expr;
 mod prompts;
 mod protocol;
@@ -34,7 +33,11 @@ use self::dto_language::{
     parse_dto_source_language,
 };
 use self::errors::{CallError, io_error_json, tool_error_result};
-use self::path_expr::{append_path, get_value_at_path, leaf_from_path};
+use self::input_records::{
+    InputDataFormat, json_records_from_value, normalize_format, parse_csv_records,
+    parse_json_records_strict,
+};
+use self::path_expr::{append_path, leaf_from_path};
 use self::prompts::{prompts_get_result, prompts_list_result};
 use self::protocol::{OutputMode, read_message, write_message};
 use self::resources::{resources_list_result, resources_read_result};
@@ -1242,128 +1245,6 @@ fn rule_has_file_branch(rule: &RuleFile) -> bool {
     rule.steps
         .as_ref()
         .is_some_and(|steps| steps.iter().any(|step| step.branch.is_some()))
-}
-
-#[derive(Clone, Copy)]
-enum InputDataFormat {
-    Json,
-    Csv,
-}
-
-fn normalize_format(format: Option<&str>, input_text: &str) -> InputDataFormat {
-    match format.map(|value| value.to_lowercase()) {
-        Some(value) if value == "csv" => InputDataFormat::Csv,
-        Some(value) if value == "json" => InputDataFormat::Json,
-        Some(_) => InputDataFormat::Json,
-        None => match input_text.trim_start().chars().next() {
-            Some('{') | Some('[') => InputDataFormat::Json,
-            _ => InputDataFormat::Csv,
-        },
-    }
-}
-
-fn json_records_from_value(
-    value: &Value,
-    records_path: Option<&str>,
-) -> Result<Vec<Value>, CallError> {
-    let target = if let Some(path) = records_path {
-        get_value_at_path(value, path)
-            .map_err(|message| {
-                CallError::InvalidParams(format!("records_path is invalid: {}", message))
-            })?
-            .ok_or_else(|| CallError::Tool {
-                message: "records_path did not match any value".to_string(),
-                errors: Some(vec![parse_error_json(
-                    "records_path did not match any value",
-                    None,
-                )]),
-            })?
-    } else {
-        value
-    };
-
-    match target {
-        Value::Array(items) => Ok(items.clone()),
-        Value::Object(_) => Ok(vec![target.clone()]),
-        _ => Err(CallError::Tool {
-            message: "records_path must resolve to an object or array".to_string(),
-            errors: Some(vec![parse_error_json(
-                "records_path must resolve to an object or array",
-                None,
-            )]),
-        }),
-    }
-}
-
-fn parse_json_records_strict(
-    input_text: &str,
-    records_path: Option<&str>,
-    input_path: Option<&str>,
-) -> Result<Vec<Value>, CallError> {
-    let value = parse_json_value_strict(input_text).map_err(|err| {
-        let message = format!("failed to parse input JSON: {}", err);
-        CallError::Tool {
-            message: message.clone(),
-            errors: Some(vec![parse_error_json(&message, input_path)]),
-        }
-    })?;
-    json_records_from_value(&value, records_path)
-}
-
-fn parse_csv_records(text: &str) -> Result<Vec<Value>, String> {
-    let mut reader = ReaderBuilder::new()
-        .has_headers(true)
-        .from_reader(text.as_bytes());
-    let headers = reader
-        .headers()
-        .map_err(|err| err.to_string())?
-        .iter()
-        .enumerate()
-        .map(|(index, name)| {
-            let trimmed = name.trim();
-            if trimmed.is_empty() {
-                format!("column_{}", index + 1)
-            } else {
-                trimmed.to_string()
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let mut records = Vec::new();
-    for result in reader.records() {
-        let record = result.map_err(|err| err.to_string())?;
-        let mut obj = Map::new();
-        for (index, value) in record.iter().enumerate() {
-            if let Some(key) = headers.get(index) {
-                obj.insert(key.clone(), csv_cell_to_value(value));
-            }
-        }
-        records.push(Value::Object(obj));
-    }
-    Ok(records)
-}
-
-fn csv_cell_to_value(value: &str) -> Value {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Value::Null;
-    }
-    let lower = trimmed.to_ascii_lowercase();
-    if lower == "true" {
-        return Value::Bool(true);
-    }
-    if lower == "false" {
-        return Value::Bool(false);
-    }
-    if let Ok(number) = trimmed.parse::<i64>() {
-        return Value::Number(number.into());
-    }
-    if let Ok(number) = trimmed.parse::<f64>() {
-        if let Some(number) = serde_json::Number::from_f64(number) {
-            return Value::Number(number);
-        }
-    }
-    Value::String(trimmed.to_string())
 }
 
 #[derive(Default)]

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -1353,6 +1353,38 @@ fn analyze_input_records_path_supports_quoted_segments() {
 }
 
 #[test]
+fn analyze_input_invalid_records_path_returns_json_rpc_error() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 122,
+        "method": "tools/call",
+        "params": {
+            "name": "analyze_input",
+            "arguments": {
+                "input_json": {
+                    "payload": [
+                        { "id": 1 }
+                    ]
+                },
+                "records_path": "payload."
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    assert_eq!(response["error"]["code"], -32602);
+    assert_eq!(
+        response["error"]["message"],
+        "records_path is invalid: path syntax is invalid"
+    );
+
+    server.shutdown();
+}
+
+#[test]
 fn raw_json_input_text_rejects_duplicate_keys_for_analysis_and_generation() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- Move MCP JSON/CSV input record parsing helpers from main.rs into input_records.rs
- Add characterization coverage for invalid records_path syntax returning JSON-RPC -32602
- Keep MCP tool schema, response contracts, duplicate-key rejection, CSV parsing, and records_path behavior unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio analyze_input_json_success
- cargo test -p rulemorph_mcp --test stdio analyze_input_csv_success
- cargo test -p rulemorph_mcp --test stdio analyze_input_invalid_records_path_returns_json_rpc_error
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_base_success
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_success
- cargo test -p rulemorph_mcp --test stdio raw_json_input_text_rejects_duplicate_keys_for_analysis_and_generation
- cargo test -p rulemorph_mcp --test stdio analyze_input_csv_rejects_mismatched_field_count
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet