### PR TITLE
Refactor endpoint trace graph condition helper

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
@@ -1,24 +1,21 @@
 use std::path::Path;
 use std::time::Instant;
 
-use rulemorph::v2_eval::{EvalValue, V2EvalContext, eval_v2_condition, eval_v2_expr};
-use rulemorph::v2_parser::{parse_v2_condition, parse_v2_expr};
-use rulemorph::{
-    Expr, RuleFile, TransformError, TransformErrorKind, transform_record_with_base_dir,
-};
+use rulemorph::{RuleFile, TransformError, TransformErrorKind, transform_record_with_base_dir};
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
+mod condition;
 mod envelope;
 mod finalize;
 mod mapping_ops;
 mod network_nodes;
 mod v2_helpers;
 
+use self::condition::eval_trace_condition;
 pub(super) use self::envelope::build_rule_trace;
 use self::finalize::build_finalize_trace;
 pub(super) use self::mapping_ops::build_mapping_ops_with_values;
 pub(super) use self::network_nodes::build_network_nodes_with_timing;
-use self::v2_helpers::{expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe};
 use super::rule_loader::{RuleKind, load_rule_kind, yaml_source_to_json};
 use super::{
     empty_object, resolve_rule_path, rule_display_name, rule_ref_from_path, rule_ref_from_rule,
@@ -410,61 +407,4 @@ fn transform_error_to_trace(err: &TransformError) -> JsonValue {
         "message": err.message,
         "path": err.path,
     })
-}
-
-fn eval_trace_condition(
-    expr: &Expr,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    path: &str,
-    rule_version: u8,
-) -> Result<bool, TransformError> {
-    if rule_version >= 2 {
-        if let Some(raw_value) = expr_to_json_for_v2_condition(expr) {
-            if let Ok(condition) = parse_v2_condition(&raw_value) {
-                let ctx = V2EvalContext::new();
-                return eval_v2_condition(&condition, record, context, out, path, &ctx);
-            }
-            if let Ok(v2_expr) = parse_v2_expr(&raw_value) {
-                let ctx = V2EvalContext::new();
-                let value = eval_v2_expr(&v2_expr, record, context, out, path, &ctx)?;
-                return match value {
-                    EvalValue::Missing => Ok(false),
-                    EvalValue::Value(JsonValue::Bool(flag)) => Ok(flag),
-                    EvalValue::Value(_) => Err(TransformError::new(
-                        TransformErrorKind::ExprError,
-                        "when/record_when must evaluate to boolean",
-                    )
-                    .with_path(path)),
-                };
-            }
-        }
-        if let Some(raw_value) = expr_to_json_for_v2_pipe(expr) {
-            let v2_expr = parse_v2_expr(&raw_value).map_err(|err| {
-                TransformError::new(
-                    TransformErrorKind::ExprError,
-                    format!("invalid v2 condition: {}", err),
-                )
-                .with_path(path)
-            })?;
-            let ctx = V2EvalContext::new();
-            let value = eval_v2_expr(&v2_expr, record, context, out, path, &ctx)?;
-            return match value {
-                EvalValue::Missing => Ok(false),
-                EvalValue::Value(JsonValue::Bool(flag)) => Ok(flag),
-                EvalValue::Value(_) => Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "when/record_when must evaluate to boolean",
-                )
-                .with_path(path)),
-            };
-        }
-    }
-
-    Err(TransformError::new(
-        TransformErrorKind::ExprError,
-        "when/record_when must evaluate to boolean",
-    )
-    .with_path(path))
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/condition.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/condition.rs
@@ -1,0 +1,63 @@
+use rulemorph::v2_eval::{EvalValue, V2EvalContext, eval_v2_condition, eval_v2_expr};
+use rulemorph::v2_parser::{parse_v2_condition, parse_v2_expr};
+use rulemorph::{Expr, TransformError, TransformErrorKind};
+use serde_json::Value as JsonValue;
+
+use super::v2_helpers::{expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe};
+
+pub(super) fn eval_trace_condition(
+    expr: &Expr,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    path: &str,
+    rule_version: u8,
+) -> Result<bool, TransformError> {
+    if rule_version >= 2 {
+        if let Some(raw_value) = expr_to_json_for_v2_condition(expr) {
+            if let Ok(condition) = parse_v2_condition(&raw_value) {
+                let ctx = V2EvalContext::new();
+                return eval_v2_condition(&condition, record, context, out, path, &ctx);
+            }
+            if let Ok(v2_expr) = parse_v2_expr(&raw_value) {
+                let ctx = V2EvalContext::new();
+                let value = eval_v2_expr(&v2_expr, record, context, out, path, &ctx)?;
+                return match value {
+                    EvalValue::Missing => Ok(false),
+                    EvalValue::Value(JsonValue::Bool(flag)) => Ok(flag),
+                    EvalValue::Value(_) => Err(TransformError::new(
+                        TransformErrorKind::ExprError,
+                        "when/record_when must evaluate to boolean",
+                    )
+                    .with_path(path)),
+                };
+            }
+        }
+        if let Some(raw_value) = expr_to_json_for_v2_pipe(expr) {
+            let v2_expr = parse_v2_expr(&raw_value).map_err(|err| {
+                TransformError::new(
+                    TransformErrorKind::ExprError,
+                    format!("invalid v2 condition: {}", err),
+                )
+                .with_path(path)
+            })?;
+            let ctx = V2EvalContext::new();
+            let value = eval_v2_expr(&v2_expr, record, context, out, path, &ctx)?;
+            return match value {
+                EvalValue::Missing => Ok(false),
+                EvalValue::Value(JsonValue::Bool(flag)) => Ok(flag),
+                EvalValue::Value(_) => Err(TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "when/record_when must evaluate to boolean",
+                )
+                .with_path(path)),
+            };
+        }
+    }
+
+    Err(TransformError::new(
+        TransformErrorKind::ExprError,
+        "when/record_when must evaluate to boolean",
+    )
+    .with_path(path))
+}


### PR DESCRIPTION
## Summary
- Move endpoint trace condition evaluation into endpoint_engine::trace_graph::condition.
- Keep v2 condition/pipe fallback, boolean requirement errors, and trace node assembly behavior unchanged.
- Leave trace JSON schema, transform semantics, validator behavior, HTTP behavior, public exports, and endpoint runtime behavior unchanged.

## Verification
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint step_rule_record_when_false_returns_error
- cargo test -p rulemorph_endpoint build_trace_emits_top_level_status
- cargo test -p rulemorph_endpoint endpoint_error_trace_uses_rule_ref_for_path
- cargo test -p rulemorph_endpoint finalize_trace_preserves_error_payload
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- git diff --check
- cargo test --quiet

PR作成直後のため、即時マージはしません。