### PR TITLE
Refactor endpoint catch helpers

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 
 use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
 
+mod catch;
 mod config;
 mod endpoint_rule;
 mod error;
@@ -38,6 +39,7 @@ mod rule_ref;
 mod trace_graph;
 mod validation;
 
+use self::catch::CatchSpec;
 pub use self::config::{ApiMode, EngineConfig, RequestContext};
 #[cfg(test)]
 use self::endpoint_rule::EndpointPath;
@@ -1302,45 +1304,6 @@ fn build_ssrf_audit_log(
         method: rule.request.method.clone(),
         url: redact_ssrf_url(url),
         reason: reason.to_string(),
-    }
-}
-
-#[derive(Debug)]
-struct CatchSpec(HashMap<String, String>);
-
-impl From<HashMap<String, String>> for CatchSpec {
-    fn from(value: HashMap<String, String>) -> Self {
-        CatchSpec(value)
-    }
-}
-
-impl CatchSpec {
-    fn match_target(&self, error: &EndpointError) -> Option<PathBuf> {
-        let map = &self.0;
-        if let Some(status) = error.status {
-            let key = status.to_string();
-            if let Some(value) = map.get(&key) {
-                return Some(PathBuf::from(value));
-            }
-            let pattern = if (400..500).contains(&status) {
-                "4xx"
-            } else if (500..600).contains(&status) {
-                "5xx"
-            } else {
-                ""
-            };
-            if !pattern.is_empty() {
-                if let Some(value) = map.get(pattern) {
-                    return Some(PathBuf::from(value));
-                }
-            }
-        }
-        if error.kind == EndpointErrorKind::Timeout {
-            if let Some(value) = map.get("timeout") {
-                return Some(PathBuf::from(value));
-            }
-        }
-        map.get("default").map(PathBuf::from)
     }
 }
 

--- a/crates/rulemorph_endpoint/src/endpoint_engine/catch.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/catch.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::error::{EndpointError, EndpointErrorKind};
+
+#[derive(Debug)]
+pub(super) struct CatchSpec(HashMap<String, String>);
+
+impl From<HashMap<String, String>> for CatchSpec {
+    fn from(value: HashMap<String, String>) -> Self {
+        CatchSpec(value)
+    }
+}
+
+impl CatchSpec {
+    pub(super) fn match_target(&self, error: &EndpointError) -> Option<PathBuf> {
+        let map = &self.0;
+        if let Some(status) = error.status {
+            let key = status.to_string();
+            if let Some(value) = map.get(&key) {
+                return Some(PathBuf::from(value));
+            }
+            let pattern = if (400..500).contains(&status) {
+                "4xx"
+            } else if (500..600).contains(&status) {
+                "5xx"
+            } else {
+                ""
+            };
+            if !pattern.is_empty() {
+                if let Some(value) = map.get(pattern) {
+                    return Some(PathBuf::from(value));
+                }
+            }
+        }
+        if error.kind == EndpointErrorKind::Timeout {
+            if let Some(value) = map.get("timeout") {
+                return Some(PathBuf::from(value));
+            }
+        }
+        map.get("default").map(PathBuf::from)
+    }
+}

--- a/crates/rulemorph_endpoint/src/endpoint_engine/endpoint_rule.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/endpoint_rule.rs
@@ -8,7 +8,7 @@ use rulemorph::v2_parser::{parse_v2_condition, parse_v2_expr};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
-use super::CatchSpec;
+use super::catch::CatchSpec;
 
 #[derive(Debug)]
 pub(super) struct CompiledEndpointRule {

--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_rule.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_rule.rs
@@ -10,7 +10,7 @@ use rulemorph::{Mapping, RuleFormat, parse_rule_file_with_format, validate_rule_
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
-use super::{CatchSpec, LoadedRule, resolve_rule_path, rule_ref_from_path};
+use super::{LoadedRule, catch::CatchSpec, resolve_rule_path, rule_ref_from_path};
 
 #[derive(Debug)]
 pub(super) struct CompiledNetworkRule {


### PR DESCRIPTION
## Summary
- Move endpoint/network catch matching helper into endpoint_engine/catch.rs
- Keep catch target priority, EndpointEngine runtime, validator behavior, HTTP contract, trace schema, and public exports unchanged
- Leave unrelated local planning artifacts unstaged/uncommitted

## Verification
- cargo fmt
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint catch
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check
- cargo test --quiet

## Review
- Controller dependency/visibility review: PASS