### PR TITLE
Refactor endpoint request runtime helper

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine.rs
@@ -3,23 +3,22 @@ use std::collections::HashMap;
 #[cfg(test)]
 use std::path::Path;
 use std::path::PathBuf;
+#[cfg(test)]
 use std::time::Instant;
 
 use anyhow::{Context, Result, anyhow};
 #[cfg(test)]
 use axum::http::HeaderMap;
-use axum::http::{Method, Request};
-use axum::response::Response;
-use http_body_util::LengthLimitError;
+use axum::http::Method;
+#[cfg(test)]
+use axum::http::Request;
 #[cfg(test)]
 use rulemorph::Mapping;
 use rulemorph::serde_guard::parse_yaml_value_strict;
-use rulemorph::v2_eval::{V2EvalContext, eval_v2_condition};
 #[cfg(test)]
 use rulemorph::v2_parser::parse_v2_expr;
 use rulemorph_trace::{TraceWriter, TraceWriterConfig};
 use serde_json::{Value as JsonValue, json};
-use tracing::warn;
 
 const MULTIPART_IMPORT_MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 const MULTIPART_IMPORT_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
@@ -37,6 +36,7 @@ mod network_exec;
 mod network_rule;
 mod reply_context;
 mod request_input;
+mod request_runtime;
 mod rule_exec;
 mod rule_loader;
 mod rule_ref;
@@ -52,12 +52,10 @@ use self::endpoint_rule::{CompiledEndpointRule, EndpointRuleFile};
 use self::error::EndpointError;
 #[cfg(test)]
 use self::error::EndpointErrorKind;
-use self::expr::apply_mappings_via_rule;
 #[cfg(test)]
 use self::expr::{build_headers, eval_expr_string};
 #[cfg(test)]
 use self::host::internal_hosts_match;
-use self::multipart_import::build_multipart_import_body;
 #[cfg(test)]
 use self::multipart_import::{copy_zip_entry_bounded, extract_zip};
 #[cfg(test)]
@@ -65,9 +63,6 @@ use self::network_rule::compile_network_rule;
 #[cfg(test)]
 use self::network_rule::{CompiledNetworkRequest, NetworkRequest};
 use self::network_rule::{CompiledNetworkRule, NetworkRuleFile, compile_retry, parse_duration};
-use self::request_input::{
-    build_input, build_input_from_parts, is_multipart_import_request, parse_query,
-};
 #[cfg(test)]
 use self::rule_loader::LoadedRule;
 use self::rule_ref::{
@@ -88,20 +83,6 @@ pub struct EndpointEngine {
     raw_rule_source: JsonValue,
     config: EngineConfig,
     trace_writer: TraceWriter,
-}
-
-fn is_length_limit_error(err: &axum::Error) -> bool {
-    let mut current: &(dyn std::error::Error + 'static) = err;
-    if current.is::<LengthLimitError>() {
-        return true;
-    }
-    while let Some(source) = current.source() {
-        if source.is::<LengthLimitError>() {
-            return true;
-        }
-        current = source;
-    }
-    false
 }
 
 struct NetworkExecution {
@@ -151,306 +132,6 @@ impl EndpointEngine {
 
     pub fn has_endpoint(&self, method: &Method, path: &str) -> bool {
         self.endpoint_rule.match_endpoint(method, path).is_some()
-    }
-
-    pub async fn handle_request(&self, request: Request<axum::body::Body>) -> Result<Response> {
-        let started = Instant::now();
-        let (parts, body) = request.into_parts();
-        let request_context = parts
-            .extensions
-            .get::<RequestContext>()
-            .cloned()
-            .unwrap_or_default();
-        let base_context = self.build_context_json(Some(&request_context));
-        let method = parts.method.clone();
-        let path = parts.uri.path().to_string();
-        let endpoint_match = self
-            .endpoint_rule
-            .match_endpoint(&method, &path)
-            .ok_or_else(|| anyhow!("no endpoint matched"))?;
-        let is_multipart = is_multipart_import_request(&method, &path, &parts.headers);
-        let mut _multipart_temp_dir: Option<tempfile::TempDir> = None;
-        let body_value = if is_multipart {
-            match build_multipart_import_body(&parts.headers, body).await {
-                Ok((body, temp_dir)) => {
-                    _multipart_temp_dir = Some(temp_dir);
-                    Ok(Some(body))
-                }
-                Err(err) => Err(err),
-            }
-        } else {
-            let body_limit = self.config.max_body_bytes;
-            match axum::body::to_bytes(body, body_limit).await {
-                Ok(body_bytes) if body_bytes.is_empty() => Ok(None),
-                Ok(body_bytes) => serde_json::from_slice::<JsonValue>(&body_bytes)
-                    .map(Some)
-                    .map_err(|err| EndpointError::invalid(err.to_string())),
-                Err(err) if is_length_limit_error(&err) => {
-                    Err(EndpointError::payload_too_large(body_limit))
-                }
-                Err(err) => Err(EndpointError::network(format!(
-                    "request body read error: {}",
-                    err
-                ))),
-            }
-        };
-
-        let endpoint = endpoint_match.endpoint;
-        let mut nodes: Vec<JsonValue> = Vec::new();
-        let mut record_status = "ok".to_string();
-        let mut record_error: Option<JsonValue> = None;
-        let mut last_error_message: Option<String> = None;
-        let mut skip_steps = false;
-
-        let mut handle_input_error = |err: EndpointError,
-                                      fallback_input: Option<JsonValue>,
-                                      body_value: Option<JsonValue>|
-         -> Result<(JsonValue, JsonValue)> {
-            skip_steps = true;
-            let fallback_input = fallback_input.unwrap_or_else(|| {
-                let query = parse_query(parts.uri.query()).unwrap_or_else(|_| empty_object());
-                build_input_from_parts(&parts, &endpoint_match.params, body_value, query)
-            });
-            if let Some(catch) = &endpoint.catch {
-                if let Some(next) = self
-                    .run_catch(
-                        catch,
-                        &err,
-                        &fallback_input,
-                        None,
-                        &self.endpoint_rule.base_dir,
-                        &base_context,
-                    )
-                    .map_err(|err| anyhow!(err.to_string()))?
-                {
-                    Ok((fallback_input, next))
-                } else {
-                    record_status = "error".to_string();
-                    record_error = Some(self.endpoint_error_to_trace(&err));
-                    last_error_message = Some(err.message.clone());
-                    Ok((fallback_input.clone(), fallback_input))
-                }
-            } else {
-                record_status = "error".to_string();
-                record_error = Some(self.endpoint_error_to_trace(&err));
-                last_error_message = Some(err.message.clone());
-                Ok((fallback_input.clone(), fallback_input))
-            }
-        };
-
-        let (record_input, mut current) = match body_value {
-            Ok(body_value) => match build_input(&parts, &endpoint_match.params, body_value.clone())
-            {
-                Ok(input) => {
-                    let record_input = input.clone();
-                    let current_result: Result<JsonValue, EndpointError> =
-                        if let Some(mappings) = &endpoint.input {
-                            apply_mappings_via_rule(mappings, &input, Some(&base_context))
-                                .map_err(EndpointError::from_transform)
-                                .map(|value| value.unwrap_or_else(empty_object))
-                        } else {
-                            Ok(input.clone())
-                        };
-                    match current_result {
-                        Ok(current) => Ok((record_input, current)),
-                        Err(err) => handle_input_error(err, Some(input), body_value),
-                    }
-                }
-                Err(err) => handle_input_error(err, None, body_value),
-            },
-            Err(err) => handle_input_error(err, None, None),
-        }?;
-
-        if !skip_steps {
-            for (step_index, step) in endpoint.steps.iter().enumerate() {
-                let step_input = current.clone();
-                let step_started = Instant::now();
-                if let Some(condition) = &step.when {
-                    let ctx = V2EvalContext::new();
-                    let keep = eval_v2_condition(
-                        condition,
-                        &current,
-                        Some(&base_context),
-                        &empty_object(),
-                        "steps.when",
-                        &ctx,
-                    )?;
-                    if !keep {
-                        let duration_us = step_started.elapsed().as_micros() as u64;
-                        nodes.push(self.build_step_trace(
-                            step_index,
-                            step,
-                            "skipped",
-                            step_input,
-                            Some(current.clone()),
-                            None,
-                            duration_us,
-                            None,
-                        ));
-                        continue;
-                    }
-                }
-                let step_context = self.step_context(&base_context, step.with.as_ref(), None);
-                let step_result = self
-                    .execute_rule(
-                        &step.rule,
-                        &current,
-                        Some(&step_context),
-                        &self.endpoint_rule.base_dir,
-                        Some(&request_context),
-                    )
-                    .await;
-                match step_result {
-                    Ok(execution) => {
-                        current = execution.output.clone();
-                        let duration_us = step_started.elapsed().as_micros() as u64;
-                        nodes.push(self.build_step_trace(
-                            step_index,
-                            step,
-                            "ok",
-                            step_input,
-                            Some(execution.output),
-                            None,
-                            duration_us,
-                            execution.child_trace,
-                        ));
-                    }
-                    Err(err) => {
-                        if let Some(catch) = &step.catch {
-                            if let Some(next) = self
-                                .run_catch(
-                                    catch,
-                                    &err.error,
-                                    &current,
-                                    step.with.as_ref(),
-                                    &self.endpoint_rule.base_dir,
-                                    &base_context,
-                                )
-                                .map_err(|err| anyhow!(err.to_string()))?
-                            {
-                                current = next.clone();
-                                let duration_us = step_started.elapsed().as_micros() as u64;
-                                nodes.push(self.build_step_trace(
-                                    step_index,
-                                    step,
-                                    "ok",
-                                    step_input,
-                                    Some(next),
-                                    None,
-                                    duration_us,
-                                    None,
-                                ));
-                                continue;
-                            }
-                        }
-
-                        if let Some(catch) = &endpoint.catch {
-                            if let Some(next) = self
-                                .run_catch(
-                                    catch,
-                                    &err.error,
-                                    &current,
-                                    None,
-                                    &self.endpoint_rule.base_dir,
-                                    &base_context,
-                                )
-                                .map_err(|err| anyhow!(err.to_string()))?
-                            {
-                                current = next.clone();
-                                let duration_us = step_started.elapsed().as_micros() as u64;
-                                nodes.push(self.build_step_trace(
-                                    step_index,
-                                    step,
-                                    "ok",
-                                    step_input,
-                                    Some(next),
-                                    None,
-                                    duration_us,
-                                    None,
-                                ));
-                                break;
-                            }
-                        }
-
-                        record_status = "error".to_string();
-                        record_error = Some(self.endpoint_error_to_trace(&err.error));
-                        last_error_message = Some(err.error.message.clone());
-                        let duration_us = step_started.elapsed().as_micros() as u64;
-                        nodes.push(self.build_step_trace(
-                            step_index,
-                            step,
-                            "error",
-                            step_input,
-                            None,
-                            Some(err.error.clone()),
-                            duration_us,
-                            err.child_trace,
-                        ));
-                        break;
-                    }
-                }
-            }
-        }
-
-        let response_result = if record_status == "error" {
-            Err(anyhow!(
-                last_error_message.unwrap_or_else(|| "endpoint error".to_string())
-            ))
-        } else {
-            match self.build_reply(&endpoint.reply, &current, &base_context) {
-                Ok(response) => Ok(response),
-                Err(err) => {
-                    let reply_error = EndpointError::invalid(err.to_string());
-                    let catch_output = if let Some(catch) = &endpoint.catch {
-                        self.run_catch(
-                            catch,
-                            &reply_error,
-                            &current,
-                            None,
-                            &self.endpoint_rule.base_dir,
-                            &base_context,
-                        )
-                        .map_err(|err| anyhow!(err.to_string()))?
-                    } else {
-                        None
-                    };
-
-                    if let Some(next) = catch_output {
-                        current = next;
-                        match self.build_reply(&endpoint.reply, &current, &base_context) {
-                            Ok(response) => Ok(response),
-                            Err(err) => {
-                                let reply_error = EndpointError::invalid(err.to_string());
-                                record_status = "error".to_string();
-                                record_error = Some(self.endpoint_error_to_trace(&reply_error));
-                                Err(anyhow!(reply_error.message))
-                            }
-                        }
-                    } else {
-                        record_status = "error".to_string();
-                        record_error = Some(self.endpoint_error_to_trace(&reply_error));
-                        Err(anyhow!(reply_error.message))
-                    }
-                }
-            }
-        };
-
-        let duration_us = started.elapsed().as_micros() as u64;
-        let trace = self.build_trace(
-            &method,
-            &path,
-            record_input,
-            current.clone(),
-            record_status,
-            record_error,
-            nodes,
-            duration_us,
-        );
-        if let Err(err) = self.write_trace(trace).await {
-            warn!("failed to write trace: {}", err);
-        }
-
-        response_result
     }
 }
 

--- a/crates/rulemorph_endpoint/src/endpoint_engine/request_runtime.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/request_runtime.rs
@@ -1,0 +1,333 @@
+use std::time::Instant;
+
+use anyhow::{Result, anyhow};
+use axum::http::Request;
+use axum::response::Response;
+use http_body_util::LengthLimitError;
+use rulemorph::v2_eval::{V2EvalContext, eval_v2_condition};
+use serde_json::Value as JsonValue;
+use tracing::warn;
+
+use super::error::EndpointError;
+use super::expr::apply_mappings_via_rule;
+use super::multipart_import::build_multipart_import_body;
+use super::request_input::{
+    build_input, build_input_from_parts, is_multipart_import_request, parse_query,
+};
+use super::{EndpointEngine, empty_object};
+
+fn is_length_limit_error(err: &axum::Error) -> bool {
+    let mut current: &(dyn std::error::Error + 'static) = err;
+    if current.is::<LengthLimitError>() {
+        return true;
+    }
+    while let Some(source) = current.source() {
+        if source.is::<LengthLimitError>() {
+            return true;
+        }
+        current = source;
+    }
+    false
+}
+
+impl EndpointEngine {
+    pub async fn handle_request(&self, request: Request<axum::body::Body>) -> Result<Response> {
+        let started = Instant::now();
+        let (parts, body) = request.into_parts();
+        let request_context = parts
+            .extensions
+            .get::<super::RequestContext>()
+            .cloned()
+            .unwrap_or_default();
+        let base_context = self.build_context_json(Some(&request_context));
+        let method = parts.method.clone();
+        let path = parts.uri.path().to_string();
+        let endpoint_match = self
+            .endpoint_rule
+            .match_endpoint(&method, &path)
+            .ok_or_else(|| anyhow!("no endpoint matched"))?;
+        let is_multipart = is_multipart_import_request(&method, &path, &parts.headers);
+        let mut _multipart_temp_dir: Option<tempfile::TempDir> = None;
+        let body_value = if is_multipart {
+            match build_multipart_import_body(&parts.headers, body).await {
+                Ok((body, temp_dir)) => {
+                    _multipart_temp_dir = Some(temp_dir);
+                    Ok(Some(body))
+                }
+                Err(err) => Err(err),
+            }
+        } else {
+            let body_limit = self.config.max_body_bytes;
+            match axum::body::to_bytes(body, body_limit).await {
+                Ok(body_bytes) if body_bytes.is_empty() => Ok(None),
+                Ok(body_bytes) => serde_json::from_slice::<JsonValue>(&body_bytes)
+                    .map(Some)
+                    .map_err(|err| EndpointError::invalid(err.to_string())),
+                Err(err) if is_length_limit_error(&err) => {
+                    Err(EndpointError::payload_too_large(body_limit))
+                }
+                Err(err) => Err(EndpointError::network(format!(
+                    "request body read error: {}",
+                    err
+                ))),
+            }
+        };
+
+        let endpoint = endpoint_match.endpoint;
+        let mut nodes: Vec<JsonValue> = Vec::new();
+        let mut record_status = "ok".to_string();
+        let mut record_error: Option<JsonValue> = None;
+        let mut last_error_message: Option<String> = None;
+        let mut skip_steps = false;
+
+        let mut handle_input_error = |err: EndpointError,
+                                      fallback_input: Option<JsonValue>,
+                                      body_value: Option<JsonValue>|
+         -> Result<(JsonValue, JsonValue)> {
+            skip_steps = true;
+            let fallback_input = fallback_input.unwrap_or_else(|| {
+                let query = parse_query(parts.uri.query()).unwrap_or_else(|_| empty_object());
+                build_input_from_parts(&parts, &endpoint_match.params, body_value, query)
+            });
+            if let Some(catch) = &endpoint.catch {
+                if let Some(next) = self
+                    .run_catch(
+                        catch,
+                        &err,
+                        &fallback_input,
+                        None,
+                        &self.endpoint_rule.base_dir,
+                        &base_context,
+                    )
+                    .map_err(|err| anyhow!(err.to_string()))?
+                {
+                    Ok((fallback_input, next))
+                } else {
+                    record_status = "error".to_string();
+                    record_error = Some(self.endpoint_error_to_trace(&err));
+                    last_error_message = Some(err.message.clone());
+                    Ok((fallback_input.clone(), fallback_input))
+                }
+            } else {
+                record_status = "error".to_string();
+                record_error = Some(self.endpoint_error_to_trace(&err));
+                last_error_message = Some(err.message.clone());
+                Ok((fallback_input.clone(), fallback_input))
+            }
+        };
+
+        let (record_input, mut current) = match body_value {
+            Ok(body_value) => match build_input(&parts, &endpoint_match.params, body_value.clone())
+            {
+                Ok(input) => {
+                    let record_input = input.clone();
+                    let current_result: Result<JsonValue, EndpointError> =
+                        if let Some(mappings) = &endpoint.input {
+                            apply_mappings_via_rule(mappings, &input, Some(&base_context))
+                                .map_err(EndpointError::from_transform)
+                                .map(|value| value.unwrap_or_else(empty_object))
+                        } else {
+                            Ok(input.clone())
+                        };
+                    match current_result {
+                        Ok(current) => Ok((record_input, current)),
+                        Err(err) => handle_input_error(err, Some(input), body_value),
+                    }
+                }
+                Err(err) => handle_input_error(err, None, body_value),
+            },
+            Err(err) => handle_input_error(err, None, None),
+        }?;
+
+        if !skip_steps {
+            for (step_index, step) in endpoint.steps.iter().enumerate() {
+                let step_input = current.clone();
+                let step_started = Instant::now();
+                if let Some(condition) = &step.when {
+                    let ctx = V2EvalContext::new();
+                    let keep = eval_v2_condition(
+                        condition,
+                        &current,
+                        Some(&base_context),
+                        &empty_object(),
+                        "steps.when",
+                        &ctx,
+                    )?;
+                    if !keep {
+                        let duration_us = step_started.elapsed().as_micros() as u64;
+                        nodes.push(self.build_step_trace(
+                            step_index,
+                            step,
+                            "skipped",
+                            step_input,
+                            Some(current.clone()),
+                            None,
+                            duration_us,
+                            None,
+                        ));
+                        continue;
+                    }
+                }
+                let step_context = self.step_context(&base_context, step.with.as_ref(), None);
+                let step_result = self
+                    .execute_rule(
+                        &step.rule,
+                        &current,
+                        Some(&step_context),
+                        &self.endpoint_rule.base_dir,
+                        Some(&request_context),
+                    )
+                    .await;
+                match step_result {
+                    Ok(execution) => {
+                        current = execution.output.clone();
+                        let duration_us = step_started.elapsed().as_micros() as u64;
+                        nodes.push(self.build_step_trace(
+                            step_index,
+                            step,
+                            "ok",
+                            step_input,
+                            Some(execution.output),
+                            None,
+                            duration_us,
+                            execution.child_trace,
+                        ));
+                    }
+                    Err(err) => {
+                        if let Some(catch) = &step.catch {
+                            if let Some(next) = self
+                                .run_catch(
+                                    catch,
+                                    &err.error,
+                                    &current,
+                                    step.with.as_ref(),
+                                    &self.endpoint_rule.base_dir,
+                                    &base_context,
+                                )
+                                .map_err(|err| anyhow!(err.to_string()))?
+                            {
+                                current = next.clone();
+                                let duration_us = step_started.elapsed().as_micros() as u64;
+                                nodes.push(self.build_step_trace(
+                                    step_index,
+                                    step,
+                                    "ok",
+                                    step_input,
+                                    Some(next),
+                                    None,
+                                    duration_us,
+                                    None,
+                                ));
+                                continue;
+                            }
+                        }
+
+                        if let Some(catch) = &endpoint.catch {
+                            if let Some(next) = self
+                                .run_catch(
+                                    catch,
+                                    &err.error,
+                                    &current,
+                                    None,
+                                    &self.endpoint_rule.base_dir,
+                                    &base_context,
+                                )
+                                .map_err(|err| anyhow!(err.to_string()))?
+                            {
+                                current = next.clone();
+                                let duration_us = step_started.elapsed().as_micros() as u64;
+                                nodes.push(self.build_step_trace(
+                                    step_index,
+                                    step,
+                                    "ok",
+                                    step_input,
+                                    Some(next),
+                                    None,
+                                    duration_us,
+                                    None,
+                                ));
+                                break;
+                            }
+                        }
+
+                        record_status = "error".to_string();
+                        record_error = Some(self.endpoint_error_to_trace(&err.error));
+                        last_error_message = Some(err.error.message.clone());
+                        let duration_us = step_started.elapsed().as_micros() as u64;
+                        nodes.push(self.build_step_trace(
+                            step_index,
+                            step,
+                            "error",
+                            step_input,
+                            None,
+                            Some(err.error.clone()),
+                            duration_us,
+                            err.child_trace,
+                        ));
+                        break;
+                    }
+                }
+            }
+        }
+
+        let response_result = if record_status == "error" {
+            Err(anyhow!(
+                last_error_message.unwrap_or_else(|| "endpoint error".to_string())
+            ))
+        } else {
+            match self.build_reply(&endpoint.reply, &current, &base_context) {
+                Ok(response) => Ok(response),
+                Err(err) => {
+                    let reply_error = EndpointError::invalid(err.to_string());
+                    let catch_output = if let Some(catch) = &endpoint.catch {
+                        self.run_catch(
+                            catch,
+                            &reply_error,
+                            &current,
+                            None,
+                            &self.endpoint_rule.base_dir,
+                            &base_context,
+                        )
+                        .map_err(|err| anyhow!(err.to_string()))?
+                    } else {
+                        None
+                    };
+
+                    if let Some(next) = catch_output {
+                        current = next;
+                        match self.build_reply(&endpoint.reply, &current, &base_context) {
+                            Ok(response) => Ok(response),
+                            Err(err) => {
+                                let reply_error = EndpointError::invalid(err.to_string());
+                                record_status = "error".to_string();
+                                record_error = Some(self.endpoint_error_to_trace(&reply_error));
+                                Err(anyhow!(reply_error.message))
+                            }
+                        }
+                    } else {
+                        record_status = "error".to_string();
+                        record_error = Some(self.endpoint_error_to_trace(&reply_error));
+                        Err(anyhow!(reply_error.message))
+                    }
+                }
+            }
+        };
+
+        let duration_us = started.elapsed().as_micros() as u64;
+        let trace = self.build_trace(
+            &method,
+            &path,
+            record_input,
+            current.clone(),
+            record_status,
+            record_error,
+            nodes,
+            duration_us,
+        );
+        if let Err(err) = self.write_trace(trace).await {
+            warn!("failed to write trace: {}", err);
+        }
+
+        response_result
+    }
+}


### PR DESCRIPTION
## Summary
- Move EndpointEngine request runtime orchestration into endpoint_engine::request_runtime.
- Keep request body parsing, length-limit detection, catch fallback, step execution, reply handling, and trace writing unchanged.
- Leave public exports, HTTP behavior, transform semantics, validator behavior, trace JSON schema, and tests unchanged.

## Verification
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint catch
- cargo test -p rulemorph_endpoint request_body_too_large_writes_trace
- cargo test -p rulemorph_endpoint step_rule_record_when_false_returns_error
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- cargo test --quiet

PR作成直後のため、即時マージはしません。