### PR TITLE
Refactor endpoint SSRF audit helpers

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine.rs
@@ -37,6 +37,7 @@ mod multipart_import;
 mod network_rule;
 mod request_input;
 mod rule_ref;
+mod ssrf_audit;
 mod trace_graph;
 mod validation;
 
@@ -62,6 +63,7 @@ use self::rule_ref::{
     resolve_rule_path, rule_display_name, rule_ref_from_path, rule_ref_from_rule,
     safe_rule_ref_from_path,
 };
+use self::ssrf_audit::build_ssrf_audit_log;
 #[cfg(test)]
 use self::trace_graph::{build_mapping_ops_with_values, sum_rule_trace_duration_us};
 use self::trace_graph::{
@@ -1261,53 +1263,6 @@ impl EndpointEngine {
             }
         }
         value
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SsrAuditLog {
-    tenant_id: String,
-    rule_ref: String,
-    method: Method,
-    url: String,
-    reason: String,
-}
-
-fn redact_ssrf_url(url: &str) -> String {
-    let Ok(parsed) = url::Url::parse(url) else {
-        return url.to_string();
-    };
-    let host = match parsed.host_str() {
-        Some(host) => host,
-        None => return url.to_string(),
-    };
-    let port = parsed
-        .port()
-        .map(|value| format!(":{value}"))
-        .unwrap_or_default();
-    format!("{}://{}{}{}", parsed.scheme(), host, port, parsed.path())
-}
-
-fn build_ssrf_audit_log(
-    rule: &CompiledNetworkRule,
-    url: &str,
-    reason: &str,
-    request_context: Option<&RequestContext>,
-) -> SsrAuditLog {
-    let tenant_id = request_context
-        .and_then(|ctx| ctx.tenant_id.as_ref())
-        .cloned()
-        .unwrap_or_else(|| "unknown".to_string());
-    let rule_ref = rule
-        .rule_ref
-        .clone()
-        .unwrap_or_else(|| "unknown".to_string());
-    SsrAuditLog {
-        tenant_id,
-        rule_ref,
-        method: rule.request.method.clone(),
-        url: redact_ssrf_url(url),
-        reason: reason.to_string(),
     }
 }
 

--- a/crates/rulemorph_endpoint/src/endpoint_engine/ssrf_audit.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/ssrf_audit.rs
@@ -4,7 +4,7 @@ use super::config::RequestContext;
 use super::network_rule::CompiledNetworkRule;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct SsrAuditLog {
+pub(super) struct SsrfAuditLog {
     pub(super) tenant_id: String,
     pub(super) rule_ref: String,
     pub(super) method: Method,
@@ -32,7 +32,7 @@ pub(super) fn build_ssrf_audit_log(
     url: &str,
     reason: &str,
     request_context: Option<&RequestContext>,
-) -> SsrAuditLog {
+) -> SsrfAuditLog {
     let tenant_id = request_context
         .and_then(|ctx| ctx.tenant_id.as_ref())
         .cloned()
@@ -41,7 +41,7 @@ pub(super) fn build_ssrf_audit_log(
         .rule_ref
         .clone()
         .unwrap_or_else(|| "unknown".to_string());
-    SsrAuditLog {
+    SsrfAuditLog {
         tenant_id,
         rule_ref,
         method: rule.request.method.clone(),

--- a/crates/rulemorph_endpoint/src/endpoint_engine/ssrf_audit.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/ssrf_audit.rs
@@ -1,0 +1,51 @@
+use axum::http::Method;
+
+use super::config::RequestContext;
+use super::network_rule::CompiledNetworkRule;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SsrAuditLog {
+    pub(super) tenant_id: String,
+    pub(super) rule_ref: String,
+    pub(super) method: Method,
+    pub(super) url: String,
+    pub(super) reason: String,
+}
+
+fn redact_ssrf_url(url: &str) -> String {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return url.to_string();
+    };
+    let host = match parsed.host_str() {
+        Some(host) => host,
+        None => return url.to_string(),
+    };
+    let port = parsed
+        .port()
+        .map(|value| format!(":{value}"))
+        .unwrap_or_default();
+    format!("{}://{}{}{}", parsed.scheme(), host, port, parsed.path())
+}
+
+pub(super) fn build_ssrf_audit_log(
+    rule: &CompiledNetworkRule,
+    url: &str,
+    reason: &str,
+    request_context: Option<&RequestContext>,
+) -> SsrAuditLog {
+    let tenant_id = request_context
+        .and_then(|ctx| ctx.tenant_id.as_ref())
+        .cloned()
+        .unwrap_or_else(|| "unknown".to_string());
+    let rule_ref = rule
+        .rule_ref
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    SsrAuditLog {
+        tenant_id,
+        rule_ref,
+        method: rule.request.method.clone(),
+        url: redact_ssrf_url(url),
+        reason: reason.to_string(),
+    }
+}


### PR DESCRIPTION
## Summary
- Move endpoint SSRF audit log construction into crates/rulemorph_endpoint/src/endpoint_engine/ssrf_audit.rs
- Keep SSRF resolution/blocking, network execution, HTTP behavior, trace schema, and public exports unchanged
- Keep the split mechanical and limited to private audit helper placement

## Verification
- cargo fmt
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint ssrf_audit_log
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check
- cargo test --quiet

## Review
- Subagent staged-diff review: PASS
