### PR TITLE
Refactor trace writer atomic helper

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer.rs
+++ b/crates/rulemorph_trace/src/trace_writer.rs
@@ -1,17 +1,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-#[cfg(test)]
-use std::sync::Mutex;
-#[cfg(test)]
-use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chrono::{Datelike, Utc};
 use serde_json::Value as JsonValue;
 use tracing::warn;
 
+mod atomic;
 mod chunk_write;
 mod externalize;
 mod masking;
@@ -23,6 +20,9 @@ mod sampling;
 #[cfg(test)]
 mod write_failure_tests;
 
+#[cfg(test)]
+use atomic::fail_write_for_trace_id;
+use atomic::write_atomic;
 use chunk_write::{
     max_ndjson_line_bytes, total_chunk_bytes, write_finalize_chunk, write_node_chunks,
     write_record_chunks,
@@ -883,92 +883,4 @@ fn blob_total_bytes(blob_files: &[PathBuf]) -> u64 {
             }
         })
         .sum()
-}
-
-fn write_atomic(path: &Path, payload: &[u8]) -> Result<()> {
-    #[cfg(test)]
-    if should_fail_write(path) {
-        return Err(anyhow::anyhow!("forced write failure"));
-    }
-    let temp_path = temp_path_for(path)?;
-    fs::write(&temp_path, payload)
-        .with_context(|| format!("failed to write temporary file: {}", temp_path.display()))?;
-    if let Err(err) = fs::rename(&temp_path, path) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(anyhow::anyhow!(
-            "failed to rename temp file {} -> {}: {}",
-            temp_path.display(),
-            path.display(),
-            err
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-fn should_fail_write(path: &Path) -> bool {
-    let config = fail_write_config()
-        .lock()
-        .expect("fail write config lock")
-        .clone();
-    let Some(config) = config else {
-        return false;
-    };
-    if !path
-        .components()
-        .any(|component| component.as_os_str() == config.trace_id)
-    {
-        return false;
-    }
-    if let Some(filename) = config.filename.as_ref() {
-        return path.file_name() == Some(filename);
-    }
-    true
-}
-
-#[cfg(test)]
-#[derive(Clone, Debug)]
-struct FailWriteConfig {
-    trace_id: std::ffi::OsString,
-    filename: Option<std::ffi::OsString>,
-}
-
-#[cfg(test)]
-fn fail_write_config() -> &'static Mutex<Option<FailWriteConfig>> {
-    static FAIL_WRITE_CONFIG: OnceLock<Mutex<Option<FailWriteConfig>>> = OnceLock::new();
-    FAIL_WRITE_CONFIG.get_or_init(|| Mutex::new(None))
-}
-
-#[cfg(test)]
-struct FailWriteGuard;
-
-#[cfg(test)]
-impl Drop for FailWriteGuard {
-    fn drop(&mut self) {
-        let mut guard = fail_write_config().lock().expect("fail write config lock");
-        *guard = None;
-    }
-}
-
-#[cfg(test)]
-fn fail_write_for_trace_id(trace_id: &str, filename: Option<&str>) -> FailWriteGuard {
-    let mut guard = fail_write_config().lock().expect("fail write config lock");
-    *guard = Some(FailWriteConfig {
-        trace_id: std::ffi::OsString::from(trace_id),
-        filename: filename.map(std::ffi::OsString::from),
-    });
-    FailWriteGuard
-}
-
-fn temp_path_for(path: &Path) -> Result<PathBuf> {
-    let filename = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("missing file name for trace chunk"))?;
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let pid = std::process::id();
-    let temp_name = format!("{}.tmp-{pid}-{nanos}", filename.to_string_lossy());
-    Ok(path.with_file_name(temp_name))
 }

--- a/crates/rulemorph_trace/src/trace_writer/atomic.rs
+++ b/crates/rulemorph_trace/src/trace_writer/atomic.rs
@@ -1,0 +1,97 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::Mutex;
+#[cfg(test)]
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+
+pub(super) fn write_atomic(path: &Path, payload: &[u8]) -> Result<()> {
+    #[cfg(test)]
+    if should_fail_write(path) {
+        return Err(anyhow::anyhow!("forced write failure"));
+    }
+    let temp_path = temp_path_for(path)?;
+    fs::write(&temp_path, payload)
+        .with_context(|| format!("failed to write temporary file: {}", temp_path.display()))?;
+    if let Err(err) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(anyhow::anyhow!(
+            "failed to rename temp file {} -> {}: {}",
+            temp_path.display(),
+            path.display(),
+            err
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn should_fail_write(path: &Path) -> bool {
+    let config = fail_write_config()
+        .lock()
+        .expect("fail write config lock")
+        .clone();
+    let Some(config) = config else {
+        return false;
+    };
+    if !path
+        .components()
+        .any(|component| component.as_os_str() == config.trace_id)
+    {
+        return false;
+    }
+    if let Some(filename) = config.filename.as_ref() {
+        return path.file_name() == Some(filename);
+    }
+    true
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+struct FailWriteConfig {
+    trace_id: std::ffi::OsString,
+    filename: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+fn fail_write_config() -> &'static Mutex<Option<FailWriteConfig>> {
+    static FAIL_WRITE_CONFIG: OnceLock<Mutex<Option<FailWriteConfig>>> = OnceLock::new();
+    FAIL_WRITE_CONFIG.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(super) struct FailWriteGuard;
+
+#[cfg(test)]
+impl Drop for FailWriteGuard {
+    fn drop(&mut self) {
+        let mut guard = fail_write_config().lock().expect("fail write config lock");
+        *guard = None;
+    }
+}
+
+#[cfg(test)]
+pub(super) fn fail_write_for_trace_id(trace_id: &str, filename: Option<&str>) -> FailWriteGuard {
+    let mut guard = fail_write_config().lock().expect("fail write config lock");
+    *guard = Some(FailWriteConfig {
+        trace_id: std::ffi::OsString::from(trace_id),
+        filename: filename.map(std::ffi::OsString::from),
+    });
+    FailWriteGuard
+}
+
+fn temp_path_for(path: &Path) -> Result<PathBuf> {
+    let filename = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("missing file name for trace chunk"))?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let pid = std::process::id();
+    let temp_name = format!("{}.tmp-{pid}-{nanos}", filename.to_string_lossy());
+    Ok(path.with_file_name(temp_name))
+}


### PR DESCRIPTION
## Summary
- move trace_writer atomic file write helper into trace_writer/atomic.rs
- keep test-only write failure injection behind cfg(test)
- keep runtime behavior, error messages, public API, and trace JSON schema unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_trace trace_writer::write_failure_tests
- cargo test -p rulemorph_trace --test trace_writer
- cargo check -p rulemorph_trace --release
- cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- cargo test --quiet
- git diff --cached --check

Subagent reviews: PASS for no-behavior-change/atomic-write behavior and module-boundary/release-build risk review.