### PR TITLE
Refactor endpoint trace graph network nodes

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
@@ -11,16 +11,17 @@ use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use uuid::Uuid;
 
 mod mapping_ops;
+mod network_nodes;
 mod v2_helpers;
 
 pub(super) use self::mapping_ops::build_mapping_ops_with_values;
+pub(super) use self::network_nodes::build_network_nodes_with_timing;
 use self::v2_helpers::{
     expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe, expr_to_json_value,
 };
 use super::rule_loader::{RuleKind, load_rule_kind, yaml_source_to_json};
 use super::{
-    CompiledNetworkRule, NetworkExecution, empty_object, resolve_rule_path, rule_display_name,
-    rule_ref_from_path, rule_ref_from_rule,
+    empty_object, resolve_rule_path, rule_display_name, rule_ref_from_path, rule_ref_from_rule,
 };
 
 pub(super) fn build_rule_trace(
@@ -610,114 +611,4 @@ fn eval_trace_condition(
         "when/record_when must evaluate to boolean",
     )
     .with_path(path))
-}
-
-pub(super) fn build_network_nodes_with_timing(
-    rule: &CompiledNetworkRule,
-    timing: &NetworkExecution,
-) -> Vec<JsonValue> {
-    let mut children = Vec::new();
-    let mut request_args = JsonMap::new();
-    request_args.insert(
-        "method".to_string(),
-        JsonValue::String(rule.request.method.to_string()),
-    );
-    request_args.insert(
-        "url".to_string(),
-        JsonValue::String(format!("{:?}", rule.request.url)),
-    );
-    if !rule.request.headers.is_empty() {
-        let mut headers = JsonMap::new();
-        for (key, expr) in &rule.request.headers {
-            headers.insert(key.to_string(), JsonValue::String(format!("{:?}", expr)));
-        }
-        request_args.insert("headers".to_string(), JsonValue::Object(headers));
-    }
-    children.push(json!({
-        "id": "op-request",
-        "kind": "op",
-        "label": "request",
-        "status": "ok",
-        "duration_us": timing.request_us,
-        "meta": { "op": "request" },
-        "args": JsonValue::Object(request_args)
-    }));
-
-    if let Some(body) = &rule.body {
-        children.push(json!({
-            "id": "op-body",
-            "kind": "op",
-            "label": "body",
-            "status": "ok",
-            "meta": { "op": "body" },
-            "args": { "expr": format!("{:?}", body) }
-        }));
-    }
-    if let Some(body_map) = &rule.body_map {
-        let mut out = JsonValue::Object(JsonMap::new());
-        let empty = JsonValue::Object(JsonMap::new());
-        let ops = build_mapping_ops_with_values(body_map, &empty, None, &mut out, 2, 0);
-        children.extend(ops);
-    }
-    if rule.body_rule.is_some() {
-        children.push(json!({
-            "id": "op-body-rule",
-            "kind": "op",
-            "label": "body_rule",
-            "status": "ok",
-            "meta": { "op": "body_rule" }
-        }));
-    }
-    if let Some(select) = &rule.select {
-        children.push(json!({
-            "id": "op-select",
-            "kind": "op",
-            "label": "select",
-            "status": "ok",
-            "meta": { "op": "select" },
-            "args": { "path": select }
-        }));
-    }
-    if let Some(retry) = &rule.retry {
-        children.push(json!({
-            "id": "op-retry",
-            "kind": "op",
-            "label": "retry",
-            "status": "ok",
-            "meta": { "op": "retry" },
-            "args": {
-                "max": retry.max,
-                "backoff": format!("{:?}", retry.backoff),
-                "initial_delay_ms": retry.initial_delay.as_millis()
-            }
-        }));
-    }
-
-    let mut node = json!({
-        "id": "step-0",
-        "kind": "network",
-        "label": "request",
-        "status": "ok",
-        "duration_us": timing.total_us,
-    });
-    if let Some(rule_ref) = rule.body_rule_ref.as_ref() {
-        if let Some(obj) = node.as_object_mut() {
-            obj.insert(
-                "meta".to_string(),
-                json!({
-                    "rule_ref": rule_ref,
-                    "rule_ref_label": "body_rule"
-                }),
-            );
-        }
-    }
-    if let Some(trace) = timing.body_rule_trace.as_ref() {
-        if let Some(obj) = node.as_object_mut() {
-            obj.insert("child_trace".to_string(), trace.clone());
-        }
-    }
-    if let Some(obj) = node.as_object_mut() {
-        obj.insert("children".to_string(), JsonValue::Array(children));
-    }
-    vec![node]
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/network_nodes.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/network_nodes.rs
@@ -1,0 +1,114 @@
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+
+use super::mapping_ops::build_mapping_ops_with_values;
+use crate::endpoint_engine::{CompiledNetworkRule, NetworkExecution};
+
+pub(in crate::endpoint_engine) fn build_network_nodes_with_timing(
+    rule: &CompiledNetworkRule,
+    timing: &NetworkExecution,
+) -> Vec<JsonValue> {
+    let mut children = Vec::new();
+    let mut request_args = JsonMap::new();
+    request_args.insert(
+        "method".to_string(),
+        JsonValue::String(rule.request.method.to_string()),
+    );
+    request_args.insert(
+        "url".to_string(),
+        JsonValue::String(format!("{:?}", rule.request.url)),
+    );
+    if !rule.request.headers.is_empty() {
+        let mut headers = JsonMap::new();
+        for (key, expr) in &rule.request.headers {
+            headers.insert(key.to_string(), JsonValue::String(format!("{:?}", expr)));
+        }
+        request_args.insert("headers".to_string(), JsonValue::Object(headers));
+    }
+    children.push(json!({
+        "id": "op-request",
+        "kind": "op",
+        "label": "request",
+        "status": "ok",
+        "duration_us": timing.request_us,
+        "meta": { "op": "request" },
+        "args": JsonValue::Object(request_args)
+    }));
+
+    if let Some(body) = &rule.body {
+        children.push(json!({
+            "id": "op-body",
+            "kind": "op",
+            "label": "body",
+            "status": "ok",
+            "meta": { "op": "body" },
+            "args": { "expr": format!("{:?}", body) }
+        }));
+    }
+    if let Some(body_map) = &rule.body_map {
+        let mut out = JsonValue::Object(JsonMap::new());
+        let empty = JsonValue::Object(JsonMap::new());
+        let ops = build_mapping_ops_with_values(body_map, &empty, None, &mut out, 2, 0);
+        children.extend(ops);
+    }
+    if rule.body_rule.is_some() {
+        children.push(json!({
+            "id": "op-body-rule",
+            "kind": "op",
+            "label": "body_rule",
+            "status": "ok",
+            "meta": { "op": "body_rule" }
+        }));
+    }
+    if let Some(select) = &rule.select {
+        children.push(json!({
+            "id": "op-select",
+            "kind": "op",
+            "label": "select",
+            "status": "ok",
+            "meta": { "op": "select" },
+            "args": { "path": select }
+        }));
+    }
+    if let Some(retry) = &rule.retry {
+        children.push(json!({
+            "id": "op-retry",
+            "kind": "op",
+            "label": "retry",
+            "status": "ok",
+            "meta": { "op": "retry" },
+            "args": {
+                "max": retry.max,
+                "backoff": format!("{:?}", retry.backoff),
+                "initial_delay_ms": retry.initial_delay.as_millis()
+            }
+        }));
+    }
+
+    let mut node = json!({
+        "id": "step-0",
+        "kind": "network",
+        "label": "request",
+        "status": "ok",
+        "duration_us": timing.total_us,
+    });
+    if let Some(rule_ref) = rule.body_rule_ref.as_ref() {
+        if let Some(obj) = node.as_object_mut() {
+            obj.insert(
+                "meta".to_string(),
+                json!({
+                    "rule_ref": rule_ref,
+                    "rule_ref_label": "body_rule"
+                }),
+            );
+        }
+    }
+    if let Some(trace) = timing.body_rule_trace.as_ref() {
+        if let Some(obj) = node.as_object_mut() {
+            obj.insert("child_trace".to_string(), trace.clone());
+        }
+    }
+    if let Some(obj) = node.as_object_mut() {
+        obj.insert("children".to_string(), JsonValue::Array(children));
+    }
+    vec![node]
+}


### PR DESCRIPTION
## Summary
- Move endpoint network trace node generation into endpoint_engine::trace_graph::network_nodes.
- Keep request/body/body_map/body_rule/select/retry child nodes, body_rule metadata, child_trace, and duration fields unchanged.
- Leave public exports, HTTP behavior, transform semantics, validator behavior, trace JSON schema, and tests unchanged.

## Verification
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint network_nodes_include_request_duration_us
- cargo test -p rulemorph_endpoint build_network_body_body_rule_none_omits_body
- cargo test -p rulemorph_endpoint network_response_too_large_returns_error
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- cargo test --quiet

PR作成直後のため、即時マージはしません。