### PR TITLE
Refactor trace writer detail state helpers

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer.rs
+++ b/crates/rulemorph_trace/src/trace_writer.rs
@@ -32,7 +32,9 @@ use chunk_write::{
     write_record_chunks,
 };
 use cleanup::{TraceDirGuard, cleanup_detail_files};
-use detail::{append_detail_reason, strip_trace_detail};
+use detail::{
+    append_detail_reason, detail_status_for_level, initial_detail_reasons, strip_trace_detail,
+};
 use externalize::externalize_trace_payloads;
 use manifest::{
     blob_total_bytes, count_inline_nodes, parse_date_parts, parse_rule_meta, parse_summary,
@@ -259,18 +261,7 @@ fn write_trace_bundle_sync(
     let mut detail_layout = "records_inline".to_string();
 
     let mut detail_level = options.detail_level;
-    let mut detail_reason = Vec::new();
-    if let Some(reason) = options.detail_reason.as_ref() {
-        for item in reason.split(|ch| ch == ',' || ch == ';') {
-            let trimmed = item.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            if !detail_reason.iter().any(|existing| existing == trimmed) {
-                detail_reason.push(trimmed.to_string());
-            }
-        }
-    }
+    let mut detail_reason = initial_detail_reasons(options.detail_reason.as_deref());
 
     if detail_level == TraceDetailLevel::Full
         && !should_keep_full_detail(&trace, &records_raw, &options)
@@ -279,11 +270,7 @@ fn write_trace_bundle_sync(
         detail_reason.push("sampled_out".to_string());
     }
 
-    let mut detail_status = match detail_level {
-        TraceDetailLevel::Full => "full".to_string(),
-        TraceDetailLevel::Basic => "basic".to_string(),
-        TraceDetailLevel::Off => "dropped".to_string(),
-    };
+    let mut detail_status = detail_status_for_level(detail_level);
 
     let masking_rules = if options.masking_enabled {
         normalize_masking_rules(&options.masking_rules)

--- a/crates/rulemorph_trace/src/trace_writer/detail.rs
+++ b/crates/rulemorph_trace/src/trace_writer/detail.rs
@@ -1,5 +1,7 @@
 use serde_json::Value as JsonValue;
 
+use super::options::TraceDetailLevel;
+
 pub(super) fn append_detail_reason(existing: Option<String>, reason: &str) -> Option<String> {
     match existing {
         None => Some(reason.to_string()),
@@ -13,6 +15,30 @@ pub(super) fn append_detail_reason(existing: Option<String>, reason: &str) -> Op
                 Some(format!("{current},{reason}"))
             }
         }
+    }
+}
+
+pub(super) fn initial_detail_reasons(reason: Option<&str>) -> Vec<String> {
+    let mut detail_reason = Vec::new();
+    if let Some(reason) = reason {
+        for item in reason.split(|ch| ch == ',' || ch == ';') {
+            let trimmed = item.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if !detail_reason.iter().any(|existing| existing == trimmed) {
+                detail_reason.push(trimmed.to_string());
+            }
+        }
+    }
+    detail_reason
+}
+
+pub(super) fn detail_status_for_level(detail_level: TraceDetailLevel) -> String {
+    match detail_level {
+        TraceDetailLevel::Full => "full".to_string(),
+        TraceDetailLevel::Basic => "basic".to_string(),
+        TraceDetailLevel::Off => "dropped".to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Move detail reason initialization and detail status mapping into trace_writer/detail.rs
- Keep detail.reason ordering/dedupe and detail.status strings unchanged
- Keep public API and trace JSON schema unchanged

## Tests
- cargo fmt
- cargo test -p rulemorph_trace trace_writer::queue_tests
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_sampling_skips_success
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_sampling_keeps_slow_trace
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_downgrades_on_oversized_record_line
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_downgrades_on_oversized_finalize
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_downgrades_on_budget_exceeded
- cargo test -p rulemorph_trace --test trace_writer
- cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- cargo test --quiet
- git diff --cached --check