### PR TITLE
Refactor trace writer trace dir helper

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer.rs
+++ b/crates/rulemorph_trace/src/trace_writer.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -19,6 +18,7 @@ mod queue;
 mod queue_tests;
 mod record_nodes;
 mod sampling;
+mod trace_dir;
 #[cfg(test)]
 mod write_failure_tests;
 
@@ -42,6 +42,7 @@ use queue::{
 };
 use record_nodes::{normalize_inline_records, split_records_and_nodes};
 use sampling::{TracePriority, should_keep_full_detail, trace_priority};
+use trace_dir::ensure_unique_trace_dir;
 
 use crate::trace_backend::TraceWriteBackend;
 use crate::trace_id::{sanitize_trace_id, trace_id_is_placeholder};
@@ -703,47 +704,4 @@ fn write_trace_bundle_sync(
     trace_dir_guard.commit();
 
     Ok(manifest_path)
-}
-
-fn ensure_unique_trace_dir(
-    base_dir: &Path,
-    trace_id: String,
-    raw_trace_id: &str,
-) -> Result<(String, PathBuf)> {
-    fs::create_dir_all(base_dir)?;
-    let base_id = trace_id;
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let mut counter = 0usize;
-    loop {
-        let candidate = if counter == 0 {
-            base_id.clone()
-        } else {
-            let suffix = if counter == 1 {
-                format!("dup-{nanos}")
-            } else {
-                format!("dup-{nanos}-{}", counter - 1)
-            };
-            format!("{base_id}-{suffix}")
-        };
-        let trace_dir = base_dir.join(&candidate);
-        match fs::create_dir(&trace_dir) {
-            Ok(()) => {
-                if counter > 0 {
-                    warn!(
-                        "trace_id collision for {}; using {} instead",
-                        raw_trace_id, candidate
-                    );
-                }
-                return Ok((candidate, trace_dir));
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                counter = counter.saturating_add(1);
-                continue;
-            }
-            Err(err) => return Err(err.into()),
-        }
-    }
 }

--- a/crates/rulemorph_trace/src/trace_writer/trace_dir.rs
+++ b/crates/rulemorph_trace/src/trace_writer/trace_dir.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use tracing::warn;
+
+pub(super) fn ensure_unique_trace_dir(
+    base_dir: &Path,
+    trace_id: String,
+    raw_trace_id: &str,
+) -> Result<(String, PathBuf)> {
+    fs::create_dir_all(base_dir)?;
+    let base_id = trace_id;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut counter = 0usize;
+    loop {
+        let candidate = if counter == 0 {
+            base_id.clone()
+        } else {
+            let suffix = if counter == 1 {
+                format!("dup-{nanos}")
+            } else {
+                format!("dup-{nanos}-{}", counter - 1)
+            };
+            format!("{base_id}-{suffix}")
+        };
+        let trace_dir = base_dir.join(&candidate);
+        match fs::create_dir(&trace_dir) {
+            Ok(()) => {
+                if counter > 0 {
+                    warn!(
+                        "trace_id collision for {}; using {} instead",
+                        raw_trace_id, candidate
+                    );
+                }
+                return Ok((candidate, trace_dir));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                counter = counter.saturating_add(1);
+                continue;
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+}

--- a/crates/rulemorph_trace/src/trace_writer/write_failure_tests.rs
+++ b/crates/rulemorph_trace/src/trace_writer/write_failure_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use serde_json::json;
+use std::fs;
 
 #[test]
 fn write_trace_bundle_cleans_up_on_manifest_write_failure() {


### PR DESCRIPTION
## Summary
- Move trace directory collision handling into trace_writer/trace_dir.rs
- Keep trace writer behavior, trace_id collision suffixing, and schema unchanged
- Preserve write-failure test access after narrowing parent imports

## Tests
- cargo test -p rulemorph_trace --test trace_writer trace_id
- cargo test -p rulemorph_trace --test trace_writer collision
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_avoids_trace_id_collision_on_sanitize
- cargo check -p rulemorph_trace --release
- cargo fmt
- cargo fmt --check
- git diff --check
- cargo test -p rulemorph_trace
- cargo test --quiet
- cargo test -p rulemorph_trace trace_writer::write_failure_tests