### PR TITLE
Refactor transform operator shared helpers

### DIFF
--- a/crates/rulemorph/src/transform/operators.rs
+++ b/crates/rulemorph/src/transform/operators.rs
@@ -7,6 +7,7 @@ mod date;
 mod json;
 mod lookup;
 mod number;
+mod shared;
 mod string;
 mod value;
 
@@ -31,6 +32,9 @@ use self::json::{
 };
 use self::lookup::eval_lookup;
 use self::number::{eval_numeric_op, eval_round, eval_to_base};
+pub(super) use self::shared::{
+    SortKey, SortKeyKind, compare_sort_keys, locals_with_item, locals_with_precomputed_args,
+};
 use self::string::{eval_pad, eval_replace, eval_split, eval_unary_string_op};
 pub(super) use self::value::{cast_value, value_as_bool, value_to_string};
 use self::value::{
@@ -647,65 +651,5 @@ pub(crate) fn eval_op(
             TransformError::new(TransformErrorKind::ExprError, "expr.op is not supported")
                 .with_path(format!("{}.op", base_path)),
         ),
-    }
-}
-
-pub(super) fn locals_with_item<'a>(
-    locals: Option<&EvalLocals<'a>>,
-    item: EvalItem<'a>,
-) -> EvalLocals<'a> {
-    EvalLocals {
-        item: Some(item),
-        acc: locals.and_then(|locals| locals.acc),
-        pipe: locals.and_then(|locals| locals.pipe),
-        locals: locals.and_then(|locals| locals.locals),
-        precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
-    }
-}
-
-pub(super) fn locals_with_precomputed_args<'a>(
-    locals: Option<&EvalLocals<'a>>,
-    base_path: &'a str,
-    arg_values: &'a [EvalValue],
-) -> EvalLocals<'a> {
-    EvalLocals {
-        item: locals.and_then(|locals| locals.item),
-        acc: locals.and_then(|locals| locals.acc),
-        pipe: locals.and_then(|locals| locals.pipe),
-        locals: locals.and_then(|locals| locals.locals),
-        precomputed_op_args: Some((base_path, arg_values)),
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum SortKeyKind {
-    Number,
-    String,
-    Bool,
-}
-
-#[derive(Clone)]
-pub(super) enum SortKey {
-    Number(f64),
-    String(String),
-    Bool(bool),
-}
-
-impl SortKey {
-    pub(super) fn kind(&self) -> SortKeyKind {
-        match self {
-            SortKey::Number(_) => SortKeyKind::Number,
-            SortKey::String(_) => SortKeyKind::String,
-            SortKey::Bool(_) => SortKeyKind::Bool,
-        }
-    }
-}
-
-pub(super) fn compare_sort_keys(left: &SortKey, right: &SortKey) -> Ordering {
-    match (left, right) {
-        (SortKey::Number(l), SortKey::Number(r)) => l.partial_cmp(r).unwrap_or(Ordering::Equal),
-        (SortKey::String(l), SortKey::String(r)) => l.cmp(r),
-        (SortKey::Bool(l), SortKey::Bool(r)) => l.cmp(r),
-        _ => Ordering::Equal,
     }
 }

--- a/crates/rulemorph/src/transform/operators/shared.rs
+++ b/crates/rulemorph/src/transform/operators/shared.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+pub(in crate::transform) fn locals_with_item<'a>(
+    locals: Option<&EvalLocals<'a>>,
+    item: EvalItem<'a>,
+) -> EvalLocals<'a> {
+    EvalLocals {
+        item: Some(item),
+        acc: locals.and_then(|locals| locals.acc),
+        pipe: locals.and_then(|locals| locals.pipe),
+        locals: locals.and_then(|locals| locals.locals),
+        precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
+    }
+}
+
+pub(in crate::transform) fn locals_with_precomputed_args<'a>(
+    locals: Option<&EvalLocals<'a>>,
+    base_path: &'a str,
+    arg_values: &'a [EvalValue],
+) -> EvalLocals<'a> {
+    EvalLocals {
+        item: locals.and_then(|locals| locals.item),
+        acc: locals.and_then(|locals| locals.acc),
+        pipe: locals.and_then(|locals| locals.pipe),
+        locals: locals.and_then(|locals| locals.locals),
+        precomputed_op_args: Some((base_path, arg_values)),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(in crate::transform) enum SortKeyKind {
+    Number,
+    String,
+    Bool,
+}
+
+#[derive(Clone)]
+pub(in crate::transform) enum SortKey {
+    Number(f64),
+    String(String),
+    Bool(bool),
+}
+
+impl SortKey {
+    pub(in crate::transform) fn kind(&self) -> SortKeyKind {
+        match self {
+            SortKey::Number(_) => SortKeyKind::Number,
+            SortKey::String(_) => SortKeyKind::String,
+            SortKey::Bool(_) => SortKeyKind::Bool,
+        }
+    }
+}
+
+pub(in crate::transform) fn compare_sort_keys(left: &SortKey, right: &SortKey) -> Ordering {
+    match (left, right) {
+        (SortKey::Number(l), SortKey::Number(r)) => l.partial_cmp(r).unwrap_or(Ordering::Equal),
+        (SortKey::String(l), SortKey::String(r)) => l.cmp(r),
+        (SortKey::Bool(l), SortKey::Bool(r)) => l.cmp(r),
+        _ => Ordering::Equal,
+    }
+}


### PR DESCRIPTION
## Summary
- move transform operator shared locals/sort key helpers into transform/operators/shared.rs
- keep the existing internal re-export surface for sibling operator modules
- leave operator dispatch, transform semantics, trace schema, and public APIs unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden t13_expr_extended
- cargo test -p rulemorph --test transform_golden t16_array_ops
- cargo test -p rulemorph --test transform_trace
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test -p rulemorph
- cargo fmt --check
- git diff --check
- cargo test --quiet