### PR TITLE
Refactor MCP input analysis helpers

### DIFF
--- a/crates/rulemorph_mcp/src/input_analysis.rs
+++ b/crates/rulemorph_mcp/src/input_analysis.rs
@@ -1,0 +1,275 @@
+use std::collections::{HashMap, HashSet};
+
+use serde_json::{Value, json};
+
+use crate::path_expr::{append_path, leaf_from_path};
+
+#[derive(Default)]
+pub(crate) struct PathStats {
+    count: usize,
+    type_counts: HashMap<&'static str, usize>,
+    examples: Vec<Value>,
+}
+
+pub(crate) fn analyze_records(
+    records: &[Value],
+    max_paths: Option<usize>,
+) -> HashMap<String, PathStats> {
+    let mut stats = HashMap::new();
+    for record in records {
+        collect_path_stats(record, "", &mut stats, max_paths);
+    }
+    stats
+}
+
+fn collect_path_stats(
+    value: &Value,
+    prefix: &str,
+    stats: &mut HashMap<String, PathStats>,
+    max_paths: Option<usize>,
+) {
+    match value {
+        Value::Object(map) => {
+            if map.is_empty() {
+                record_path_value(stats, prefix, value, max_paths);
+                return;
+            }
+            for (key, child) in map {
+                let next = append_path(prefix, key);
+                collect_path_stats(child, &next, stats, max_paths);
+            }
+        }
+        Value::Array(_) => {
+            record_path_value(stats, prefix, value, max_paths);
+        }
+        _ => record_path_value(stats, prefix, value, max_paths),
+    }
+}
+
+fn record_path_value(
+    stats: &mut HashMap<String, PathStats>,
+    path: &str,
+    value: &Value,
+    max_paths: Option<usize>,
+) {
+    let path = if path.is_empty() {
+        "$".to_string()
+    } else {
+        path.to_string()
+    };
+    if !stats.contains_key(&path) && max_paths.is_some_and(|max| stats.len() >= max) {
+        return;
+    }
+    let entry = stats.entry(path).or_default();
+    entry.count += 1;
+    let type_name = value_type_name(value);
+    *entry.type_counts.entry(type_name).or_insert(0) += 1;
+    if entry.examples.len() < 3 && is_primitive(value) && !entry.examples.contains(value) {
+        entry.examples.push(value.clone());
+    }
+}
+
+pub(crate) fn stats_to_json(stats: &HashMap<String, PathStats>) -> Value {
+    let mut entries: Vec<(&String, &PathStats)> = stats.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut values = Vec::new();
+    for (path, stat) in entries {
+        let mut types = serde_json::Map::new();
+        let mut type_entries: Vec<_> = stat.type_counts.iter().collect();
+        type_entries.sort_by(|a, b| a.0.cmp(b.0));
+        for (type_name, count) in type_entries {
+            types.insert(type_name.to_string(), json!(count));
+        }
+
+        let mut obj = json!({
+            "path": path,
+            "count": stat.count,
+            "types": types
+        });
+        if !stat.examples.is_empty() {
+            obj["examples"] = Value::Array(stat.examples.clone());
+        }
+        values.push(obj);
+    }
+    Value::Array(values)
+}
+
+#[derive(Clone)]
+pub(crate) struct InputPathInfo {
+    pub(crate) path: String,
+    leaf: String,
+    tokens: Vec<String>,
+    type_counts: HashMap<&'static str, usize>,
+}
+
+#[derive(Clone)]
+pub(crate) struct Candidate {
+    pub(crate) source: String,
+    pub(crate) score: f64,
+    pub(crate) reason: &'static str,
+    pub(crate) confidence: &'static str,
+}
+
+pub(crate) fn build_input_paths(stats: &HashMap<String, PathStats>) -> Vec<InputPathInfo> {
+    let mut paths = Vec::new();
+    for (path, stat) in stats {
+        if path == "$" {
+            continue;
+        }
+        let leaf = leaf_from_path(path).unwrap_or_else(|| path.clone());
+        let tokens = split_tokens(&leaf);
+        paths.push(InputPathInfo {
+            path: path.clone(),
+            leaf,
+            tokens,
+            type_counts: stat.type_counts.clone(),
+        });
+    }
+    paths
+}
+
+fn split_tokens(value: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            current.push(ch.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            tokens.push(current.clone());
+            current.clear();
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn token_similarity(a: &[String], b: &[String]) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let set_a: HashSet<&str> = a.iter().map(String::as_str).collect();
+    let set_b: HashSet<&str> = b.iter().map(String::as_str).collect();
+    let overlap = set_a.intersection(&set_b).count() as f64;
+    let denom = set_a.len().max(set_b.len()) as f64;
+    if denom == 0.0 { 0.0 } else { overlap / denom }
+}
+
+pub(crate) fn select_candidates(
+    target_leaf: &str,
+    source_hint: Option<&str>,
+    value_type: Option<&str>,
+    input_paths: &[InputPathInfo],
+    max_candidates: usize,
+) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+    let target_tokens = split_tokens(target_leaf);
+    let source_leaf = source_hint.and_then(leaf_from_path);
+    let source_tokens = source_leaf.as_deref().map(split_tokens).unwrap_or_default();
+
+    for input in input_paths {
+        let mut score = 0.0;
+        let mut reason = None;
+
+        if let Some(source_hint) = source_hint {
+            if input.path == source_hint {
+                score = 1.0;
+                reason = Some("exact_source");
+            }
+        }
+
+        if reason.is_none() && !target_leaf.is_empty() {
+            if input.leaf.eq_ignore_ascii_case(target_leaf) {
+                score = 0.8;
+                reason = Some("leaf_match");
+            }
+        }
+
+        if reason.is_none() {
+            if let Some(source_leaf) = source_leaf.as_deref() {
+                if input.leaf.eq_ignore_ascii_case(source_leaf) {
+                    score = 0.75;
+                    reason = Some("leaf_match");
+                }
+            }
+        }
+
+        if reason.is_none() {
+            let mut similarity = token_similarity(&target_tokens, &input.tokens);
+            if !source_tokens.is_empty() {
+                similarity = similarity.max(token_similarity(&source_tokens, &input.tokens));
+            }
+            if similarity > 0.0 {
+                score = 0.6 * similarity;
+                reason = Some("token_match");
+            }
+        }
+
+        if let Some(reason) = reason {
+            score += type_boost(&input.type_counts, value_type);
+            let confidence = confidence_for_score(score);
+            candidates.push(Candidate {
+                source: input.path.clone(),
+                score,
+                reason,
+                confidence,
+            });
+        }
+    }
+
+    candidates.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.source.cmp(&b.source))
+    });
+    candidates.truncate(max_candidates);
+    candidates
+}
+
+fn type_boost(type_counts: &HashMap<&'static str, usize>, value_type: Option<&str>) -> f64 {
+    let Some(value_type) = value_type else {
+        return 0.0;
+    };
+    let type_name = match value_type {
+        "string" => "string",
+        "int" | "float" => "number",
+        "bool" => "bool",
+        _ => return 0.0,
+    };
+    if type_counts.contains_key(type_name) {
+        0.1
+    } else {
+        0.0
+    }
+}
+
+fn confidence_for_score(score: f64) -> &'static str {
+    if score >= 0.9 {
+        "high"
+    } else if score >= 0.7 {
+        "medium"
+    } else {
+        "low"
+    }
+}
+
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn is_primitive(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
+    )
+}

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -16,6 +16,7 @@ mod args;
 mod dto_language;
 mod dto_normalize;
 mod errors;
+mod input_analysis;
 mod input_records;
 mod path_expr;
 mod prompts;
@@ -38,6 +39,7 @@ use self::dto_normalize::{
     normalize_swift_text, normalize_typescript_text,
 };
 use self::errors::{CallError, io_error_json, tool_error_result};
+use self::input_analysis::{analyze_records, build_input_paths, select_candidates, stats_to_json};
 use self::input_records::{
     InputDataFormat, json_records_from_value, normalize_format, parse_csv_records,
     parse_json_records_strict,
@@ -1250,255 +1252,6 @@ fn rule_has_file_branch(rule: &RuleFile) -> bool {
     rule.steps
         .as_ref()
         .is_some_and(|steps| steps.iter().any(|step| step.branch.is_some()))
-}
-
-#[derive(Default)]
-struct PathStats {
-    count: usize,
-    type_counts: HashMap<&'static str, usize>,
-    examples: Vec<Value>,
-}
-
-fn analyze_records(records: &[Value], max_paths: Option<usize>) -> HashMap<String, PathStats> {
-    let mut stats = HashMap::new();
-    for record in records {
-        collect_path_stats(record, "", &mut stats, max_paths);
-    }
-    stats
-}
-
-fn collect_path_stats(
-    value: &Value,
-    prefix: &str,
-    stats: &mut HashMap<String, PathStats>,
-    max_paths: Option<usize>,
-) {
-    match value {
-        Value::Object(map) => {
-            if map.is_empty() {
-                record_path_value(stats, prefix, value, max_paths);
-                return;
-            }
-            for (key, child) in map {
-                let next = append_path(prefix, key);
-                collect_path_stats(child, &next, stats, max_paths);
-            }
-        }
-        Value::Array(_) => {
-            record_path_value(stats, prefix, value, max_paths);
-        }
-        _ => record_path_value(stats, prefix, value, max_paths),
-    }
-}
-
-fn record_path_value(
-    stats: &mut HashMap<String, PathStats>,
-    path: &str,
-    value: &Value,
-    max_paths: Option<usize>,
-) {
-    let path = if path.is_empty() {
-        "$".to_string()
-    } else {
-        path.to_string()
-    };
-    if !stats.contains_key(&path) && max_paths.is_some_and(|max| stats.len() >= max) {
-        return;
-    }
-    let entry = stats.entry(path).or_default();
-    entry.count += 1;
-    let type_name = value_type_name(value);
-    *entry.type_counts.entry(type_name).or_insert(0) += 1;
-    if entry.examples.len() < 3 && is_primitive(value) && !entry.examples.contains(value) {
-        entry.examples.push(value.clone());
-    }
-}
-
-fn stats_to_json(stats: &HashMap<String, PathStats>) -> Value {
-    let mut entries: Vec<(&String, &PathStats)> = stats.iter().collect();
-    entries.sort_by(|a, b| a.0.cmp(b.0));
-
-    let mut values = Vec::new();
-    for (path, stat) in entries {
-        let mut types = serde_json::Map::new();
-        let mut type_entries: Vec<_> = stat.type_counts.iter().collect();
-        type_entries.sort_by(|a, b| a.0.cmp(b.0));
-        for (type_name, count) in type_entries {
-            types.insert(type_name.to_string(), json!(count));
-        }
-
-        let mut obj = json!({
-            "path": path,
-            "count": stat.count,
-            "types": types
-        });
-        if !stat.examples.is_empty() {
-            obj["examples"] = Value::Array(stat.examples.clone());
-        }
-        values.push(obj);
-    }
-    Value::Array(values)
-}
-
-#[derive(Clone)]
-struct InputPathInfo {
-    path: String,
-    leaf: String,
-    tokens: Vec<String>,
-    type_counts: HashMap<&'static str, usize>,
-}
-
-#[derive(Clone)]
-struct Candidate {
-    source: String,
-    score: f64,
-    reason: &'static str,
-    confidence: &'static str,
-}
-
-fn build_input_paths(stats: &HashMap<String, PathStats>) -> Vec<InputPathInfo> {
-    let mut paths = Vec::new();
-    for (path, stat) in stats {
-        if path == "$" {
-            continue;
-        }
-        let leaf = leaf_from_path(path).unwrap_or_else(|| path.clone());
-        let tokens = split_tokens(&leaf);
-        paths.push(InputPathInfo {
-            path: path.clone(),
-            leaf,
-            tokens,
-            type_counts: stat.type_counts.clone(),
-        });
-    }
-    paths
-}
-
-fn split_tokens(value: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    for ch in value.chars() {
-        if ch.is_ascii_alphanumeric() {
-            current.push(ch.to_ascii_lowercase());
-        } else if !current.is_empty() {
-            tokens.push(current.clone());
-            current.clear();
-        }
-    }
-    if !current.is_empty() {
-        tokens.push(current);
-    }
-    tokens
-}
-
-fn token_similarity(a: &[String], b: &[String]) -> f64 {
-    if a.is_empty() || b.is_empty() {
-        return 0.0;
-    }
-    let set_a: HashSet<&str> = a.iter().map(String::as_str).collect();
-    let set_b: HashSet<&str> = b.iter().map(String::as_str).collect();
-    let overlap = set_a.intersection(&set_b).count() as f64;
-    let denom = set_a.len().max(set_b.len()) as f64;
-    if denom == 0.0 { 0.0 } else { overlap / denom }
-}
-
-fn select_candidates(
-    target_leaf: &str,
-    source_hint: Option<&str>,
-    value_type: Option<&str>,
-    input_paths: &[InputPathInfo],
-    max_candidates: usize,
-) -> Vec<Candidate> {
-    let mut candidates = Vec::new();
-    let target_tokens = split_tokens(target_leaf);
-    let source_leaf = source_hint.and_then(leaf_from_path);
-    let source_tokens = source_leaf.as_deref().map(split_tokens).unwrap_or_default();
-
-    for input in input_paths {
-        let mut score = 0.0;
-        let mut reason = None;
-
-        if let Some(source_hint) = source_hint {
-            if input.path == source_hint {
-                score = 1.0;
-                reason = Some("exact_source");
-            }
-        }
-
-        if reason.is_none() && !target_leaf.is_empty() {
-            if input.leaf.eq_ignore_ascii_case(target_leaf) {
-                score = 0.8;
-                reason = Some("leaf_match");
-            }
-        }
-
-        if reason.is_none() {
-            if let Some(source_leaf) = source_leaf.as_deref() {
-                if input.leaf.eq_ignore_ascii_case(source_leaf) {
-                    score = 0.75;
-                    reason = Some("leaf_match");
-                }
-            }
-        }
-
-        if reason.is_none() {
-            let mut similarity = token_similarity(&target_tokens, &input.tokens);
-            if !source_tokens.is_empty() {
-                similarity = similarity.max(token_similarity(&source_tokens, &input.tokens));
-            }
-            if similarity > 0.0 {
-                score = 0.6 * similarity;
-                reason = Some("token_match");
-            }
-        }
-
-        if let Some(reason) = reason {
-            score += type_boost(&input.type_counts, value_type);
-            let confidence = confidence_for_score(score);
-            candidates.push(Candidate {
-                source: input.path.clone(),
-                score,
-                reason,
-                confidence,
-            });
-        }
-    }
-
-    candidates.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.source.cmp(&b.source))
-    });
-    candidates.truncate(max_candidates);
-    candidates
-}
-
-fn type_boost(type_counts: &HashMap<&'static str, usize>, value_type: Option<&str>) -> f64 {
-    let Some(value_type) = value_type else {
-        return 0.0;
-    };
-    let type_name = match value_type {
-        "string" => "string",
-        "int" | "float" => "number",
-        "bool" => "bool",
-        _ => return 0.0,
-    };
-    if type_counts.contains_key(type_name) {
-        0.1
-    } else {
-        0.0
-    }
-}
-
-fn confidence_for_score(score: f64) -> &'static str {
-    if score >= 0.9 {
-        "high"
-    } else if score >= 0.7 {
-        "medium"
-    } else {
-        "low"
-    }
 }
 
 struct DtoSchema {
@@ -2862,24 +2615,6 @@ fn build_input_yaml(format: &str, records_path: Option<&str>) -> YamlValue {
         input_map.insert(yaml_key("csv"), YamlValue::Mapping(YamlMapping::new()));
     }
     YamlValue::Mapping(input_map)
-}
-
-fn value_type_name(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "bool",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
-    }
-}
-
-fn is_primitive(value: &Value) -> bool {
-    matches!(
-        value,
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
-    )
 }
 
 fn update_yaml_input_spec(root: &mut YamlValue, format: Option<&str>, records_path: Option<&str>) {

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -1315,6 +1315,38 @@ fn analyze_input_json_success() {
 }
 
 #[test]
+fn analyze_input_max_paths_limits_reported_paths() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 121,
+        "method": "tools/call",
+        "params": {
+            "name": "analyze_input",
+            "arguments": {
+                "input_json": {
+                    "id": 1,
+                    "name": "Ada",
+                    "active": true
+                },
+                "max_paths": 2
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    let paths = response["result"]["meta"]["paths"]
+        .as_array()
+        .expect("paths array");
+    assert_eq!(paths.len(), 2);
+    assert_eq!(response["result"]["meta"]["summary"]["paths"], json!(2));
+
+    server.shutdown();
+}
+
+#[test]
 fn analyze_input_records_path_supports_quoted_segments() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- Move MCP input analysis and candidate scoring helpers into input_analysis.rs
- Add characterization coverage for analyze_input max_paths limiting reported paths
- Keep analyze_input metadata, generated rules output, candidate scoring, and MCP schemas unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio analyze_input_max_paths_limits_reported_paths
- cargo test -p rulemorph_mcp --test stdio analyze_input_json_success
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_base_success
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_success
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_base_csv_uses_scalar_type_boost
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet