### PR TITLE
Refactor endpoint trace graph finalize helper

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/tests.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/tests.rs
@@ -2000,6 +2000,112 @@ fn rule_trace_duration_includes_finalize_duration() {
 }
 
 #[test]
+fn finalize_trace_includes_operation_nodes_in_order() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "score"
+    source: "input.score"
+finalize:
+  filter:
+    gte: ["@item.score", 10]
+  sort:
+    by: "score"
+    order: "asc"
+  limit: 1
+  offset: 0
+  wrap:
+    data: "@out"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let record = json!({ "score": 12 });
+    let trace = build_rule_nodes_from_rule(&rule, &record, None, Path::new("."));
+    let finalize = trace.finalize.expect("finalize trace");
+
+    assert_eq!(
+        finalize.get("status").and_then(|value| value.as_str()),
+        Some("ok")
+    );
+    assert!(
+        finalize
+            .get("duration_us")
+            .and_then(|value| value.as_u64())
+            .is_some()
+    );
+    assert_eq!(
+        finalize
+            .get("input")
+            .and_then(|value| value.as_array())
+            .map(|items| items.len()),
+        Some(1)
+    );
+    let labels: Vec<&str> = finalize
+        .get("nodes")
+        .and_then(|value| value.as_array())
+        .expect("finalize nodes")
+        .iter()
+        .map(|node| {
+            node.get("label")
+                .and_then(|value| value.as_str())
+                .expect("node label")
+        })
+        .collect();
+    assert_eq!(labels, vec!["filter", "sort", "limit", "offset", "wrap"]);
+    assert_eq!(
+        finalize
+            .get("nodes")
+            .and_then(|value| value.as_array())
+            .and_then(|nodes| nodes.first())
+            .and_then(|node| node.get("args"))
+            .and_then(|args| args.get("expr")),
+        Some(&json!({ "gte": ["@item.score", 10] }))
+    );
+}
+
+#[test]
+fn finalize_trace_preserves_error_payload() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "score"
+    source: "input.score"
+finalize:
+  wrap:
+    data:
+      - "@out"
+      - unknown_op
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let record = json!({ "score": 12 });
+    let trace = build_rule_nodes_from_rule(&rule, &record, None, Path::new("."));
+    let finalize = trace.finalize.expect("finalize trace");
+    let error = finalize.get("error").expect("finalize error");
+
+    assert_eq!(
+        finalize.get("status").and_then(|value| value.as_str()),
+        Some("error")
+    );
+    assert_eq!(
+        error.get("code").and_then(|value| value.as_str()),
+        Some("ExprError")
+    );
+    assert_eq!(
+        error.get("message").and_then(|value| value.as_str()),
+        Some("expr.op is not supported")
+    );
+    assert_eq!(
+        error.get("path").and_then(|value| value.as_str()),
+        Some("finalize.wrap.data[1].op")
+    );
+}
+
+#[test]
 fn network_nodes_include_request_duration_us() {
     let body_yaml = r#"
 version: 2

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
@@ -10,15 +10,15 @@ use rulemorph::{
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use uuid::Uuid;
 
+mod finalize;
 mod mapping_ops;
 mod network_nodes;
 mod v2_helpers;
 
+use self::finalize::build_finalize_trace;
 pub(super) use self::mapping_ops::build_mapping_ops_with_values;
 pub(super) use self::network_nodes::build_network_nodes_with_timing;
-use self::v2_helpers::{
-    expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe, expr_to_json_value,
-};
+use self::v2_helpers::{expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe};
 use super::rule_loader::{RuleKind, load_rule_kind, yaml_source_to_json};
 use super::{
     empty_object, resolve_rule_path, rule_display_name, rule_ref_from_path, rule_ref_from_rule,
@@ -423,103 +423,9 @@ pub(super) fn build_rule_nodes_from_rule(
         nodes.push(node);
     }
 
-    if let Some(finalize) = &rule.finalize {
-        let mut base_rule = rule.clone();
-        base_rule.finalize = None;
-        let base_started = Instant::now();
-        let pre_finalize = transform_record_with_base_dir(&base_rule, record, context, base_dir)
-            .ok()
-            .and_then(|value| value);
-        let base_duration_us = base_started.elapsed().as_micros() as u64;
-        pre_finalize_output = pre_finalize.clone();
-        let finalize_input = match pre_finalize {
-            Some(value) => JsonValue::Array(vec![value]),
-            None => JsonValue::Array(Vec::new()),
-        };
-        let finalize_started = Instant::now();
-        let finalize_result = transform_record_with_base_dir(rule, record, context, base_dir);
-        let total_duration_us = finalize_started.elapsed().as_micros() as u64;
-        let finalize_duration_us = total_duration_us.saturating_sub(base_duration_us);
-        let mut finalize_status = "ok";
-        let mut finalize_output: Option<JsonValue> = None;
-        let mut finalize_error: Option<JsonValue> = None;
-        match finalize_result {
-            Ok(Some(value)) => {
-                finalize_output = Some(value);
-            }
-            Ok(None) => {
-                finalize_output = Some(JsonValue::Null);
-            }
-            Err(err) => {
-                finalize_status = "error";
-                finalize_error = Some(transform_error_to_trace(&err));
-            }
-        }
-        let mut children = Vec::new();
-        if let Some(filter) = &finalize.filter {
-            children.push(json!({
-                "id": "op-filter",
-                "kind": "op",
-                "label": "filter",
-                "status": "ok",
-                "meta": { "op": "filter" },
-                "args": { "expr": expr_to_json_value(filter) }
-            }));
-        }
-        if let Some(sort) = &finalize.sort {
-            children.push(json!({
-                "id": "op-sort",
-                "kind": "op",
-                "label": "sort",
-                "status": "ok",
-                "meta": { "op": "sort" },
-                "args": { "by": sort.by, "order": sort.order }
-            }));
-        }
-        if let Some(limit) = finalize.limit {
-            children.push(json!({
-                "id": "op-limit",
-                "kind": "op",
-                "label": "limit",
-                "status": "ok",
-                "meta": { "op": "limit" },
-                "args": { "limit": limit }
-            }));
-        }
-        if let Some(offset) = finalize.offset {
-            children.push(json!({
-                "id": "op-offset",
-                "kind": "op",
-                "label": "offset",
-                "status": "ok",
-                "meta": { "op": "offset" },
-                "args": { "offset": offset }
-            }));
-        }
-        if let Some(wrap) = &finalize.wrap {
-            children.push(json!({
-                "id": "op-wrap",
-                "kind": "op",
-                "label": "wrap",
-                "status": "ok",
-                "meta": { "op": "wrap" },
-                "args": { "wrap": wrap }
-            }));
-        }
-
-        let mut finalize = json!({
-            "status": finalize_status,
-            "input": finalize_input,
-            "output": finalize_output,
-            "duration_us": finalize_duration_us,
-            "nodes": children,
-        });
-        if let Some(err) = finalize_error {
-            if let Some(obj) = finalize.as_object_mut() {
-                obj.insert("error".to_string(), err);
-            }
-        }
-        finalize_trace = Some(finalize);
+    if let Some(finalize) = build_finalize_trace(rule, record, context, base_dir) {
+        pre_finalize_output = finalize.pre_finalize_output;
+        finalize_trace = Some(finalize.trace);
     }
 
     let duration_us = sum_rule_trace_duration_us(&nodes, finalize_trace.as_ref());

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/finalize.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/finalize.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+use std::time::Instant;
+
+use rulemorph::{RuleFile, transform_record_with_base_dir};
+use serde_json::{Value as JsonValue, json};
+
+use super::transform_error_to_trace;
+use super::v2_helpers::expr_to_json_value;
+
+pub(super) struct FinalizeTrace {
+    pub(super) trace: JsonValue,
+    pub(super) pre_finalize_output: Option<JsonValue>,
+}
+
+pub(super) fn build_finalize_trace(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Option<FinalizeTrace> {
+    let finalize = rule.finalize.as_ref()?;
+
+    let mut base_rule = rule.clone();
+    base_rule.finalize = None;
+    let base_started = Instant::now();
+    let pre_finalize = transform_record_with_base_dir(&base_rule, record, context, base_dir)
+        .ok()
+        .and_then(|value| value);
+    let base_duration_us = base_started.elapsed().as_micros() as u64;
+    let pre_finalize_output = pre_finalize.clone();
+    let finalize_input = match pre_finalize {
+        Some(value) => JsonValue::Array(vec![value]),
+        None => JsonValue::Array(Vec::new()),
+    };
+    let finalize_started = Instant::now();
+    let finalize_result = transform_record_with_base_dir(rule, record, context, base_dir);
+    let total_duration_us = finalize_started.elapsed().as_micros() as u64;
+    let finalize_duration_us = total_duration_us.saturating_sub(base_duration_us);
+    let mut finalize_status = "ok";
+    let mut finalize_output: Option<JsonValue> = None;
+    let mut finalize_error: Option<JsonValue> = None;
+    match finalize_result {
+        Ok(Some(value)) => {
+            finalize_output = Some(value);
+        }
+        Ok(None) => {
+            finalize_output = Some(JsonValue::Null);
+        }
+        Err(err) => {
+            finalize_status = "error";
+            finalize_error = Some(transform_error_to_trace(&err));
+        }
+    }
+    let mut children = Vec::new();
+    if let Some(filter) = &finalize.filter {
+        children.push(json!({
+            "id": "op-filter",
+            "kind": "op",
+            "label": "filter",
+            "status": "ok",
+            "meta": { "op": "filter" },
+            "args": { "expr": expr_to_json_value(filter) }
+        }));
+    }
+    if let Some(sort) = &finalize.sort {
+        children.push(json!({
+            "id": "op-sort",
+            "kind": "op",
+            "label": "sort",
+            "status": "ok",
+            "meta": { "op": "sort" },
+            "args": { "by": sort.by, "order": sort.order }
+        }));
+    }
+    if let Some(limit) = finalize.limit {
+        children.push(json!({
+            "id": "op-limit",
+            "kind": "op",
+            "label": "limit",
+            "status": "ok",
+            "meta": { "op": "limit" },
+            "args": { "limit": limit }
+        }));
+    }
+    if let Some(offset) = finalize.offset {
+        children.push(json!({
+            "id": "op-offset",
+            "kind": "op",
+            "label": "offset",
+            "status": "ok",
+            "meta": { "op": "offset" },
+            "args": { "offset": offset }
+        }));
+    }
+    if let Some(wrap) = &finalize.wrap {
+        children.push(json!({
+            "id": "op-wrap",
+            "kind": "op",
+            "label": "wrap",
+            "status": "ok",
+            "meta": { "op": "wrap" },
+            "args": { "wrap": wrap }
+        }));
+    }
+
+    let mut trace = json!({
+        "status": finalize_status,
+        "input": finalize_input,
+        "output": finalize_output,
+        "duration_us": finalize_duration_us,
+        "nodes": children,
+    });
+    if let Some(err) = finalize_error {
+        if let Some(obj) = trace.as_object_mut() {
+            obj.insert("error".to_string(), err);
+        }
+    }
+
+    Some(FinalizeTrace {
+        trace,
+        pre_finalize_output,
+    })
+}


### PR DESCRIPTION
## Summary
- Add characterization tests for endpoint finalize trace operation node shape and error payloads.
- Move finalize trace construction into endpoint_engine::trace_graph::finalize.
- Keep trace JSON schema, transform semantics, validator behavior, HTTP behavior, public exports, and endpoint runtime behavior unchanged.

## Verification
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint finalize_trace_includes_operation_nodes_in_order
- cargo test -p rulemorph_endpoint finalize_trace_preserves_error_payload
- cargo test -p rulemorph_endpoint rule_trace_duration_includes_finalize_duration
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- git diff --check
- cargo test --quiet

PR作成直後のため、即時マージはしません。