### PR TITLE
Refactor endpoint validation state helpers

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
@@ -12,60 +12,12 @@ use super::{
 
 mod diagnostics;
 mod source;
+mod state;
 
 pub use self::diagnostics::{RulesDirError, RulesDirErrors};
 use self::diagnostics::{push_error, push_parse_error, push_rule_error};
 use self::source::{parse_rule_type, parse_yaml, read_rule_source};
-
-#[derive(Debug, Default, Clone, Copy)]
-struct RuleRefUsage {
-    step: bool,
-    body_rule: bool,
-    catch_rule: bool,
-    branch_rule: bool,
-}
-
-impl RuleRefUsage {
-    fn step() -> Self {
-        RuleRefUsage {
-            step: true,
-            ..RuleRefUsage::default()
-        }
-    }
-
-    fn body_rule() -> Self {
-        RuleRefUsage {
-            body_rule: true,
-            ..RuleRefUsage::default()
-        }
-    }
-
-    fn catch_rule() -> Self {
-        RuleRefUsage {
-            catch_rule: true,
-            ..RuleRefUsage::default()
-        }
-    }
-
-    fn branch_rule() -> Self {
-        RuleRefUsage {
-            branch_rule: true,
-            ..RuleRefUsage::default()
-        }
-    }
-
-    fn merge(&mut self, other: RuleRefUsage) {
-        self.step |= other.step;
-        self.body_rule |= other.body_rule;
-        self.catch_rule |= other.catch_rule;
-        self.branch_rule |= other.branch_rule;
-    }
-}
-
-#[derive(Debug, Default)]
-struct ValidationState {
-    validated_content: BTreeSet<PathBuf>,
-}
+use self::state::{RuleRefUsage, ValidationState};
 
 pub fn validate_rules_dir(rules_dir: &Path) -> std::result::Result<(), RulesDirErrors> {
     let mut errors = Vec::new();

--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation/state.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation/state.rs
@@ -1,0 +1,52 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(super) struct RuleRefUsage {
+    pub(super) step: bool,
+    pub(super) body_rule: bool,
+    pub(super) catch_rule: bool,
+    pub(super) branch_rule: bool,
+}
+
+impl RuleRefUsage {
+    pub(super) fn step() -> Self {
+        RuleRefUsage {
+            step: true,
+            ..RuleRefUsage::default()
+        }
+    }
+
+    pub(super) fn body_rule() -> Self {
+        RuleRefUsage {
+            body_rule: true,
+            ..RuleRefUsage::default()
+        }
+    }
+
+    pub(super) fn catch_rule() -> Self {
+        RuleRefUsage {
+            catch_rule: true,
+            ..RuleRefUsage::default()
+        }
+    }
+
+    pub(super) fn branch_rule() -> Self {
+        RuleRefUsage {
+            branch_rule: true,
+            ..RuleRefUsage::default()
+        }
+    }
+
+    pub(super) fn merge(&mut self, other: RuleRefUsage) {
+        self.step |= other.step;
+        self.body_rule |= other.body_rule;
+        self.catch_rule |= other.catch_rule;
+        self.branch_rule |= other.branch_rule;
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct ValidationState {
+    pub(super) validated_content: BTreeSet<PathBuf>,
+}


### PR DESCRIPTION
## Summary
- move RuleRefUsage and ValidationState into endpoint_engine::validation::state
- keep rule reference collection, traversal, and validation behavior unchanged
- keep this PR scoped to the state helper split after #159 was merged

## No behavior changes
- no transform semantics changes
- no trace JSON schema changes
- no HTTP / CLI / MCP contract changes
- no public API names or exports changed

## Verification
- cargo fmt
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint --test rules_dir_validation
- cargo test -p rulemorph_endpoint validate_rules_dir
- cargo test -p rulemorph_endpoint
- cargo fmt --check
- git diff --check
- cargo test --quiet

After rebasing onto the v0.3.1 commit that includes #159:
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint --test rules_dir_validation
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- cargo test -p rulemorph_endpoint