### PR TITLE
Refactor MCP DTO schema model helpers

### DIFF
--- a/crates/rulemorph_mcp/src/dto_schema.rs
+++ b/crates/rulemorph_mcp/src/dto_schema.rs
@@ -1,0 +1,107 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::path_expr::append_path;
+
+pub(crate) struct DtoSchema {
+    pub(crate) root: String,
+    pub(crate) types: HashMap<String, DtoType>,
+}
+
+pub(crate) struct DtoType {
+    pub(crate) fields: Vec<DtoField>,
+}
+
+pub(crate) struct DtoField {
+    pub(crate) json_key: String,
+    pub(crate) field_type: DtoFieldType,
+    pub(crate) optional: bool,
+}
+
+pub(crate) enum DtoFieldType {
+    Primitive(PrimitiveKind),
+    Object(String),
+    Unknown,
+}
+
+pub(crate) enum PrimitiveKind {
+    String,
+    Int,
+    Float,
+    Bool,
+}
+
+pub(crate) struct GeneratedMapping {
+    pub(crate) target: String,
+    pub(crate) value_type: Option<String>,
+    pub(crate) required: bool,
+}
+
+pub(crate) fn generate_mappings_from_schema(
+    schema: &DtoSchema,
+) -> Result<Vec<GeneratedMapping>, String> {
+    let mut mappings = Vec::new();
+    let mut visiting = HashSet::new();
+    build_mappings_for_type(
+        schema,
+        &schema.root,
+        "",
+        false,
+        &mut visiting,
+        &mut mappings,
+    )?;
+    Ok(mappings)
+}
+
+fn build_mappings_for_type(
+    schema: &DtoSchema,
+    type_name: &str,
+    prefix: &str,
+    parent_optional: bool,
+    visiting: &mut HashSet<String>,
+    out: &mut Vec<GeneratedMapping>,
+) -> Result<(), String> {
+    if !visiting.insert(type_name.to_string()) {
+        return Ok(());
+    }
+    let dto_type = schema
+        .types
+        .get(type_name)
+        .ok_or_else(|| format!("unknown dto type: {}", type_name))?;
+
+    for field in &dto_type.fields {
+        let target = append_path(prefix, &field.json_key);
+        let optional = parent_optional || field.optional;
+        match &field.field_type {
+            DtoFieldType::Primitive(kind) => {
+                let value_type = primitive_to_value_type(kind);
+                out.push(GeneratedMapping {
+                    target,
+                    value_type,
+                    required: !optional,
+                });
+            }
+            DtoFieldType::Unknown => {
+                out.push(GeneratedMapping {
+                    target,
+                    value_type: None,
+                    required: !optional,
+                });
+            }
+            DtoFieldType::Object(child) => {
+                build_mappings_for_type(schema, child, &target, optional, visiting, out)?;
+            }
+        }
+    }
+
+    visiting.remove(type_name);
+    Ok(())
+}
+
+fn primitive_to_value_type(kind: &PrimitiveKind) -> Option<String> {
+    match kind {
+        PrimitiveKind::String => Some("string".to_string()),
+        PrimitiveKind::Int => Some("int".to_string()),
+        PrimitiveKind::Float => Some("float".to_string()),
+        PrimitiveKind::Bool => Some("bool".to_string()),
+    }
+}

--- a/crates/rulemorph_mcp/src/main.rs
+++ b/crates/rulemorph_mcp/src/main.rs
@@ -15,6 +15,7 @@ use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 mod args;
 mod dto_language;
 mod dto_normalize;
+mod dto_schema;
 mod errors;
 mod input_analysis;
 mod input_records;
@@ -38,13 +39,16 @@ use self::dto_normalize::{
     normalize_java_text, normalize_kotlin_text, normalize_python_text, normalize_rust_text,
     normalize_swift_text, normalize_typescript_text,
 };
+use self::dto_schema::{
+    DtoField, DtoFieldType, DtoSchema, DtoType, PrimitiveKind, generate_mappings_from_schema,
+};
 use self::errors::{CallError, io_error_json, tool_error_result};
 use self::input_analysis::{analyze_records, build_input_paths, select_candidates, stats_to_json};
 use self::input_records::{
     InputDataFormat, json_records_from_value, normalize_format, parse_csv_records,
     parse_json_records_strict,
 };
-use self::path_expr::{append_path, leaf_from_path};
+use self::path_expr::leaf_from_path;
 use self::prompts::{prompts_get_result, prompts_list_result};
 use self::protocol::{OutputMode, read_message, write_message};
 use self::resources::{resources_list_result, resources_read_result};
@@ -1252,40 +1256,6 @@ fn rule_has_file_branch(rule: &RuleFile) -> bool {
     rule.steps
         .as_ref()
         .is_some_and(|steps| steps.iter().any(|step| step.branch.is_some()))
-}
-
-struct DtoSchema {
-    root: String,
-    types: HashMap<String, DtoType>,
-}
-
-struct DtoType {
-    fields: Vec<DtoField>,
-}
-
-struct DtoField {
-    json_key: String,
-    field_type: DtoFieldType,
-    optional: bool,
-}
-
-enum DtoFieldType {
-    Primitive(PrimitiveKind),
-    Object(String),
-    Unknown,
-}
-
-enum PrimitiveKind {
-    String,
-    Int,
-    Float,
-    Bool,
-}
-
-struct GeneratedMapping {
-    target: String,
-    value_type: Option<String>,
-    required: bool,
 }
 
 fn parse_dto_schema(text: &str, language: DtoSourceLanguage) -> Result<DtoSchema, String> {
@@ -2529,74 +2499,6 @@ fn parse_serde_rename(line: &str) -> Option<String> {
     let after_quote = &after_marker[quote_start + 1..];
     let quote_end = after_quote.find('"')?;
     Some(after_quote[..quote_end].to_string())
-}
-
-fn generate_mappings_from_schema(schema: &DtoSchema) -> Result<Vec<GeneratedMapping>, String> {
-    let mut mappings = Vec::new();
-    let mut visiting = HashSet::new();
-    build_mappings_for_type(
-        schema,
-        &schema.root,
-        "",
-        false,
-        &mut visiting,
-        &mut mappings,
-    )?;
-    Ok(mappings)
-}
-
-fn build_mappings_for_type(
-    schema: &DtoSchema,
-    type_name: &str,
-    prefix: &str,
-    parent_optional: bool,
-    visiting: &mut HashSet<String>,
-    out: &mut Vec<GeneratedMapping>,
-) -> Result<(), String> {
-    if !visiting.insert(type_name.to_string()) {
-        return Ok(());
-    }
-    let dto_type = schema
-        .types
-        .get(type_name)
-        .ok_or_else(|| format!("unknown dto type: {}", type_name))?;
-
-    for field in &dto_type.fields {
-        let target = append_path(prefix, &field.json_key);
-        let optional = parent_optional || field.optional;
-        match &field.field_type {
-            DtoFieldType::Primitive(kind) => {
-                let value_type = primitive_to_value_type(kind);
-                out.push(GeneratedMapping {
-                    target,
-                    value_type,
-                    required: !optional,
-                });
-            }
-            DtoFieldType::Unknown => {
-                out.push(GeneratedMapping {
-                    target,
-                    value_type: None,
-                    required: !optional,
-                });
-            }
-            DtoFieldType::Object(child) => {
-                build_mappings_for_type(schema, child, &target, optional, visiting, out)?;
-            }
-        }
-    }
-
-    visiting.remove(type_name);
-    Ok(())
-}
-
-fn primitive_to_value_type(kind: &PrimitiveKind) -> Option<String> {
-    match kind {
-        PrimitiveKind::String => Some("string".to_string()),
-        PrimitiveKind::Int => Some("int".to_string()),
-        PrimitiveKind::Float => Some("float".to_string()),
-        PrimitiveKind::Bool => Some("bool".to_string()),
-    }
 }
 
 fn build_input_yaml(format: &str, records_path: Option<&str>) -> YamlValue {


### PR DESCRIPTION
## Summary
- Move MCP DTO schema model types and mapping generation helpers into dto_schema.rs
- Keep DTO language parsers in main.rs for this stage
- Keep generate_rules_from_dto YAML output, metadata, required propagation, and value_type mapping unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_nested_optional_object_keeps_required_semantics
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_base_success
- cargo test -p rulemorph_mcp
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet