### PR TITLE
Refactor trace writer enqueue helper

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer.rs
+++ b/crates/rulemorph_trace/src/trace_writer.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use serde_json::Value as JsonValue;
-use tracing::warn;
 
 mod atomic;
 mod chunk_write;
 mod cleanup;
 mod detail;
+mod enqueue;
 mod externalize;
 mod manifest;
 mod masking;
@@ -31,9 +31,8 @@ use chunk_write::{
     write_record_chunks,
 };
 use cleanup::{TraceDirGuard, cleanup_detail_files};
-use detail::{
-    append_detail_reason, detail_status_for_level, initial_detail_reasons, strip_trace_detail,
-};
+use detail::{detail_status_for_level, initial_detail_reasons, strip_trace_detail};
+use enqueue::enqueue_trace;
 use externalize::externalize_trace_payloads;
 use manifest::{
     blob_total_bytes, count_inline_nodes, parse_rule_meta, parse_summary, reserve_budget,
@@ -41,12 +40,9 @@ use manifest::{
 use masking::{apply_masking, normalize_masking_rules};
 use options::clamp_max_chunk_bytes_uncompressed;
 pub use options::{TraceCompression, TraceDetailLevel, TraceWriteOptions, TraceWriterConfig};
-use queue::{
-    TraceQueue, TraceWriteRequest, estimate_trace_bytes, evict_normal, push_request, queue_bytes,
-    trace_id_for_log, trace_writer_loop,
-};
+use queue::{TraceQueue, trace_writer_loop};
 use record_nodes::{normalize_inline_records, split_records_and_nodes};
-use sampling::{TracePriority, should_keep_full_detail, trace_priority};
+use sampling::should_keep_full_detail;
 use trace_dir::{ensure_unique_trace_dir, resolve_trace_timestamp, trace_dir_base_for_timestamp};
 use trace_identity::resolve_trace_id;
 
@@ -115,84 +111,7 @@ impl TraceWriter {
         options: Option<TraceWriteOptions>,
     ) -> bool {
         let options = options.unwrap_or_else(|| self.default_options.clone());
-        let priority = trace_priority(&trace, &options);
-        let mut request = TraceWriteRequest {
-            trace,
-            options,
-            priority,
-            downgraded: false,
-            approx_bytes: 0,
-        };
-        if request.options.detail_level != TraceDetailLevel::Full {
-            strip_trace_detail(&mut request.trace);
-        }
-        if request.options.masking_enabled {
-            let masking_rules = normalize_masking_rules(&request.options.masking_rules);
-            apply_masking(&mut request.trace, &masking_rules);
-        }
-        request.approx_bytes = estimate_trace_bytes(&request.trace);
-        let mut guard = self.queue.items.lock().expect("trace queue lock");
-        let mut current_bytes = queue_bytes(&guard);
-        let mut queue_full = guard.len() >= self.queue.capacity
-            || current_bytes.saturating_add(request.approx_bytes) > self.queue.max_bytes;
-
-        if queue_full && priority == TracePriority::High {
-            while guard.len() >= self.queue.capacity
-                || current_bytes.saturating_add(request.approx_bytes) > self.queue.max_bytes
-            {
-                if !evict_normal(&mut guard) {
-                    break;
-                }
-                current_bytes = queue_bytes(&guard);
-            }
-            queue_full = guard.len() >= self.queue.capacity
-                || current_bytes.saturating_add(request.approx_bytes) > self.queue.max_bytes;
-        }
-
-        if queue_full && request.options.detail_level == TraceDetailLevel::Full {
-            request.options.detail_level = TraceDetailLevel::Basic;
-            request.options.detail_reason =
-                append_detail_reason(request.options.detail_reason.take(), "queue_full");
-            request.downgraded = true;
-            strip_trace_detail(&mut request.trace);
-            request.approx_bytes = estimate_trace_bytes(&request.trace);
-            queue_full = guard.len() >= self.queue.capacity
-                || current_bytes.saturating_add(request.approx_bytes) > self.queue.max_bytes;
-
-            if queue_full && priority == TracePriority::High {
-                while guard.len() >= self.queue.capacity
-                    || current_bytes.saturating_add(request.approx_bytes) > self.queue.max_bytes
-                {
-                    if !evict_normal(&mut guard) {
-                        break;
-                    }
-                    current_bytes = queue_bytes(&guard);
-                }
-                queue_full = guard.len() >= self.queue.capacity
-                    || current_bytes.saturating_add(request.approx_bytes) > self.queue.max_bytes;
-            }
-        }
-
-        if queue_full {
-            let can_enqueue = match priority {
-                TracePriority::High => {
-                    guard.len() < self.queue.capacity
-                        && current_bytes.saturating_add(request.approx_bytes)
-                            <= self.queue.max_bytes
-                }
-                TracePriority::Normal => false,
-            };
-            if !can_enqueue {
-                warn!(
-                    "trace queue full; dropping trace {}",
-                    trace_id_for_log(&request.trace)
-                );
-                return false;
-            }
-        }
-        push_request(&mut guard, request);
-        self.queue.cvar.notify_one();
-        true
+        enqueue_trace(&self.queue, trace, options)
     }
 }
 

--- a/crates/rulemorph_trace/src/trace_writer/enqueue.rs
+++ b/crates/rulemorph_trace/src/trace_writer/enqueue.rs
@@ -1,0 +1,95 @@
+use serde_json::Value as JsonValue;
+use tracing::warn;
+
+use super::detail::{append_detail_reason, strip_trace_detail};
+use super::masking::{apply_masking, normalize_masking_rules};
+use super::options::{TraceDetailLevel, TraceWriteOptions};
+use super::queue::{
+    TraceQueue, TraceWriteRequest, estimate_trace_bytes, evict_normal, push_request, queue_bytes,
+    trace_id_for_log,
+};
+use super::sampling::{TracePriority, trace_priority};
+
+pub(super) fn enqueue_trace(
+    queue: &TraceQueue,
+    trace: JsonValue,
+    options: TraceWriteOptions,
+) -> bool {
+    let priority = trace_priority(&trace, &options);
+    let mut request = TraceWriteRequest {
+        trace,
+        options,
+        priority,
+        downgraded: false,
+        approx_bytes: 0,
+    };
+    if request.options.detail_level != TraceDetailLevel::Full {
+        strip_trace_detail(&mut request.trace);
+    }
+    if request.options.masking_enabled {
+        let masking_rules = normalize_masking_rules(&request.options.masking_rules);
+        apply_masking(&mut request.trace, &masking_rules);
+    }
+    request.approx_bytes = estimate_trace_bytes(&request.trace);
+    let mut guard = queue.items.lock().expect("trace queue lock");
+    let mut current_bytes = queue_bytes(&guard);
+    let mut queue_full = guard.len() >= queue.capacity
+        || current_bytes.saturating_add(request.approx_bytes) > queue.max_bytes;
+
+    if queue_full && priority == TracePriority::High {
+        while guard.len() >= queue.capacity
+            || current_bytes.saturating_add(request.approx_bytes) > queue.max_bytes
+        {
+            if !evict_normal(&mut guard) {
+                break;
+            }
+            current_bytes = queue_bytes(&guard);
+        }
+        queue_full = guard.len() >= queue.capacity
+            || current_bytes.saturating_add(request.approx_bytes) > queue.max_bytes;
+    }
+
+    if queue_full && request.options.detail_level == TraceDetailLevel::Full {
+        request.options.detail_level = TraceDetailLevel::Basic;
+        request.options.detail_reason =
+            append_detail_reason(request.options.detail_reason.take(), "queue_full");
+        request.downgraded = true;
+        strip_trace_detail(&mut request.trace);
+        request.approx_bytes = estimate_trace_bytes(&request.trace);
+        queue_full = guard.len() >= queue.capacity
+            || current_bytes.saturating_add(request.approx_bytes) > queue.max_bytes;
+
+        if queue_full && priority == TracePriority::High {
+            while guard.len() >= queue.capacity
+                || current_bytes.saturating_add(request.approx_bytes) > queue.max_bytes
+            {
+                if !evict_normal(&mut guard) {
+                    break;
+                }
+                current_bytes = queue_bytes(&guard);
+            }
+            queue_full = guard.len() >= queue.capacity
+                || current_bytes.saturating_add(request.approx_bytes) > queue.max_bytes;
+        }
+    }
+
+    if queue_full {
+        let can_enqueue = match priority {
+            TracePriority::High => {
+                guard.len() < queue.capacity
+                    && current_bytes.saturating_add(request.approx_bytes) <= queue.max_bytes
+            }
+            TracePriority::Normal => false,
+        };
+        if !can_enqueue {
+            warn!(
+                "trace queue full; dropping trace {}",
+                trace_id_for_log(&request.trace)
+            );
+            return false;
+        }
+    }
+    push_request(&mut guard, request);
+    queue.cvar.notify_one();
+    true
+}

--- a/crates/rulemorph_trace/src/trace_writer/queue_tests.rs
+++ b/crates/rulemorph_trace/src/trace_writer/queue_tests.rs
@@ -1,4 +1,6 @@
 use super::options::{DEFAULT_TRACE_QUEUE_CAPACITY, DEFAULT_TRACE_QUEUE_MAX_BYTES};
+use super::queue::trace_id_for_log;
+use super::sampling::TracePriority;
 use super::*;
 use serde_json::json;
 


### PR DESCRIPTION
## Summary
- move trace writer enqueue queue/downgrade/drop handling into trace_writer/enqueue.rs
- keep TraceWriter public enqueue APIs unchanged
- make queue tests import private helpers directly instead of relying on parent incidental imports

## Verification
- cargo fmt
- cargo test -p rulemorph_trace trace_writer::queue_tests
- cargo test -p rulemorph_trace --test trace_writer
- cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- cargo test --quiet
- git diff --cached --check