### PR TITLE
Refactor endpoint engine config helpers

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine.rs
@@ -17,13 +17,11 @@ use rulemorph::{
     parse_rule_file_with_format, transform_record, transform_record_with_base_dir,
     validate_rule_file_with_source,
 };
-use rulemorph_trace::{TraceWriteOptions, TraceWriter, TraceWriterConfig};
+use rulemorph_trace::{TraceWriter, TraceWriterConfig};
 use serde::Deserialize;
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use tracing::warn;
 
-const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
-const DEFAULT_MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const MULTIPART_IMPORT_MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 const MULTIPART_IMPORT_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
 const MULTIPART_IMPORT_MAX_ENTRIES: usize = 4096;
@@ -31,12 +29,16 @@ use uuid::Uuid;
 
 use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
 
+mod config;
 mod error;
+mod host;
 mod multipart_import;
 mod trace_graph;
 mod validation;
 
+pub use self::config::{ApiMode, EngineConfig, RequestContext};
 use self::error::{EndpointError, EndpointErrorKind};
+use self::host::internal_hosts_match;
 use self::multipart_import::build_multipart_import_body;
 #[cfg(test)]
 use self::multipart_import::{copy_zip_entry_bounded, extract_zip};
@@ -46,116 +48,6 @@ use self::trace_graph::{
     build_network_nodes_with_timing, build_rule_nodes_from_rule, build_rule_trace,
 };
 pub use self::validation::{RulesDirError, RulesDirErrors, validate_rules_dir};
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ApiMode {
-    UiOnly,
-    Rules,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct RequestContext {
-    pub tenant_id: Option<String>,
-    pub internal_api_key: Option<String>,
-}
-
-impl Default for ApiMode {
-    fn default() -> Self {
-        ApiMode::Rules
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct EngineConfig {
-    pub internal_base: String,
-    pub data_dir: PathBuf,
-    pub trace_write_options: TraceWriteOptions,
-    pub max_body_bytes: usize,
-    pub max_response_bytes: usize,
-    pub ssrf_allowlist: Vec<String>,
-    pub ssrf_allow_private: bool,
-    pub ssrf_private_allowlist: Vec<String>,
-    pub allow_internal_auth: bool,
-    pub internal_auth_path_allowlist: Vec<String>,
-    pub internal_api_key: Option<String>,
-}
-
-impl EngineConfig {
-    pub fn new(internal_base: String, data_dir: PathBuf) -> Self {
-        let mut config = Self {
-            internal_base,
-            data_dir,
-            trace_write_options: TraceWriteOptions::default(),
-            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
-            ssrf_allowlist: Vec::new(),
-            ssrf_allow_private: false,
-            ssrf_private_allowlist: Vec::new(),
-            allow_internal_auth: false,
-            internal_auth_path_allowlist: Vec::new(),
-            internal_api_key: None,
-        };
-        if let Ok(parsed) = url::Url::parse(&config.internal_base) {
-            if let Some(host) = parsed.host_str() {
-                config.ssrf_private_allowlist.push(host.to_string());
-                if is_loopback_host(&normalize_internal_host(host)) {
-                    config
-                        .ssrf_private_allowlist
-                        .extend(["localhost", "127.0.0.1", "::1"].map(str::to_string));
-                    config.ssrf_private_allowlist.sort();
-                    config.ssrf_private_allowlist.dedup();
-                }
-            }
-        }
-        config
-    }
-
-    pub fn with_trace_write_options(mut self, trace_write_options: TraceWriteOptions) -> Self {
-        self.trace_write_options = trace_write_options;
-        self
-    }
-
-    pub fn with_max_body_bytes(mut self, max_body_bytes: usize) -> Self {
-        self.max_body_bytes = max_body_bytes;
-        self
-    }
-
-    pub fn with_max_response_bytes(mut self, max_response_bytes: usize) -> Self {
-        self.max_response_bytes = max_response_bytes;
-        self
-    }
-
-    pub fn with_ssrf_allowlist(mut self, ssrf_allowlist: Vec<String>) -> Self {
-        self.ssrf_allowlist = ssrf_allowlist;
-        self
-    }
-
-    pub fn with_ssrf_allow_private(mut self, ssrf_allow_private: bool) -> Self {
-        self.ssrf_allow_private = ssrf_allow_private;
-        self
-    }
-
-    pub fn with_ssrf_private_allowlist(mut self, ssrf_private_allowlist: Vec<String>) -> Self {
-        self.ssrf_private_allowlist = ssrf_private_allowlist;
-        self
-    }
-
-    pub fn with_internal_auth_enabled(mut self, enabled: bool) -> Self {
-        self.allow_internal_auth = enabled;
-        self
-    }
-
-    pub fn with_internal_auth_path_allowlist(mut self, allowlist: Vec<String>) -> Self {
-        self.internal_auth_path_allowlist = allowlist;
-        self
-    }
-
-    pub fn with_internal_api_key(mut self, internal_api_key: String) -> Self {
-        self.internal_api_key = Some(internal_api_key);
-        self.allow_internal_auth = true;
-        self
-    }
-}
 
 pub struct EndpointEngine {
     endpoint_rule: CompiledEndpointRule,
@@ -1805,24 +1697,6 @@ fn is_multipart_form_data(headers: &HeaderMap) -> bool {
 
 fn is_multipart_import_request(method: &Method, path: &str, headers: &HeaderMap) -> bool {
     method == Method::POST && path == "/api/import" && is_multipart_form_data(headers)
-}
-
-fn internal_hosts_match(target: Option<&str>, base: Option<&str>) -> bool {
-    let Some(target) = target.map(normalize_internal_host) else {
-        return false;
-    };
-    let Some(base) = base.map(normalize_internal_host) else {
-        return false;
-    };
-    target == base || is_loopback_host(&target) && is_loopback_host(&base)
-}
-
-fn normalize_internal_host(host: &str) -> String {
-    host.trim().trim_end_matches('.').to_ascii_lowercase()
-}
-
-fn is_loopback_host(host: &str) -> bool {
-    matches!(host, "localhost" | "127.0.0.1" | "::1")
 }
 
 fn build_headers(

--- a/crates/rulemorph_endpoint/src/endpoint_engine/config.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/config.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+
+use rulemorph_trace::TraceWriteOptions;
+
+use super::host::{is_loopback_host, normalize_internal_host};
+
+const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+const DEFAULT_MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApiMode {
+    UiOnly,
+    Rules,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RequestContext {
+    pub tenant_id: Option<String>,
+    pub internal_api_key: Option<String>,
+}
+
+impl Default for ApiMode {
+    fn default() -> Self {
+        ApiMode::Rules
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct EngineConfig {
+    pub internal_base: String,
+    pub data_dir: PathBuf,
+    pub trace_write_options: TraceWriteOptions,
+    pub max_body_bytes: usize,
+    pub max_response_bytes: usize,
+    pub ssrf_allowlist: Vec<String>,
+    pub ssrf_allow_private: bool,
+    pub ssrf_private_allowlist: Vec<String>,
+    pub allow_internal_auth: bool,
+    pub internal_auth_path_allowlist: Vec<String>,
+    pub internal_api_key: Option<String>,
+}
+
+impl EngineConfig {
+    pub fn new(internal_base: String, data_dir: PathBuf) -> Self {
+        let mut config = Self {
+            internal_base,
+            data_dir,
+            trace_write_options: TraceWriteOptions::default(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+            ssrf_allowlist: Vec::new(),
+            ssrf_allow_private: false,
+            ssrf_private_allowlist: Vec::new(),
+            allow_internal_auth: false,
+            internal_auth_path_allowlist: Vec::new(),
+            internal_api_key: None,
+        };
+        if let Ok(parsed) = url::Url::parse(&config.internal_base) {
+            if let Some(host) = parsed.host_str() {
+                config.ssrf_private_allowlist.push(host.to_string());
+                if is_loopback_host(&normalize_internal_host(host)) {
+                    config
+                        .ssrf_private_allowlist
+                        .extend(["localhost", "127.0.0.1", "::1"].map(str::to_string));
+                    config.ssrf_private_allowlist.sort();
+                    config.ssrf_private_allowlist.dedup();
+                }
+            }
+        }
+        config
+    }
+
+    pub fn with_trace_write_options(mut self, trace_write_options: TraceWriteOptions) -> Self {
+        self.trace_write_options = trace_write_options;
+        self
+    }
+
+    pub fn with_max_body_bytes(mut self, max_body_bytes: usize) -> Self {
+        self.max_body_bytes = max_body_bytes;
+        self
+    }
+
+    pub fn with_max_response_bytes(mut self, max_response_bytes: usize) -> Self {
+        self.max_response_bytes = max_response_bytes;
+        self
+    }
+
+    pub fn with_ssrf_allowlist(mut self, ssrf_allowlist: Vec<String>) -> Self {
+        self.ssrf_allowlist = ssrf_allowlist;
+        self
+    }
+
+    pub fn with_ssrf_allow_private(mut self, ssrf_allow_private: bool) -> Self {
+        self.ssrf_allow_private = ssrf_allow_private;
+        self
+    }
+
+    pub fn with_ssrf_private_allowlist(mut self, ssrf_private_allowlist: Vec<String>) -> Self {
+        self.ssrf_private_allowlist = ssrf_private_allowlist;
+        self
+    }
+
+    pub fn with_internal_auth_enabled(mut self, enabled: bool) -> Self {
+        self.allow_internal_auth = enabled;
+        self
+    }
+
+    pub fn with_internal_auth_path_allowlist(mut self, allowlist: Vec<String>) -> Self {
+        self.internal_auth_path_allowlist = allowlist;
+        self
+    }
+
+    pub fn with_internal_api_key(mut self, internal_api_key: String) -> Self {
+        self.internal_api_key = Some(internal_api_key);
+        self.allow_internal_auth = true;
+        self
+    }
+}

--- a/crates/rulemorph_endpoint/src/endpoint_engine/host.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/host.rs
@@ -1,0 +1,17 @@
+pub(super) fn internal_hosts_match(target: Option<&str>, base: Option<&str>) -> bool {
+    let Some(target) = target.map(normalize_internal_host) else {
+        return false;
+    };
+    let Some(base) = base.map(normalize_internal_host) else {
+        return false;
+    };
+    target == base || is_loopback_host(&target) && is_loopback_host(&base)
+}
+
+pub(super) fn normalize_internal_host(host: &str) -> String {
+    host.trim().trim_end_matches('.').to_ascii_lowercase()
+}
+
+pub(super) fn is_loopback_host(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+}


### PR DESCRIPTION
## Summary
- move endpoint engine public config types into endpoint_engine/config.rs
- move internal host normalization helpers into endpoint_engine/host.rs
- preserve rulemorph_endpoint re-exports, EngineConfig defaults/builders, and internal auth/SSRF host behavior

## Verification
- cargo fmt
- cargo test -p rulemorph_endpoint internal_hosts_match_loopback_aliases
- cargo test -p rulemorph_endpoint engine_config_allows_loopback_aliases_for_internal_base
- cargo test -p rulemorph_endpoint internal_auth
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- git diff --cached --check
- cargo test --quiet

## Review
- Subagent public re-export/config review: PASS
- Subagent security-boundary/dependency review: PASS