### PR TITLE
Refactor endpoint trace graph mapping ops

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
@@ -3,18 +3,19 @@ use std::time::Instant;
 
 use chrono::Utc;
 use rulemorph::v2_eval::{EvalValue, V2EvalContext, eval_v2_condition, eval_v2_expr};
-use rulemorph::v2_parser::{parse_v2_condition, parse_v2_expr, parse_v2_pipe_from_value};
+use rulemorph::v2_parser::{parse_v2_condition, parse_v2_expr};
 use rulemorph::{
-    Expr, Mapping, RuleFile, TransformError, TransformErrorKind, transform_record_with_base_dir,
+    Expr, RuleFile, TransformError, TransformErrorKind, transform_record_with_base_dir,
 };
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use uuid::Uuid;
 
+mod mapping_ops;
 mod v2_helpers;
 
+pub(super) use self::mapping_ops::build_mapping_ops_with_values;
 use self::v2_helpers::{
-    build_pipe_steps, eval_v2_pipe_value, eval_v2_start_value, expr_to_json_for_v2_condition,
-    expr_to_json_for_v2_pipe, expr_to_json_value, resolve_source_value, set_path_value,
+    expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe, expr_to_json_value,
 };
 use super::rule_loader::{RuleKind, load_rule_kind, yaml_source_to_json};
 use super::{
@@ -719,100 +720,4 @@ pub(super) fn build_network_nodes_with_timing(
         obj.insert("children".to_string(), JsonValue::Array(children));
     }
     vec![node]
-}
-
-pub(super) fn build_mapping_ops_with_values(
-    mappings: &[Mapping],
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &mut JsonValue,
-    rule_version: u8,
-    step_index: usize,
-) -> Vec<JsonValue> {
-    let mut ops = Vec::new();
-    for (index, mapping) in mappings.iter().enumerate() {
-        let op_started = Instant::now();
-        let mut args = JsonMap::new();
-        args.insert(
-            "target".to_string(),
-            JsonValue::String(mapping.target.clone()),
-        );
-        if let Some(source) = &mapping.source {
-            args.insert("source".to_string(), JsonValue::String(source.clone()));
-        }
-        if let Some(value) = &mapping.value {
-            args.insert("value".to_string(), value.clone());
-        }
-        if let Some(expr) = &mapping.expr {
-            args.insert("expr".to_string(), expr_to_json_value(expr));
-        }
-        if let Some(when) = &mapping.when {
-            args.insert("when".to_string(), expr_to_json_value(when));
-        }
-        if let Some(value_type) = &mapping.value_type {
-            args.insert("type".to_string(), JsonValue::String(value_type.clone()));
-        }
-        if mapping.required {
-            args.insert("required".to_string(), JsonValue::Bool(true));
-        }
-        if let Some(default) = &mapping.default {
-            args.insert("default".to_string(), default.clone());
-        }
-
-        let mut input_value = None;
-        let mut output_value = None;
-        let mut pipe_value = None;
-        let mut pipe_steps: Option<Vec<JsonValue>> = None;
-        if let Some(expr) = &mapping.expr {
-            if rule_version >= 2 {
-                if let Some(raw) = expr_to_json_for_v2_pipe(expr) {
-                    pipe_value = Some(raw.clone());
-                    if let Ok(pipe) = parse_v2_pipe_from_value(&raw) {
-                        let ctx = V2EvalContext::new();
-                        input_value = eval_v2_start_value(&pipe.start, record, context, out, &ctx);
-                        output_value = eval_v2_pipe_value(&pipe, record, context, out, &ctx);
-                        pipe_steps = Some(build_pipe_steps(&pipe, record, context, out, &ctx));
-                    }
-                }
-            }
-        } else if let Some(source) = &mapping.source {
-            input_value = resolve_source_value(source, record, context, out);
-            output_value = input_value.clone();
-            pipe_steps = Some(vec![json!({
-                "index": 0,
-                "label": "source",
-                "input": input_value,
-                "output": output_value
-            })]);
-        } else if let Some(value) = &mapping.value {
-            input_value = Some(value.clone());
-            output_value = Some(value.clone());
-            pipe_steps = Some(vec![json!({
-                "index": 0,
-                "label": "value",
-                "input": input_value,
-                "output": output_value
-            })]);
-        }
-
-        if let Some(value) = output_value.clone() {
-            let _ = set_path_value(out, &mapping.target, value);
-        }
-
-        let duration_us = op_started.elapsed().as_micros() as u64;
-        ops.push(json!({
-            "id": format!("op-{}-{}", step_index, index),
-            "kind": "op",
-            "label": mapping.target,
-            "status": "ok",
-            "input": input_value,
-            "pipe_value": pipe_value,
-            "pipe_steps": pipe_steps,
-            "args": JsonValue::Object(args),
-            "output": output_value,
-            "duration_us": duration_us,
-            "meta": { "op": "mapping" }
-        }));
-    }
-    ops
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/mapping_ops.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/mapping_ops.rs
@@ -1,0 +1,107 @@
+use std::time::Instant;
+
+use rulemorph::Mapping;
+use rulemorph::v2_eval::V2EvalContext;
+use rulemorph::v2_parser::parse_v2_pipe_from_value;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+
+use super::v2_helpers::{
+    build_pipe_steps, eval_v2_pipe_value, eval_v2_start_value, expr_to_json_for_v2_pipe,
+    expr_to_json_value, resolve_source_value, set_path_value,
+};
+
+pub(in crate::endpoint_engine) fn build_mapping_ops_with_values(
+    mappings: &[Mapping],
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &mut JsonValue,
+    rule_version: u8,
+    step_index: usize,
+) -> Vec<JsonValue> {
+    let mut ops = Vec::new();
+    for (index, mapping) in mappings.iter().enumerate() {
+        let op_started = Instant::now();
+        let mut args = JsonMap::new();
+        args.insert(
+            "target".to_string(),
+            JsonValue::String(mapping.target.clone()),
+        );
+        if let Some(source) = &mapping.source {
+            args.insert("source".to_string(), JsonValue::String(source.clone()));
+        }
+        if let Some(value) = &mapping.value {
+            args.insert("value".to_string(), value.clone());
+        }
+        if let Some(expr) = &mapping.expr {
+            args.insert("expr".to_string(), expr_to_json_value(expr));
+        }
+        if let Some(when) = &mapping.when {
+            args.insert("when".to_string(), expr_to_json_value(when));
+        }
+        if let Some(value_type) = &mapping.value_type {
+            args.insert("type".to_string(), JsonValue::String(value_type.clone()));
+        }
+        if mapping.required {
+            args.insert("required".to_string(), JsonValue::Bool(true));
+        }
+        if let Some(default) = &mapping.default {
+            args.insert("default".to_string(), default.clone());
+        }
+
+        let mut input_value = None;
+        let mut output_value = None;
+        let mut pipe_value = None;
+        let mut pipe_steps: Option<Vec<JsonValue>> = None;
+        if let Some(expr) = &mapping.expr {
+            if rule_version >= 2 {
+                if let Some(raw) = expr_to_json_for_v2_pipe(expr) {
+                    pipe_value = Some(raw.clone());
+                    if let Ok(pipe) = parse_v2_pipe_from_value(&raw) {
+                        let ctx = V2EvalContext::new();
+                        input_value = eval_v2_start_value(&pipe.start, record, context, out, &ctx);
+                        output_value = eval_v2_pipe_value(&pipe, record, context, out, &ctx);
+                        pipe_steps = Some(build_pipe_steps(&pipe, record, context, out, &ctx));
+                    }
+                }
+            }
+        } else if let Some(source) = &mapping.source {
+            input_value = resolve_source_value(source, record, context, out);
+            output_value = input_value.clone();
+            pipe_steps = Some(vec![json!({
+                "index": 0,
+                "label": "source",
+                "input": input_value,
+                "output": output_value
+            })]);
+        } else if let Some(value) = &mapping.value {
+            input_value = Some(value.clone());
+            output_value = Some(value.clone());
+            pipe_steps = Some(vec![json!({
+                "index": 0,
+                "label": "value",
+                "input": input_value,
+                "output": output_value
+            })]);
+        }
+
+        if let Some(value) = output_value.clone() {
+            let _ = set_path_value(out, &mapping.target, value);
+        }
+
+        let duration_us = op_started.elapsed().as_micros() as u64;
+        ops.push(json!({
+            "id": format!("op-{}-{}", step_index, index),
+            "kind": "op",
+            "label": mapping.target,
+            "status": "ok",
+            "input": input_value,
+            "pipe_value": pipe_value,
+            "pipe_steps": pipe_steps,
+            "args": JsonValue::Object(args),
+            "output": output_value,
+            "duration_us": duration_us,
+            "meta": { "op": "mapping" }
+        }));
+    }
+    ops
+}


### PR DESCRIPTION
## Summary
- Move endpoint trace graph mapping-op node generation into endpoint_engine::trace_graph::mapping_ops.
- Keep mapping op trace fields, pipe values/steps, source/value output capture, and body_map trace behavior unchanged.
- Leave public exports, HTTP behavior, transform semantics, validator behavior, trace JSON schema, and tests unchanged.

## Verification
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint mapping_ops_include_duration_us
- cargo test -p rulemorph_endpoint network_nodes_include_request_duration_us
- cargo test -p rulemorph_endpoint build_network_body_body_rule_none_omits_body
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- cargo test --quiet

PR作成直後のため、即時マージはしません。