### PR TITLE
Refactor trace store meta parse helpers

### DIFF
--- a/crates/rulemorph_trace/src/trace_store.rs
+++ b/crates/rulemorph_trace/src/trace_store.rs
@@ -12,10 +12,8 @@ use tracing::warn;
 use walkdir::WalkDir;
 
 use crate::trace_backend::TraceBackend;
-use crate::trace_id::{sanitize_trace_id, trace_id_is_placeholder};
 use crate::trace_schema::{
-    RuleMeta, TRACE_JSON_MAX_BYTES, TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX,
-    TraceManifest, TraceSummary,
+    RuleMeta, TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX, TraceManifest, TraceSummary,
 };
 
 mod chunk_read;
@@ -23,6 +21,7 @@ mod import_bundle;
 mod import_path;
 mod legacy;
 mod manifest_budget;
+mod meta;
 mod purge;
 mod trace_id_path;
 
@@ -39,12 +38,13 @@ use self::legacy::{apply_legacy_limits, looks_like_legacy_trace};
 use self::manifest_budget::{
     apply_manifest_budget, apply_record_total_budget_for_get, resolve_max_chunk_bytes,
 };
+use self::meta::{is_manifest, parse_trace_meta, read_trace_json_with_limit_async};
 use self::purge::purge_trace_metas;
 #[cfg(test)]
 use self::purge::resolve_trace_timestamp;
-use self::trace_id_path::{
-    fallback_trace_id_for_path, hash_trace_id_for_path, path_hash_for_trace_id,
-};
+#[cfg(test)]
+use self::trace_id_path::fallback_trace_id_for_path;
+use self::trace_id_path::path_hash_for_trace_id;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceMeta {
@@ -1386,205 +1386,6 @@ mod tests {
 
         Ok(())
     }
-}
-
-async fn read_trace_json_with_limit_async(path: &Path) -> Result<String> {
-    let metadata = tokio::fs::metadata(path)
-        .await
-        .with_context(|| format!("failed to read trace metadata: {}", path.display()))?;
-    if metadata.len() > TRACE_JSON_MAX_BYTES {
-        return Err(anyhow::anyhow!(
-            "trace json exceeds max bytes: {} > {}",
-            metadata.len(),
-            TRACE_JSON_MAX_BYTES
-        ));
-    }
-    tokio::fs::read_to_string(path)
-        .await
-        .with_context(|| format!("failed to read trace: {}", path.display()))
-}
-
-fn read_trace_json_with_limit(path: &Path) -> Result<String> {
-    let metadata = std::fs::metadata(path)
-        .with_context(|| format!("failed to read trace metadata: {}", path.display()))?;
-    if metadata.len() > TRACE_JSON_MAX_BYTES {
-        return Err(anyhow::anyhow!(
-            "trace json exceeds max bytes: {} > {}",
-            metadata.len(),
-            TRACE_JSON_MAX_BYTES
-        ));
-    }
-    std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read trace: {}", path.display()))
-}
-
-fn parse_trace_meta(path: &Path) -> Result<TraceMeta> {
-    let raw = read_trace_json_with_limit(path)?;
-    let value: Value = serde_json::from_str(&raw)
-        .with_context(|| format!("invalid trace json: {}", path.display()))?;
-
-    if is_manifest(&value) {
-        let manifest: TraceManifest = serde_json::from_value(value)
-            .with_context(|| format!("invalid trace manifest: {}", path.display()))?;
-        return parse_manifest_meta(&manifest, path);
-    }
-
-    if !looks_like_legacy_trace(&value) {
-        return Err(anyhow::anyhow!("not a trace file"));
-    }
-
-    let raw_trace_id = value
-        .get("trace_id")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| {
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string()
-        });
-    let mut trace_id = sanitize_trace_id(&raw_trace_id);
-    if trace_id.is_empty() {
-        trace_id = fallback_trace_id_for_path(path);
-        warn!(
-            "legacy trace_id sanitized to empty; using {} from {}",
-            trace_id,
-            path.display()
-        );
-    } else if trace_id_is_placeholder(&trace_id) {
-        let fallback = hash_trace_id_for_path(path);
-        warn!(
-            "legacy trace_id is insufficient; using {} from {}",
-            fallback,
-            path.display()
-        );
-        trace_id = fallback;
-    } else if trace_id != raw_trace_id {
-        warn!(
-            "legacy trace_id sanitized from {} to {}",
-            raw_trace_id, trace_id
-        );
-    }
-
-    let status = value
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("ok")
-        .to_string();
-
-    let timestamp = value
-        .get("timestamp")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-
-    let duration_us = value
-        .get("summary")
-        .and_then(|s| s.get("duration_us"))
-        .and_then(|v| v.as_u64())
-        .or_else(|| {
-            value
-                .get("summary")
-                .and_then(|s| s.get("duration_ms"))
-                .and_then(|v| v.as_u64())
-                .map(|v| v.saturating_mul(1000))
-        })
-        .or_else(|| value.get("duration_us").and_then(|v| v.as_u64()))
-        .or_else(|| {
-            value
-                .get("duration_ms")
-                .and_then(|v| v.as_u64())
-                .map(|v| v.saturating_mul(1000))
-        });
-
-    let rule = value.get("rule").map(|rule| RuleMeta {
-        name: rule
-            .get("name")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        path: rule
-            .get("path")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        r#type: rule
-            .get("type")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        version: rule
-            .get("version")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u8),
-    });
-
-    let summary = value.get("summary").map(|summary| TraceSummary {
-        record_total: summary.get("record_total").and_then(|v| v.as_u64()),
-        record_success: summary.get("record_success").and_then(|v| v.as_u64()),
-        record_failed: summary.get("record_failed").and_then(|v| v.as_u64()),
-        duration_ms: summary.get("duration_ms").and_then(|v| v.as_u64()),
-        duration_us: summary.get("duration_us").and_then(|v| v.as_u64()),
-    });
-
-    Ok(TraceMeta {
-        trace_id,
-        status,
-        timestamp,
-        duration_us,
-        rule,
-        summary,
-        path: path.display().to_string(),
-    })
-}
-
-fn is_manifest(value: &Value) -> bool {
-    value.get("trace_schema_version").is_some()
-}
-
-fn parse_manifest_meta(manifest: &TraceManifest, path: &Path) -> Result<TraceMeta> {
-    let duration_us = manifest
-        .summary
-        .as_ref()
-        .and_then(|summary| summary.duration_us)
-        .or_else(|| {
-            manifest
-                .summary
-                .as_ref()
-                .and_then(|summary| summary.duration_ms)
-                .map(|value| value.saturating_mul(1000))
-        });
-
-    let raw_trace_id = manifest.trace_id.clone();
-    let mut trace_id = sanitize_trace_id(&raw_trace_id);
-    if trace_id.is_empty() {
-        trace_id = fallback_trace_id_for_path(path);
-        warn!(
-            "manifest trace_id sanitized to empty; using {} from {}",
-            trace_id,
-            path.display()
-        );
-    } else if trace_id_is_placeholder(&trace_id) {
-        let fallback = hash_trace_id_for_path(path);
-        warn!(
-            "manifest trace_id is insufficient; using {} from {}",
-            fallback,
-            path.display()
-        );
-        trace_id = fallback;
-    } else if trace_id != raw_trace_id {
-        warn!(
-            "manifest trace_id sanitized from {} to {}",
-            raw_trace_id, trace_id
-        );
-    }
-
-    Ok(TraceMeta {
-        trace_id,
-        status: manifest.status.clone().unwrap_or_else(|| "ok".to_string()),
-        timestamp: manifest.timestamp.clone(),
-        duration_us,
-        rule: manifest.rule.clone(),
-        summary: manifest.summary.clone(),
-        path: path.display().to_string(),
-    })
 }
 
 fn build_trace_from_manifest(manifest: &TraceManifest, base_dir: &Path) -> Result<Value> {

--- a/crates/rulemorph_trace/src/trace_store/import_bundle.rs
+++ b/crates/rulemorph_trace/src/trace_store/import_bundle.rs
@@ -9,7 +9,8 @@ use walkdir::WalkDir;
 use super::import_path::{
     copy_file_create_new, ensure_import_base_dir, ensure_import_target_parent,
 };
-use super::{is_trace_meta_candidate, parse_trace_meta, rules_dir, traces_dir};
+use super::meta::parse_trace_meta;
+use super::{is_trace_meta_candidate, rules_dir, traces_dir};
 
 const IMPORT_MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 pub(super) const IMPORT_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/rulemorph_trace/src/trace_store/meta.rs
+++ b/crates/rulemorph_trace/src/trace_store/meta.rs
@@ -1,0 +1,210 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use tracing::warn;
+
+use super::TraceMeta;
+use super::legacy::looks_like_legacy_trace;
+use super::trace_id_path::{fallback_trace_id_for_path, hash_trace_id_for_path};
+use crate::trace_id::{sanitize_trace_id, trace_id_is_placeholder};
+use crate::trace_schema::{RuleMeta, TRACE_JSON_MAX_BYTES, TraceManifest, TraceSummary};
+
+pub(super) async fn read_trace_json_with_limit_async(path: &Path) -> Result<String> {
+    let metadata = tokio::fs::metadata(path)
+        .await
+        .with_context(|| format!("failed to read trace metadata: {}", path.display()))?;
+    if metadata.len() > TRACE_JSON_MAX_BYTES {
+        return Err(anyhow::anyhow!(
+            "trace json exceeds max bytes: {} > {}",
+            metadata.len(),
+            TRACE_JSON_MAX_BYTES
+        ));
+    }
+    tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("failed to read trace: {}", path.display()))
+}
+
+fn read_trace_json_with_limit(path: &Path) -> Result<String> {
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("failed to read trace metadata: {}", path.display()))?;
+    if metadata.len() > TRACE_JSON_MAX_BYTES {
+        return Err(anyhow::anyhow!(
+            "trace json exceeds max bytes: {} > {}",
+            metadata.len(),
+            TRACE_JSON_MAX_BYTES
+        ));
+    }
+    std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read trace: {}", path.display()))
+}
+
+pub(super) fn parse_trace_meta(path: &Path) -> Result<TraceMeta> {
+    let raw = read_trace_json_with_limit(path)?;
+    let value: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("invalid trace json: {}", path.display()))?;
+
+    if is_manifest(&value) {
+        let manifest: TraceManifest = serde_json::from_value(value)
+            .with_context(|| format!("invalid trace manifest: {}", path.display()))?;
+        return parse_manifest_meta(&manifest, path);
+    }
+
+    if !looks_like_legacy_trace(&value) {
+        return Err(anyhow::anyhow!("not a trace file"));
+    }
+
+    let raw_trace_id = value
+        .get("trace_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        });
+    let mut trace_id = sanitize_trace_id(&raw_trace_id);
+    if trace_id.is_empty() {
+        trace_id = fallback_trace_id_for_path(path);
+        warn!(
+            "legacy trace_id sanitized to empty; using {} from {}",
+            trace_id,
+            path.display()
+        );
+    } else if trace_id_is_placeholder(&trace_id) {
+        let fallback = hash_trace_id_for_path(path);
+        warn!(
+            "legacy trace_id is insufficient; using {} from {}",
+            fallback,
+            path.display()
+        );
+        trace_id = fallback;
+    } else if trace_id != raw_trace_id {
+        warn!(
+            "legacy trace_id sanitized from {} to {}",
+            raw_trace_id, trace_id
+        );
+    }
+
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("ok")
+        .to_string();
+
+    let timestamp = value
+        .get("timestamp")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let duration_us = value
+        .get("summary")
+        .and_then(|s| s.get("duration_us"))
+        .and_then(|v| v.as_u64())
+        .or_else(|| {
+            value
+                .get("summary")
+                .and_then(|s| s.get("duration_ms"))
+                .and_then(|v| v.as_u64())
+                .map(|v| v.saturating_mul(1000))
+        })
+        .or_else(|| value.get("duration_us").and_then(|v| v.as_u64()))
+        .or_else(|| {
+            value
+                .get("duration_ms")
+                .and_then(|v| v.as_u64())
+                .map(|v| v.saturating_mul(1000))
+        });
+
+    let rule = value.get("rule").map(|rule| RuleMeta {
+        name: rule
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        path: rule
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        r#type: rule
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        version: rule
+            .get("version")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u8),
+    });
+
+    let summary = value.get("summary").map(|summary| TraceSummary {
+        record_total: summary.get("record_total").and_then(|v| v.as_u64()),
+        record_success: summary.get("record_success").and_then(|v| v.as_u64()),
+        record_failed: summary.get("record_failed").and_then(|v| v.as_u64()),
+        duration_ms: summary.get("duration_ms").and_then(|v| v.as_u64()),
+        duration_us: summary.get("duration_us").and_then(|v| v.as_u64()),
+    });
+
+    Ok(TraceMeta {
+        trace_id,
+        status,
+        timestamp,
+        duration_us,
+        rule,
+        summary,
+        path: path.display().to_string(),
+    })
+}
+
+pub(super) fn is_manifest(value: &Value) -> bool {
+    value.get("trace_schema_version").is_some()
+}
+
+fn parse_manifest_meta(manifest: &TraceManifest, path: &Path) -> Result<TraceMeta> {
+    let duration_us = manifest
+        .summary
+        .as_ref()
+        .and_then(|summary| summary.duration_us)
+        .or_else(|| {
+            manifest
+                .summary
+                .as_ref()
+                .and_then(|summary| summary.duration_ms)
+                .map(|value| value.saturating_mul(1000))
+        });
+
+    let raw_trace_id = manifest.trace_id.clone();
+    let mut trace_id = sanitize_trace_id(&raw_trace_id);
+    if trace_id.is_empty() {
+        trace_id = fallback_trace_id_for_path(path);
+        warn!(
+            "manifest trace_id sanitized to empty; using {} from {}",
+            trace_id,
+            path.display()
+        );
+    } else if trace_id_is_placeholder(&trace_id) {
+        let fallback = hash_trace_id_for_path(path);
+        warn!(
+            "manifest trace_id is insufficient; using {} from {}",
+            fallback,
+            path.display()
+        );
+        trace_id = fallback;
+    } else if trace_id != raw_trace_id {
+        warn!(
+            "manifest trace_id sanitized from {} to {}",
+            raw_trace_id, trace_id
+        );
+    }
+
+    Ok(TraceMeta {
+        trace_id,
+        status: manifest.status.clone().unwrap_or_else(|| "ok".to_string()),
+        timestamp: manifest.timestamp.clone(),
+        duration_us,
+        rule: manifest.rule.clone(),
+        summary: manifest.summary.clone(),
+        path: path.display().to_string(),
+    })
+}


### PR DESCRIPTION
## Summary
- move trace JSON read and metadata parsing helpers into trace_store/meta.rs
- keep legacy and manifest trace metadata extraction behavior unchanged
- keep import/list/get public behavior and trace JSON schema unchanged

## Tests
- cargo fmt
- cargo test -p rulemorph_trace --test trace_store trace_store_ignores_oversized_trace_json
- cargo test -p rulemorph_trace --test trace_writer trace_id
- cargo test -p rulemorph_trace --test trace_store
- cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --quiet