### PR TITLE
Refactor trace writer options module

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer.rs
+++ b/crates/rulemorph_trace/src/trace_writer.rs
@@ -13,6 +13,7 @@ mod cleanup;
 mod externalize;
 mod manifest;
 mod masking;
+mod options;
 mod queue;
 #[cfg(test)]
 mod queue_tests;
@@ -36,6 +37,8 @@ use manifest::{
     reserve_budget,
 };
 use masking::{apply_masking, normalize_masking_rules};
+use options::clamp_max_chunk_bytes_uncompressed;
+pub use options::{TraceCompression, TraceDetailLevel, TraceWriteOptions, TraceWriterConfig};
 use queue::{
     TraceQueue, TraceWriteRequest, estimate_trace_bytes, evict_normal, push_request, queue_bytes,
     trace_id_for_log, trace_writer_loop,
@@ -47,25 +50,11 @@ use trace_dir::ensure_unique_trace_dir;
 use crate::trace_backend::TraceWriteBackend;
 use crate::trace_id::{sanitize_trace_id, trace_id_is_placeholder};
 use crate::trace_schema::{
-    TRACE_CHUNK_BYTES_UNCOMPRESSED_HARD_MAX, TRACE_CHUNK_COUNT_HARD_MAX, TRACE_JSON_MAX_BYTES,
-    TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX, TraceDetailRef, TraceManifest,
-    TraceMasking,
+    TRACE_CHUNK_COUNT_HARD_MAX, TRACE_JSON_MAX_BYTES, TRACE_NODE_COUNT_HARD_MAX,
+    TRACE_RECORD_COUNT_HARD_MAX, TraceDetailRef, TraceManifest, TraceMasking,
 };
 
-const DEFAULT_MAX_RECORDS_PER_CHUNK: usize = 200;
-const DEFAULT_MAX_NODES_PER_CHUNK: usize = 2000;
-const DEFAULT_MAX_CHUNK_BYTES: usize = 4 * 1024 * 1024; // 4MB
-const DEFAULT_MAX_TRACE_BYTES: usize = 10 * 1024 * 1024; // 10MB (compressed)
-const DEFAULT_MAX_PAYLOAD_BYTES: usize = 64 * 1024;
-const DEFAULT_PAYLOAD_PREVIEW_BYTES: usize = 1024;
-const DEFAULT_SAMPLING_RATE: f64 = 1.0;
-const DEFAULT_TRACE_QUEUE_CAPACITY: usize = 256;
-const DEFAULT_TRACE_QUEUE_MAX_BYTES: usize = 64 * 1024 * 1024;
 const TRACE_SCHEMA_VERSION: u8 = 1;
-
-fn clamp_max_chunk_bytes_uncompressed(value: usize) -> usize {
-    value.clamp(1, TRACE_CHUNK_BYTES_UNCOMPRESSED_HARD_MAX)
-}
 
 fn append_detail_reason(existing: Option<String>, reason: &str) -> Option<String> {
     match existing {
@@ -79,88 +68,6 @@ fn append_detail_reason(existing: Option<String>, reason: &str) -> Option<String
             } else {
                 Some(format!("{current},{reason}"))
             }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct TraceWriteOptions {
-    pub max_records_per_chunk: usize,
-    pub max_nodes_per_chunk: usize,
-    pub max_chunk_bytes_uncompressed: usize,
-    pub compression: TraceCompression,
-    pub detail_level: TraceDetailLevel,
-    pub max_bytes_per_trace: usize,
-    pub max_payload_bytes: usize,
-    pub payload_preview_bytes: usize,
-    pub masking_enabled: bool,
-    pub masking_rules: Vec<String>,
-    pub detail_reason: Option<String>,
-    pub split_nodes: bool,
-    pub sampling_rate: f64,
-    pub sampling_slow_threshold_us: Option<u64>,
-}
-
-impl Default for TraceWriteOptions {
-    fn default() -> Self {
-        Self {
-            max_records_per_chunk: DEFAULT_MAX_RECORDS_PER_CHUNK,
-            max_nodes_per_chunk: DEFAULT_MAX_NODES_PER_CHUNK,
-            max_chunk_bytes_uncompressed: DEFAULT_MAX_CHUNK_BYTES,
-            compression: TraceCompression::Zstd,
-            detail_level: TraceDetailLevel::Full,
-            max_bytes_per_trace: DEFAULT_MAX_TRACE_BYTES,
-            max_payload_bytes: DEFAULT_MAX_PAYLOAD_BYTES,
-            payload_preview_bytes: DEFAULT_PAYLOAD_PREVIEW_BYTES,
-            masking_enabled: true,
-            masking_rules: vec![
-                "password".to_string(),
-                "token".to_string(),
-                "secret".to_string(),
-                "authorization".to_string(),
-                "cookie".to_string(),
-                "api_key".to_string(),
-                "api-key".to_string(),
-                "apikey".to_string(),
-            ],
-            detail_reason: None,
-            split_nodes: true,
-            sampling_rate: DEFAULT_SAMPLING_RATE,
-            sampling_slow_threshold_us: None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TraceDetailLevel {
-    Full,
-    Basic,
-    Off,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum TraceCompression {
-    Zstd,
-    None,
-}
-
-#[derive(Clone)]
-pub struct TraceWriterConfig {
-    pub queue_capacity: usize,
-    pub queue_max_bytes: usize,
-    pub write_options: TraceWriteOptions,
-    pub spawn_worker: bool,
-    pub write_backend: Option<Arc<dyn TraceWriteBackend>>,
-}
-
-impl Default for TraceWriterConfig {
-    fn default() -> Self {
-        Self {
-            queue_capacity: DEFAULT_TRACE_QUEUE_CAPACITY,
-            queue_max_bytes: DEFAULT_TRACE_QUEUE_MAX_BYTES,
-            write_options: TraceWriteOptions::default(),
-            spawn_worker: true,
-            write_backend: None,
         }
     }
 }

--- a/crates/rulemorph_trace/src/trace_writer/options.rs
+++ b/crates/rulemorph_trace/src/trace_writer/options.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use crate::trace_backend::TraceWriteBackend;
+use crate::trace_schema::TRACE_CHUNK_BYTES_UNCOMPRESSED_HARD_MAX;
+
+const DEFAULT_MAX_RECORDS_PER_CHUNK: usize = 200;
+const DEFAULT_MAX_NODES_PER_CHUNK: usize = 2000;
+const DEFAULT_MAX_CHUNK_BYTES: usize = 4 * 1024 * 1024; // 4MB
+const DEFAULT_MAX_TRACE_BYTES: usize = 10 * 1024 * 1024; // 10MB (compressed)
+const DEFAULT_MAX_PAYLOAD_BYTES: usize = 64 * 1024;
+const DEFAULT_PAYLOAD_PREVIEW_BYTES: usize = 1024;
+pub(super) const DEFAULT_SAMPLING_RATE: f64 = 1.0;
+pub(super) const DEFAULT_TRACE_QUEUE_CAPACITY: usize = 256;
+pub(super) const DEFAULT_TRACE_QUEUE_MAX_BYTES: usize = 64 * 1024 * 1024;
+
+pub(super) fn clamp_max_chunk_bytes_uncompressed(value: usize) -> usize {
+    value.clamp(1, TRACE_CHUNK_BYTES_UNCOMPRESSED_HARD_MAX)
+}
+
+#[derive(Debug, Clone)]
+pub struct TraceWriteOptions {
+    pub max_records_per_chunk: usize,
+    pub max_nodes_per_chunk: usize,
+    pub max_chunk_bytes_uncompressed: usize,
+    pub compression: TraceCompression,
+    pub detail_level: TraceDetailLevel,
+    pub max_bytes_per_trace: usize,
+    pub max_payload_bytes: usize,
+    pub payload_preview_bytes: usize,
+    pub masking_enabled: bool,
+    pub masking_rules: Vec<String>,
+    pub detail_reason: Option<String>,
+    pub split_nodes: bool,
+    pub sampling_rate: f64,
+    pub sampling_slow_threshold_us: Option<u64>,
+}
+
+impl Default for TraceWriteOptions {
+    fn default() -> Self {
+        Self {
+            max_records_per_chunk: DEFAULT_MAX_RECORDS_PER_CHUNK,
+            max_nodes_per_chunk: DEFAULT_MAX_NODES_PER_CHUNK,
+            max_chunk_bytes_uncompressed: DEFAULT_MAX_CHUNK_BYTES,
+            compression: TraceCompression::Zstd,
+            detail_level: TraceDetailLevel::Full,
+            max_bytes_per_trace: DEFAULT_MAX_TRACE_BYTES,
+            max_payload_bytes: DEFAULT_MAX_PAYLOAD_BYTES,
+            payload_preview_bytes: DEFAULT_PAYLOAD_PREVIEW_BYTES,
+            masking_enabled: true,
+            masking_rules: vec![
+                "password".to_string(),
+                "token".to_string(),
+                "secret".to_string(),
+                "authorization".to_string(),
+                "cookie".to_string(),
+                "api_key".to_string(),
+                "api-key".to_string(),
+                "apikey".to_string(),
+            ],
+            detail_reason: None,
+            split_nodes: true,
+            sampling_rate: DEFAULT_SAMPLING_RATE,
+            sampling_slow_threshold_us: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceDetailLevel {
+    Full,
+    Basic,
+    Off,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum TraceCompression {
+    Zstd,
+    None,
+}
+
+#[derive(Clone)]
+pub struct TraceWriterConfig {
+    pub queue_capacity: usize,
+    pub queue_max_bytes: usize,
+    pub write_options: TraceWriteOptions,
+    pub spawn_worker: bool,
+    pub write_backend: Option<Arc<dyn TraceWriteBackend>>,
+}
+
+impl Default for TraceWriterConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: DEFAULT_TRACE_QUEUE_CAPACITY,
+            queue_max_bytes: DEFAULT_TRACE_QUEUE_MAX_BYTES,
+            write_options: TraceWriteOptions::default(),
+            spawn_worker: true,
+            write_backend: None,
+        }
+    }
+}

--- a/crates/rulemorph_trace/src/trace_writer/queue_tests.rs
+++ b/crates/rulemorph_trace/src/trace_writer/queue_tests.rs
@@ -1,3 +1,4 @@
+use super::options::{DEFAULT_TRACE_QUEUE_CAPACITY, DEFAULT_TRACE_QUEUE_MAX_BYTES};
 use super::*;
 use serde_json::json;
 

--- a/crates/rulemorph_trace/src/trace_writer/sampling.rs
+++ b/crates/rulemorph_trace/src/trace_writer/sampling.rs
@@ -1,6 +1,6 @@
 use serde_json::Value as JsonValue;
 
-use super::{DEFAULT_SAMPLING_RATE, TraceWriteOptions};
+use super::{TraceWriteOptions, options::DEFAULT_SAMPLING_RATE};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(super) enum TracePriority {


### PR DESCRIPTION
## Summary
- Move trace writer option/config types and default constants into trace_writer/options.rs
- Keep existing trace_writer public re-exports source-compatible
- Keep queue/sampling behavior and trace schema unchanged

## Tests
- cargo fmt
- cargo check -p rulemorph_trace --release
- cargo test -p rulemorph_trace trace_writer::queue_tests
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_clamps_chunk_size_option_to_schema_limit
- cargo test -p rulemorph_trace --test trace_writer
- cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- cargo test --quiet
- git diff --cached --check