### PR TITLE
Refactor DTO schema helpers

### DIFF
--- a/crates/rulemorph/src/dto.rs
+++ b/crates/rulemorph/src/dto.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
-use serde_json::Value as JsonValue;
+mod schema;
 
-use crate::model::{Expr, RuleFile};
-use crate::path::{PathToken, parse_path};
+use self::schema::{
+    Field, FieldType, PrimitiveType, SchemaNode, build_schema, node_has_required, node_uses_json,
+};
+use crate::model::RuleFile;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DtoLanguage {
@@ -54,162 +56,6 @@ pub fn generate_dto(
         DtoLanguage::Kotlin => render_kotlin(&schema, &name),
         DtoLanguage::Swift => render_swift(&schema, &name),
     }
-}
-
-#[derive(Clone)]
-struct SchemaNode {
-    fields: Vec<Field>,
-}
-
-#[derive(Clone)]
-struct Field {
-    key: String,
-    field_type: FieldType,
-    optional: bool,
-}
-
-#[derive(Clone)]
-enum FieldType {
-    Primitive(PrimitiveType),
-    Object(Box<SchemaNode>),
-    JsonValue,
-}
-
-#[derive(Clone, Copy)]
-enum PrimitiveType {
-    String,
-    Int,
-    Float,
-    Bool,
-}
-
-fn build_schema(rule: &RuleFile) -> Result<SchemaNode, DtoError> {
-    let mut root = SchemaNode { fields: Vec::new() };
-
-    let step_mappings = rule
-        .steps
-        .iter()
-        .flat_map(|steps| steps.iter())
-        .flat_map(|step| step.mappings.iter())
-        .flat_map(|mappings| mappings.iter());
-
-    for mapping in rule.mappings.iter().chain(step_mappings) {
-        let tokens =
-            parse_path(&mapping.target).map_err(|_| DtoError::new("target path is invalid"))?;
-        if tokens
-            .iter()
-            .any(|token| matches!(token, PathToken::Index(_)))
-        {
-            return Err(DtoError::new("target path must not include indexes"));
-        }
-
-        let mut keys = Vec::new();
-        for token in tokens {
-            match token {
-                PathToken::Key(key) => keys.push(key),
-                PathToken::Index(_) => {}
-            }
-        }
-
-        if keys.is_empty() {
-            return Err(DtoError::new("target path is invalid"));
-        }
-
-        let field_type = match mapping.value_type.as_deref() {
-            Some("string") => FieldType::Primitive(PrimitiveType::String),
-            Some("int") => FieldType::Primitive(PrimitiveType::Int),
-            Some("float") => FieldType::Primitive(PrimitiveType::Float),
-            Some("bool") => FieldType::Primitive(PrimitiveType::Bool),
-            Some(_) => return Err(DtoError::new("unsupported type in mapping")),
-            None => FieldType::JsonValue,
-        };
-        let conditional = match &mapping.when {
-            None => false,
-            Some(Expr::Literal(JsonValue::Bool(true))) => false,
-            _ => true,
-        };
-        let optional = conditional
-            || !(mapping.required || mapping.value.is_some() || mapping.default.is_some());
-
-        insert_field(&mut root, &keys, field_type, optional)?;
-    }
-
-    Ok(root)
-}
-
-fn insert_field(
-    node: &mut SchemaNode,
-    keys: &[String],
-    field_type: FieldType,
-    optional: bool,
-) -> Result<(), DtoError> {
-    if keys.is_empty() {
-        return Err(DtoError::new("target path is invalid"));
-    }
-
-    let key = &keys[0];
-    if keys.len() == 1 {
-        if node.fields.iter().any(|field| field.key == *key) {
-            return Err(DtoError::new("duplicate target in dto"));
-        }
-        node.fields.push(Field {
-            key: key.clone(),
-            field_type,
-            optional,
-        });
-        return Ok(());
-    }
-
-    if let Some(field) = node.fields.iter_mut().find(|field| field.key == *key) {
-        match &mut field.field_type {
-            FieldType::Object(child) => {
-                return insert_field(child, &keys[1..], field_type, optional);
-            }
-            _ => return Err(DtoError::new("target conflicts with non-object")),
-        }
-    }
-
-    let mut child = SchemaNode { fields: Vec::new() };
-    insert_field(&mut child, &keys[1..], field_type, optional)?;
-    node.fields.push(Field {
-        key: key.clone(),
-        field_type: FieldType::Object(Box::new(child)),
-        optional: false,
-    });
-    Ok(())
-}
-
-fn node_has_required(node: &SchemaNode) -> bool {
-    for field in &node.fields {
-        match &field.field_type {
-            FieldType::Object(child) => {
-                if node_has_required(child) {
-                    return true;
-                }
-            }
-            _ => {
-                if !field.optional {
-                    return true;
-                }
-            }
-        }
-    }
-    false
-}
-
-fn node_uses_json(node: &SchemaNode) -> bool {
-    for field in &node.fields {
-        match &field.field_type {
-            FieldType::JsonValue => return true,
-            FieldType::Object(child) => {
-                if node_uses_json(child) {
-                    return true;
-                }
-            }
-            _ => {}
-        }
-    }
-    false
 }
 
 struct TypeDef<'a> {

--- a/crates/rulemorph/src/dto/schema.rs
+++ b/crates/rulemorph/src/dto/schema.rs
@@ -1,0 +1,161 @@
+use serde_json::Value as JsonValue;
+
+use super::DtoError;
+use crate::model::{Expr, RuleFile};
+use crate::path::{PathToken, parse_path};
+
+#[derive(Clone)]
+pub(super) struct SchemaNode {
+    pub(super) fields: Vec<Field>,
+}
+
+#[derive(Clone)]
+pub(super) struct Field {
+    pub(super) key: String,
+    pub(super) field_type: FieldType,
+    pub(super) optional: bool,
+}
+
+#[derive(Clone)]
+pub(super) enum FieldType {
+    Primitive(PrimitiveType),
+    Object(Box<SchemaNode>),
+    JsonValue,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum PrimitiveType {
+    String,
+    Int,
+    Float,
+    Bool,
+}
+
+pub(super) fn build_schema(rule: &RuleFile) -> Result<SchemaNode, DtoError> {
+    let mut root = SchemaNode { fields: Vec::new() };
+
+    let step_mappings = rule
+        .steps
+        .iter()
+        .flat_map(|steps| steps.iter())
+        .flat_map(|step| step.mappings.iter())
+        .flat_map(|mappings| mappings.iter());
+
+    for mapping in rule.mappings.iter().chain(step_mappings) {
+        let tokens =
+            parse_path(&mapping.target).map_err(|_| DtoError::new("target path is invalid"))?;
+        if tokens
+            .iter()
+            .any(|token| matches!(token, PathToken::Index(_)))
+        {
+            return Err(DtoError::new("target path must not include indexes"));
+        }
+
+        let mut keys = Vec::new();
+        for token in tokens {
+            match token {
+                PathToken::Key(key) => keys.push(key),
+                PathToken::Index(_) => {}
+            }
+        }
+
+        if keys.is_empty() {
+            return Err(DtoError::new("target path is invalid"));
+        }
+
+        let field_type = match mapping.value_type.as_deref() {
+            Some("string") => FieldType::Primitive(PrimitiveType::String),
+            Some("int") => FieldType::Primitive(PrimitiveType::Int),
+            Some("float") => FieldType::Primitive(PrimitiveType::Float),
+            Some("bool") => FieldType::Primitive(PrimitiveType::Bool),
+            Some(_) => return Err(DtoError::new("unsupported type in mapping")),
+            None => FieldType::JsonValue,
+        };
+        let conditional = match &mapping.when {
+            None => false,
+            Some(Expr::Literal(JsonValue::Bool(true))) => false,
+            _ => true,
+        };
+        let optional = conditional
+            || !(mapping.required || mapping.value.is_some() || mapping.default.is_some());
+
+        insert_field(&mut root, &keys, field_type, optional)?;
+    }
+
+    Ok(root)
+}
+
+fn insert_field(
+    node: &mut SchemaNode,
+    keys: &[String],
+    field_type: FieldType,
+    optional: bool,
+) -> Result<(), DtoError> {
+    if keys.is_empty() {
+        return Err(DtoError::new("target path is invalid"));
+    }
+
+    let key = &keys[0];
+    if keys.len() == 1 {
+        if node.fields.iter().any(|field| field.key == *key) {
+            return Err(DtoError::new("duplicate target in dto"));
+        }
+        node.fields.push(Field {
+            key: key.clone(),
+            field_type,
+            optional,
+        });
+        return Ok(());
+    }
+
+    if let Some(field) = node.fields.iter_mut().find(|field| field.key == *key) {
+        match &mut field.field_type {
+            FieldType::Object(child) => {
+                return insert_field(child, &keys[1..], field_type, optional);
+            }
+            _ => return Err(DtoError::new("target conflicts with non-object")),
+        }
+    }
+
+    let mut child = SchemaNode { fields: Vec::new() };
+    insert_field(&mut child, &keys[1..], field_type, optional)?;
+    node.fields.push(Field {
+        key: key.clone(),
+        field_type: FieldType::Object(Box::new(child)),
+        optional: false,
+    });
+    Ok(())
+}
+
+pub(super) fn node_has_required(node: &SchemaNode) -> bool {
+    for field in &node.fields {
+        match &field.field_type {
+            FieldType::Object(child) => {
+                if node_has_required(child) {
+                    return true;
+                }
+            }
+            _ => {
+                if !field.optional {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+pub(super) fn node_uses_json(node: &SchemaNode) -> bool {
+    for field in &node.fields {
+        match &field.field_type {
+            FieldType::JsonValue => return true,
+            FieldType::Object(child) => {
+                if node_uses_json(child) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}


### PR DESCRIPTION
## Summary
- move DTO schema model/build helpers into dto/schema.rs
- keep DTO renderers, naming, reserved-word handling, and public API names unchanged
- leave generated DTO output and CLI/MCP contracts unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --test dto_golden
- cargo test -p rulemorph --test dto_security
- cargo test -p rulemorph_cli --test cli generate_outputs_rust_dto
- cargo test -p rulemorph_mcp --test stdio
- cargo fmt --check
- git diff --check
- cargo test --quiet