### PR TITLE
Refactor endpoint validation diagnostics helper

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
@@ -1,13 +1,10 @@
 use std::collections::{BTreeSet, HashMap};
-use std::fmt;
 use std::path::{Path, PathBuf};
 
 use axum::http::Method;
 use rulemorph::serde_guard::parse_yaml_value_strict;
 use rulemorph::v2_parser::parse_v2_expr;
-use rulemorph::{
-    RuleError, RuleFormat, parse_rule_file_with_format, validate_rule_file_with_source,
-};
+use rulemorph::{RuleFormat, parse_rule_file_with_format, validate_rule_file_with_source};
 use serde::de::DeserializeOwned;
 
 use super::{
@@ -15,47 +12,10 @@ use super::{
     resolve_rule_path,
 };
 
-#[derive(Debug, Clone)]
-pub struct RulesDirError {
-    pub code: String,
-    pub file: PathBuf,
-    pub path: Option<String>,
-    pub line: Option<usize>,
-    pub column: Option<usize>,
-    pub message: String,
-}
+mod diagnostics;
 
-#[derive(Debug, Clone)]
-pub struct RulesDirErrors {
-    pub errors: Vec<RulesDirError>,
-}
-
-impl fmt::Display for RulesDirErrors {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (index, err) in self.errors.iter().enumerate() {
-            if index > 0 {
-                writeln!(f)?;
-            }
-            let mut parts = Vec::new();
-            parts.push(format!("E {}", err.code));
-            parts.push(format!("file={}", err.file.display()));
-            if let Some(path) = &err.path {
-                parts.push(format!("path={}", path));
-            }
-            if let Some(line) = err.line {
-                parts.push(format!("line={}", line));
-            }
-            if let Some(column) = err.column {
-                parts.push(format!("col={}", column));
-            }
-            parts.push(format!("msg=\"{}\"", err.message));
-            write!(f, "{}", parts.join(" "))?;
-        }
-        Ok(())
-    }
-}
-
-impl std::error::Error for RulesDirErrors {}
+pub use self::diagnostics::{RulesDirError, RulesDirErrors};
+use self::diagnostics::{push_error, push_parse_error, push_rule_error};
 
 #[derive(Debug, Default, Clone, Copy)]
 struct RuleRefUsage {
@@ -244,55 +204,6 @@ fn parse_rule_type(path: &Path, source: &str, errors: &mut Vec<RulesDirError>) -
             .unwrap_or("normal")
             .to_string(),
     )
-}
-
-fn push_parse_error(
-    errors: &mut Vec<RulesDirError>,
-    path: &Path,
-    message: &str,
-    location: Option<(usize, usize)>,
-) {
-    push_error(
-        errors,
-        "RuleParseFailed",
-        path,
-        message.to_string(),
-        None,
-        location,
-    );
-}
-
-fn push_error(
-    errors: &mut Vec<RulesDirError>,
-    code: impl Into<String>,
-    file: &Path,
-    message: impl Into<String>,
-    path: Option<String>,
-    location: Option<(usize, usize)>,
-) {
-    let (line, column) = location
-        .map(|(line, column)| (Some(line), Some(column)))
-        .unwrap_or((None, None));
-    errors.push(RulesDirError {
-        code: code.into(),
-        file: file.to_path_buf(),
-        path,
-        line,
-        column,
-        message: message.into(),
-    });
-}
-
-fn push_rule_error(errors: &mut Vec<RulesDirError>, path: &Path, err: &RuleError) {
-    let location = err.location.as_ref().map(|loc| (loc.line, loc.column));
-    push_error(
-        errors,
-        err.code.as_str(),
-        path,
-        err.message.clone(),
-        err.path.clone(),
-        location,
-    );
 }
 
 fn validate_rule_path(

--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation/diagnostics.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation/diagnostics.rs
@@ -1,0 +1,95 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use rulemorph::RuleError;
+
+#[derive(Debug, Clone)]
+pub struct RulesDirError {
+    pub code: String,
+    pub file: PathBuf,
+    pub path: Option<String>,
+    pub line: Option<usize>,
+    pub column: Option<usize>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RulesDirErrors {
+    pub errors: Vec<RulesDirError>,
+}
+
+impl fmt::Display for RulesDirErrors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, err) in self.errors.iter().enumerate() {
+            if index > 0 {
+                writeln!(f)?;
+            }
+            let mut parts = Vec::new();
+            parts.push(format!("E {}", err.code));
+            parts.push(format!("file={}", err.file.display()));
+            if let Some(path) = &err.path {
+                parts.push(format!("path={}", path));
+            }
+            if let Some(line) = err.line {
+                parts.push(format!("line={}", line));
+            }
+            if let Some(column) = err.column {
+                parts.push(format!("col={}", column));
+            }
+            parts.push(format!("msg=\"{}\"", err.message));
+            write!(f, "{}", parts.join(" "))?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for RulesDirErrors {}
+
+pub(super) fn push_parse_error(
+    errors: &mut Vec<RulesDirError>,
+    path: &Path,
+    message: &str,
+    location: Option<(usize, usize)>,
+) {
+    push_error(
+        errors,
+        "RuleParseFailed",
+        path,
+        message.to_string(),
+        None,
+        location,
+    );
+}
+
+pub(super) fn push_error(
+    errors: &mut Vec<RulesDirError>,
+    code: impl Into<String>,
+    file: &Path,
+    message: impl Into<String>,
+    path: Option<String>,
+    location: Option<(usize, usize)>,
+) {
+    let (line, column) = location
+        .map(|(line, column)| (Some(line), Some(column)))
+        .unwrap_or((None, None));
+    errors.push(RulesDirError {
+        code: code.into(),
+        file: file.to_path_buf(),
+        path,
+        line,
+        column,
+        message: message.into(),
+    });
+}
+
+pub(super) fn push_rule_error(errors: &mut Vec<RulesDirError>, path: &Path, err: &RuleError) {
+    let location = err.location.as_ref().map(|loc| (loc.line, loc.column));
+    push_error(
+        errors,
+        err.code.as_str(),
+        path,
+        err.message.clone(),
+        err.path.clone(),
+        location,
+    );
+}


### PR DESCRIPTION
## Summary
- move RulesDirError / RulesDirErrors and validation diagnostic push helpers into endpoint_engine::validation::diagnostics
- keep rule validation traversal, network validation, and public re-exports unchanged
- keep this PR independent from #157 by branching from origin/v0.3.1

## No behavior changes
- no transform semantics changes
- no trace JSON schema changes
- no HTTP / CLI / MCP contract changes
- no public API names or exports changed

## Verification
- cargo fmt
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint --test rules_dir_validation
- cargo test -p rulemorph_endpoint validate_rules_dir
- cargo test -p rulemorph_endpoint
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- git diff --check
- cargo test --quiet