### PR TITLE
Refactor v2 parser error type

### DIFF
--- a/crates/rulemorph/src/v2_parser.rs
+++ b/crates/rulemorph/src/v2_parser.rs
@@ -18,8 +18,10 @@ use crate::v2_validator::is_valid_op;
 use serde_json::Value as JsonValue;
 // Note: V2Step::Ref variant is used for reference steps like "@doubled"
 
+mod error;
 mod ref_parse;
 
+pub use error::V2ParseError;
 pub use ref_parse::{extract_literal, is_literal_escape, is_pipe_value, is_v2_ref, parse_v2_ref};
 
 // =============================================================================
@@ -447,33 +449,6 @@ fn parse_comparison_from_object(
 
     Ok(None)
 }
-
-// =============================================================================
-// Parse Errors
-// =============================================================================
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum V2ParseError {
-    EmptyPipe,
-    InvalidStart(String),
-    InvalidStep(String),
-    InvalidArgs(String),
-    InvalidCondition(String),
-}
-
-impl std::fmt::Display for V2ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            V2ParseError::EmptyPipe => write!(f, "pipe array cannot be empty"),
-            V2ParseError::InvalidStart(msg) => write!(f, "invalid start value: {}", msg),
-            V2ParseError::InvalidStep(msg) => write!(f, "invalid step: {}", msg),
-            V2ParseError::InvalidArgs(msg) => write!(f, "invalid args: {}", msg),
-            V2ParseError::InvalidCondition(msg) => write!(f, "invalid condition: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for V2ParseError {}
 
 // =============================================================================
 // v2 Parser Tests

--- a/crates/rulemorph/src/v2_parser/error.rs
+++ b/crates/rulemorph/src/v2_parser/error.rs
@@ -1,0 +1,22 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum V2ParseError {
+    EmptyPipe,
+    InvalidStart(String),
+    InvalidStep(String),
+    InvalidArgs(String),
+    InvalidCondition(String),
+}
+
+impl std::fmt::Display for V2ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            V2ParseError::EmptyPipe => write!(f, "pipe array cannot be empty"),
+            V2ParseError::InvalidStart(msg) => write!(f, "invalid start value: {}", msg),
+            V2ParseError::InvalidStep(msg) => write!(f, "invalid step: {}", msg),
+            V2ParseError::InvalidArgs(msg) => write!(f, "invalid args: {}", msg),
+            V2ParseError::InvalidCondition(msg) => write!(f, "invalid condition: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for V2ParseError {}


### PR DESCRIPTION
## Summary
- move V2ParseError and its Display/Error impl into v2_parser/error.rs
- re-export V2ParseError from rulemorph::v2_parser to preserve the public import path
- leave parser logic, parser semantics, transform semantics, and trace schema unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --lib v2_parser
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph --test v2_transform
- cargo test -p rulemorph --test validation
- cargo fmt --check
- git diff --check
- cargo test --quiet