### PR TITLE
Refactor trace writer record node helpers

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer.rs
+++ b/crates/rulemorph_trace/src/trace_writer.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -10,13 +9,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use chrono::{Datelike, Utc};
-use serde_json::{Value as JsonValue, json};
+use serde_json::Value as JsonValue;
 use tracing::warn;
 
 mod chunk_write;
 mod externalize;
 mod masking;
 mod queue;
+mod record_nodes;
 mod sampling;
 
 use chunk_write::{
@@ -29,6 +29,7 @@ use queue::{
     TraceQueue, TraceWriteRequest, estimate_trace_bytes, evict_normal, push_request, queue_bytes,
     trace_id_for_log, trace_writer_loop,
 };
+use record_nodes::{normalize_inline_records, split_records_and_nodes};
 use sampling::{TracePriority, should_keep_full_detail, trace_priority};
 
 use crate::trace_backend::TraceWriteBackend;
@@ -1229,37 +1230,6 @@ fn cleanup_detail_files(
     blob_files.clear();
 }
 
-fn normalize_inline_records(records: &[JsonValue]) -> Vec<JsonValue> {
-    records
-        .iter()
-        .map(|record| {
-            let mut record_clone = record.clone();
-            if let Some(obj) = record_clone.as_object_mut() {
-                if let Some(nodes_value) = obj.get("nodes").cloned() {
-                    let normalized = normalize_nodes_value(&nodes_value);
-                    obj.insert("nodes".to_string(), JsonValue::Array(normalized));
-                }
-            }
-            record_clone
-        })
-        .collect()
-}
-
-fn normalize_nodes_value(nodes_value: &JsonValue) -> Vec<JsonValue> {
-    match nodes_value {
-        JsonValue::Array(nodes) => nodes.iter().map(normalize_node_value).collect(),
-        JsonValue::Object(_) => vec![normalize_node_value(nodes_value)],
-        other => vec![json!({ "value": other })],
-    }
-}
-
-fn normalize_node_value(value: &JsonValue) -> JsonValue {
-    match value {
-        JsonValue::Object(map) => JsonValue::Object(map.clone()),
-        other => json!({ "value": other }),
-    }
-}
-
 fn parse_date_parts(timestamp: &str) -> Option<(i32, u32, u32)> {
     let parsed = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
     Some((parsed.year(), parsed.month(), parsed.day()))
@@ -1305,90 +1275,6 @@ fn reserve_budget(remaining: &mut u64, bytes: u64) -> bool {
     }
     *remaining -= bytes;
     true
-}
-
-fn parse_record_index(value: &JsonValue) -> Option<u64> {
-    match value {
-        JsonValue::Number(num) => num.as_u64(),
-        JsonValue::String(text) => text.parse::<u64>().ok(),
-        _ => None,
-    }
-}
-
-fn build_node_chunk_entry(node: &JsonValue, record_index: u64) -> JsonValue {
-    match node {
-        JsonValue::Object(map) if map.contains_key("record_index") => json!({
-            "record_index": record_index,
-            "node": JsonValue::Object(map.clone()),
-        }),
-        JsonValue::Object(map) => {
-            let mut entry = JsonValue::Object(map.clone());
-            if let Some(obj) = entry.as_object_mut() {
-                obj.insert("record_index".to_string(), JsonValue::from(record_index));
-            }
-            entry
-        }
-        other => json!({
-            "record_index": record_index,
-            "value": other,
-        }),
-    }
-}
-
-fn split_records_and_nodes(records: &[JsonValue]) -> (Vec<JsonValue>, Vec<JsonValue>) {
-    let mut records_out = Vec::with_capacity(records.len());
-    let mut nodes_out = Vec::new();
-    let mut seen_indices: HashSet<u64> = HashSet::new();
-
-    for (index, record) in records.iter().enumerate() {
-        let mut record_index = record
-            .get("index")
-            .and_then(parse_record_index)
-            .unwrap_or(index as u64);
-        if seen_indices.contains(&record_index) {
-            record_index = index as u64;
-        }
-        if seen_indices.contains(&record_index) {
-            let start = record_index;
-            loop {
-                record_index = record_index.wrapping_add(1);
-                if !seen_indices.contains(&record_index) {
-                    break;
-                }
-                if record_index == start {
-                    warn!(
-                        "record_index space exhausted while deduplicating; using {}",
-                        record_index
-                    );
-                    break;
-                }
-            }
-        }
-        seen_indices.insert(record_index);
-        if let Some(nodes_value) = record.get("nodes") {
-            match nodes_value {
-                JsonValue::Array(nodes) => {
-                    for node in nodes {
-                        nodes_out.push(build_node_chunk_entry(node, record_index));
-                    }
-                }
-                other => {
-                    nodes_out.push(build_node_chunk_entry(other, record_index));
-                }
-            }
-        }
-
-        let mut record_clone = record.clone();
-        if let Some(obj) = record_clone.as_object_mut() {
-            obj.insert("index".to_string(), JsonValue::from(record_index));
-            if obj.contains_key("nodes") {
-                obj.remove("nodes");
-            }
-        }
-        records_out.push(record_clone);
-    }
-
-    (records_out, nodes_out)
 }
 
 fn ensure_unique_trace_dir(

--- a/crates/rulemorph_trace/src/trace_writer/record_nodes.rs
+++ b/crates/rulemorph_trace/src/trace_writer/record_nodes.rs
@@ -1,0 +1,119 @@
+use std::collections::HashSet;
+
+use serde_json::{Value as JsonValue, json};
+use tracing::warn;
+
+pub(super) fn normalize_inline_records(records: &[JsonValue]) -> Vec<JsonValue> {
+    records
+        .iter()
+        .map(|record| {
+            let mut record_clone = record.clone();
+            if let Some(obj) = record_clone.as_object_mut() {
+                if let Some(nodes_value) = obj.get("nodes").cloned() {
+                    let normalized = normalize_nodes_value(&nodes_value);
+                    obj.insert("nodes".to_string(), JsonValue::Array(normalized));
+                }
+            }
+            record_clone
+        })
+        .collect()
+}
+
+fn normalize_nodes_value(nodes_value: &JsonValue) -> Vec<JsonValue> {
+    match nodes_value {
+        JsonValue::Array(nodes) => nodes.iter().map(normalize_node_value).collect(),
+        JsonValue::Object(_) => vec![normalize_node_value(nodes_value)],
+        other => vec![json!({ "value": other })],
+    }
+}
+
+fn normalize_node_value(value: &JsonValue) -> JsonValue {
+    match value {
+        JsonValue::Object(map) => JsonValue::Object(map.clone()),
+        other => json!({ "value": other }),
+    }
+}
+
+fn parse_record_index(value: &JsonValue) -> Option<u64> {
+    match value {
+        JsonValue::Number(num) => num.as_u64(),
+        JsonValue::String(text) => text.parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn build_node_chunk_entry(node: &JsonValue, record_index: u64) -> JsonValue {
+    match node {
+        JsonValue::Object(map) if map.contains_key("record_index") => json!({
+            "record_index": record_index,
+            "node": JsonValue::Object(map.clone()),
+        }),
+        JsonValue::Object(map) => {
+            let mut entry = JsonValue::Object(map.clone());
+            if let Some(obj) = entry.as_object_mut() {
+                obj.insert("record_index".to_string(), JsonValue::from(record_index));
+            }
+            entry
+        }
+        other => json!({
+            "record_index": record_index,
+            "value": other,
+        }),
+    }
+}
+
+pub(super) fn split_records_and_nodes(records: &[JsonValue]) -> (Vec<JsonValue>, Vec<JsonValue>) {
+    let mut records_out = Vec::with_capacity(records.len());
+    let mut nodes_out = Vec::new();
+    let mut seen_indices: HashSet<u64> = HashSet::new();
+
+    for (index, record) in records.iter().enumerate() {
+        let mut record_index = record
+            .get("index")
+            .and_then(parse_record_index)
+            .unwrap_or(index as u64);
+        if seen_indices.contains(&record_index) {
+            record_index = index as u64;
+        }
+        if seen_indices.contains(&record_index) {
+            let start = record_index;
+            loop {
+                record_index = record_index.wrapping_add(1);
+                if !seen_indices.contains(&record_index) {
+                    break;
+                }
+                if record_index == start {
+                    warn!(
+                        "record_index space exhausted while deduplicating; using {}",
+                        record_index
+                    );
+                    break;
+                }
+            }
+        }
+        seen_indices.insert(record_index);
+        if let Some(nodes_value) = record.get("nodes") {
+            match nodes_value {
+                JsonValue::Array(nodes) => {
+                    for node in nodes {
+                        nodes_out.push(build_node_chunk_entry(node, record_index));
+                    }
+                }
+                other => {
+                    nodes_out.push(build_node_chunk_entry(other, record_index));
+                }
+            }
+        }
+
+        let mut record_clone = record.clone();
+        if let Some(obj) = record_clone.as_object_mut() {
+            obj.insert("index".to_string(), JsonValue::from(record_index));
+            if obj.contains_key("nodes") {
+                obj.remove("nodes");
+            }
+        }
+        records_out.push(record_clone);
+    }
+
+    (records_out, nodes_out)
+}

--- a/crates/rulemorph_trace/tests/trace_writer.rs
+++ b/crates/rulemorph_trace/tests/trace_writer.rs
@@ -2491,6 +2491,49 @@ async fn write_trace_bundle_wraps_inline_non_object_nodes() -> anyhow::Result<()
 }
 
 #[tokio::test]
+async fn write_trace_bundle_wraps_inline_scalar_nodes_value() -> anyhow::Result<()> {
+    let temp_dir = create_temp_dir()?;
+
+    let trace = json!({
+        "trace_id": "trace-inline-scalar-nodes",
+        "records": [
+            {
+                "status": "ok",
+                "nodes": "raw-node"
+            }
+        ]
+    });
+
+    let options = TraceWriteOptions {
+        compression: TraceCompression::None,
+        split_nodes: false,
+        ..Default::default()
+    };
+
+    let manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
+    let manifest = read_manifest(&manifest_path)?;
+    let detail = manifest.detail.expect("detail should exist");
+    let trace_dir = trace_dir(&manifest_path);
+    let record_chunk = &detail.records[0];
+    let record_payload = fs::read_to_string(trace_dir.join(&record_chunk.path))?;
+    let record_line = record_payload
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .expect("record line should exist");
+    let record: serde_json::Value = serde_json::from_str(record_line)?;
+    let nodes = record
+        .get("nodes")
+        .and_then(|value| value.as_array())
+        .expect("nodes should be array");
+    assert_eq!(
+        nodes[0].get("value").and_then(|value| value.as_str()),
+        Some("raw-node")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn write_trace_bundle_wraps_inline_non_object_nodes_on_read() -> anyhow::Result<()> {
     let temp_dir = create_temp_dir()?;
 


### PR DESCRIPTION
## Summary
- Move trace writer record/node normalization helpers into private trace_writer::record_nodes module
- Add a characterization test for inline scalar nodes normalization
- Keep trace JSON schema, split_nodes behavior, and record_index semantics unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_wraps_inline_scalar_nodes_value
- cargo test -p rulemorph_trace --test trace_writer
- cargo test -p rulemorph_trace
- cargo test -p rulemorph --test transform_trace
- cargo test -p rulemorph --test transform_trace_semantics
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet

## Review
- Subagent spec review: PASS
- Subagent code quality review: PASS