### PR TITLE
Refactor endpoint trace graph duration helper

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph.rs
@@ -5,6 +5,7 @@ use rulemorph::{RuleFile, TransformError, TransformErrorKind, transform_record_w
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 mod condition;
+mod duration;
 mod envelope;
 mod finalize;
 mod mapping_ops;
@@ -12,6 +13,7 @@ mod network_nodes;
 mod v2_helpers;
 
 use self::condition::eval_trace_condition;
+pub(super) use self::duration::sum_rule_trace_duration_us;
 pub(super) use self::envelope::build_rule_trace;
 use self::finalize::build_finalize_trace;
 pub(super) use self::mapping_ops::build_mapping_ops_with_values;
@@ -383,22 +385,6 @@ pub(super) fn build_rule_nodes_from_rule(
         pre_finalize_output,
         duration_us,
     }
-}
-
-fn sum_node_duration_us(nodes: &[JsonValue]) -> u64 {
-    nodes
-        .iter()
-        .filter_map(|node| node.get("duration_us").and_then(|value| value.as_u64()))
-        .sum()
-}
-
-pub(super) fn sum_rule_trace_duration_us(nodes: &[JsonValue], finalize: Option<&JsonValue>) -> u64 {
-    sum_node_duration_us(nodes).saturating_add(
-        finalize
-            .and_then(|trace| trace.get("duration_us"))
-            .and_then(|value| value.as_u64())
-            .unwrap_or(0),
-    )
 }
 
 fn transform_error_to_trace(err: &TransformError) -> JsonValue {

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/duration.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/duration.rs
@@ -1,0 +1,20 @@
+use serde_json::Value as JsonValue;
+
+fn sum_node_duration_us(nodes: &[JsonValue]) -> u64 {
+    nodes
+        .iter()
+        .filter_map(|node| node.get("duration_us").and_then(|value| value.as_u64()))
+        .sum()
+}
+
+pub(in crate::endpoint_engine) fn sum_rule_trace_duration_us(
+    nodes: &[JsonValue],
+    finalize: Option<&JsonValue>,
+) -> u64 {
+    sum_node_duration_us(nodes).saturating_add(
+        finalize
+            .and_then(|trace| trace.get("duration_us"))
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+    )
+}


### PR DESCRIPTION
## Summary
- Move endpoint trace duration aggregation into endpoint_engine::trace_graph::duration.
- Keep the parent trace_graph::sum_rule_trace_duration_us import surface intact.
- Leave trace JSON schema, transform semantics, validator behavior, HTTP behavior, public exports, and endpoint runtime behavior unchanged.

## Verification
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint rule_trace_duration_includes_finalize_duration
- cargo test -p rulemorph_endpoint build_trace_emits_top_level_status
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- git diff --check
- cargo test --quiet

PR作成直後のため、即時マージはしません。