### PR TITLE
Refactor v2 validator context support

### DIFF
--- a/crates/rulemorph/src/v2_validator.rs
+++ b/crates/rulemorph/src/v2_validator.rs
@@ -7,8 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde_json::Value as JsonValue;
 
-use crate::error::{ErrorCode, RuleError};
-use crate::locator::YamlLocator;
+use crate::error::ErrorCode;
 use crate::path::{PathToken, parse_path};
 use crate::v2_model::{
     V2Comparison, V2Condition, V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Pipe, V2Ref,
@@ -17,6 +16,10 @@ use crate::v2_model::{
 use crate::v2_operator::{
     V2OperatorArgScope, is_valid_operator, operator_arg_range, operator_arg_scope,
 };
+
+mod context;
+
+pub use self::context::{V2Scope, V2ValidationCtx};
 
 // =============================================================================
 // Type System
@@ -64,175 +67,6 @@ impl V2Type {
             self,
             V2Type::Null | V2Type::Number | V2Type::String | V2Type::Array(_) | V2Type::Object
         )
-    }
-}
-
-// =============================================================================
-// Scope Management (Lexical Scoping)
-// =============================================================================
-
-/// Scope tracking for lexical scoping of let bindings
-#[derive(Debug, Clone)]
-pub struct V2Scope {
-    /// Let-bound variable names in current scope
-    let_bindings: HashSet<String>,
-    /// Whether @item/@item.index is available
-    item_available: bool,
-    /// Whether @acc is available
-    acc_available: bool,
-    /// Parent scope (for lexical scoping)
-    parent: Option<Box<V2Scope>>,
-}
-
-impl V2Scope {
-    /// Create a new empty scope
-    pub fn new() -> Self {
-        Self {
-            let_bindings: HashSet::new(),
-            item_available: false,
-            acc_available: false,
-            parent: None,
-        }
-    }
-
-    /// Create a new child scope inheriting from parent
-    pub fn with_parent(parent: &V2Scope) -> Self {
-        Self {
-            let_bindings: HashSet::new(),
-            item_available: parent.item_available,
-            acc_available: parent.acc_available,
-            parent: Some(Box::new(parent.clone())),
-        }
-    }
-
-    /// Enable @item references in this scope
-    pub fn with_item(mut self) -> Self {
-        self.item_available = true;
-        self
-    }
-
-    /// Enable @acc references in this scope
-    pub fn with_acc(mut self) -> Self {
-        self.acc_available = true;
-        self
-    }
-
-    /// Add a let binding to the current scope
-    pub fn add_binding(&mut self, name: String) {
-        self.let_bindings.insert(name);
-    }
-
-    /// Check if a let binding exists in scope chain
-    pub fn has_binding(&self, name: &str) -> bool {
-        if self.let_bindings.contains(name) {
-            return true;
-        }
-        if let Some(ref parent) = self.parent {
-            return parent.has_binding(name);
-        }
-        false
-    }
-
-    /// Check if @item is available
-    pub fn allows_item(&self) -> bool {
-        self.item_available
-    }
-
-    /// Check if @acc is available
-    pub fn allows_acc(&self) -> bool {
-        self.acc_available
-    }
-}
-
-impl Default for V2Scope {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// =============================================================================
-// Validation Context
-// =============================================================================
-
-/// Context for v2 validation
-pub struct V2ValidationCtx<'a> {
-    /// YAML source locator for error positions
-    locator: Option<&'a YamlLocator>,
-    /// Accumulated errors
-    errors: Vec<RuleError>,
-    /// Previously computed output targets (for @out forward reference check)
-    produced_targets: HashSet<Vec<PathToken>>,
-    /// Whether @out forward references are allowed
-    allow_any_out_ref: bool,
-    /// Whether @context was referenced (for informational purposes)
-    pub context_referenced: bool,
-}
-
-impl<'a> V2ValidationCtx<'a> {
-    /// Create a new validation context
-    pub fn new(locator: Option<&'a YamlLocator>) -> Self {
-        Self {
-            locator,
-            errors: Vec::new(),
-            produced_targets: HashSet::new(),
-            allow_any_out_ref: false,
-            context_referenced: false,
-        }
-    }
-
-    /// Create context with existing produced targets
-    pub fn with_produced_targets(
-        locator: Option<&'a YamlLocator>,
-        produced_targets: HashSet<Vec<PathToken>>,
-        allow_any_out_ref: bool,
-    ) -> Self {
-        Self {
-            locator,
-            errors: Vec::new(),
-            produced_targets,
-            allow_any_out_ref,
-            context_referenced: false,
-        }
-    }
-
-    /// Push an error with path
-    pub fn push_error(&mut self, code: ErrorCode, message: impl Into<String>, path: &str) {
-        let mut err = RuleError::new(code, message).with_path(path);
-        if let Some(locator) = self.locator {
-            if let Some(location) = locator.location_for(path) {
-                err = err.with_location(location.line, location.column);
-            }
-        }
-        self.errors.push(err);
-    }
-
-    /// Add a produced target
-    pub fn add_produced_target(&mut self, tokens: Vec<PathToken>) {
-        self.produced_targets.insert(tokens);
-    }
-
-    /// Get reference to produced targets
-    pub fn produced_targets(&self) -> &HashSet<Vec<PathToken>> {
-        &self.produced_targets
-    }
-
-    /// Consume context and return errors if any
-    pub fn finish(self) -> Result<(), Vec<RuleError>> {
-        if self.errors.is_empty() {
-            Ok(())
-        } else {
-            Err(self.errors)
-        }
-    }
-
-    /// Check if there are errors
-    pub fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
-    }
-
-    /// Get collected errors
-    pub fn errors(&self) -> &[RuleError] {
-        &self.errors
     }
 }
 

--- a/crates/rulemorph/src/v2_validator/context.rs
+++ b/crates/rulemorph/src/v2_validator/context.rs
@@ -1,0 +1,174 @@
+use std::collections::HashSet;
+
+use crate::error::{ErrorCode, RuleError};
+use crate::locator::YamlLocator;
+use crate::path::PathToken;
+
+// =============================================================================
+// Scope Management (Lexical Scoping)
+// =============================================================================
+
+/// Scope tracking for lexical scoping of let bindings
+#[derive(Debug, Clone)]
+pub struct V2Scope {
+    /// Let-bound variable names in current scope
+    let_bindings: HashSet<String>,
+    /// Whether @item/@item.index is available
+    item_available: bool,
+    /// Whether @acc is available
+    acc_available: bool,
+    /// Parent scope (for lexical scoping)
+    parent: Option<Box<V2Scope>>,
+}
+
+impl V2Scope {
+    /// Create a new empty scope
+    pub fn new() -> Self {
+        Self {
+            let_bindings: HashSet::new(),
+            item_available: false,
+            acc_available: false,
+            parent: None,
+        }
+    }
+
+    /// Create a new child scope inheriting from parent
+    pub fn with_parent(parent: &V2Scope) -> Self {
+        Self {
+            let_bindings: HashSet::new(),
+            item_available: parent.item_available,
+            acc_available: parent.acc_available,
+            parent: Some(Box::new(parent.clone())),
+        }
+    }
+
+    /// Enable @item references in this scope
+    pub fn with_item(mut self) -> Self {
+        self.item_available = true;
+        self
+    }
+
+    /// Enable @acc references in this scope
+    pub fn with_acc(mut self) -> Self {
+        self.acc_available = true;
+        self
+    }
+
+    /// Add a let binding to the current scope
+    pub fn add_binding(&mut self, name: String) {
+        self.let_bindings.insert(name);
+    }
+
+    /// Check if a let binding exists in scope chain
+    pub fn has_binding(&self, name: &str) -> bool {
+        if self.let_bindings.contains(name) {
+            return true;
+        }
+        if let Some(ref parent) = self.parent {
+            return parent.has_binding(name);
+        }
+        false
+    }
+
+    /// Check if @item is available
+    pub fn allows_item(&self) -> bool {
+        self.item_available
+    }
+
+    /// Check if @acc is available
+    pub fn allows_acc(&self) -> bool {
+        self.acc_available
+    }
+}
+
+impl Default for V2Scope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Validation Context
+// =============================================================================
+
+/// Context for v2 validation
+pub struct V2ValidationCtx<'a> {
+    /// YAML source locator for error positions
+    locator: Option<&'a YamlLocator>,
+    /// Accumulated errors
+    errors: Vec<RuleError>,
+    /// Previously computed output targets (for @out forward reference check)
+    pub(super) produced_targets: HashSet<Vec<PathToken>>,
+    /// Whether @out forward references are allowed
+    pub(super) allow_any_out_ref: bool,
+    /// Whether @context was referenced (for informational purposes)
+    pub context_referenced: bool,
+}
+
+impl<'a> V2ValidationCtx<'a> {
+    /// Create a new validation context
+    pub fn new(locator: Option<&'a YamlLocator>) -> Self {
+        Self {
+            locator,
+            errors: Vec::new(),
+            produced_targets: HashSet::new(),
+            allow_any_out_ref: false,
+            context_referenced: false,
+        }
+    }
+
+    /// Create context with existing produced targets
+    pub fn with_produced_targets(
+        locator: Option<&'a YamlLocator>,
+        produced_targets: HashSet<Vec<PathToken>>,
+        allow_any_out_ref: bool,
+    ) -> Self {
+        Self {
+            locator,
+            errors: Vec::new(),
+            produced_targets,
+            allow_any_out_ref,
+            context_referenced: false,
+        }
+    }
+
+    /// Push an error with path
+    pub fn push_error(&mut self, code: ErrorCode, message: impl Into<String>, path: &str) {
+        let mut err = RuleError::new(code, message).with_path(path);
+        if let Some(locator) = self.locator {
+            if let Some(location) = locator.location_for(path) {
+                err = err.with_location(location.line, location.column);
+            }
+        }
+        self.errors.push(err);
+    }
+
+    /// Add a produced target
+    pub fn add_produced_target(&mut self, tokens: Vec<PathToken>) {
+        self.produced_targets.insert(tokens);
+    }
+
+    /// Get reference to produced targets
+    pub fn produced_targets(&self) -> &HashSet<Vec<PathToken>> {
+        &self.produced_targets
+    }
+
+    /// Consume context and return errors if any
+    pub fn finish(self) -> Result<(), Vec<RuleError>> {
+        if self.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(self.errors)
+        }
+    }
+
+    /// Check if there are errors
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Get collected errors
+    pub fn errors(&self) -> &[RuleError] {
+        &self.errors
+    }
+}


### PR DESCRIPTION
## Summary
- Move v2 validator lexical scope and validation context support into v2_validator/context.rs
- Re-export V2Scope and V2ValidationCtx from v2_validator to preserve source-compatible import paths
- Leave validation traversal, operator metadata, cycle detection, transform semantics, and trace schema unchanged

## Invariants
- Public rulemorph::v2_validator::{V2Scope, V2ValidationCtx} names and signatures are preserved
- Validation error code/message/path/location behavior is unchanged
- No transform semantics or trace JSON schema changes
- No CLI/MCP/HTTP contract changes

## Tests
- cargo fmt
- cargo test -p rulemorph --lib v2_validator
- cargo test -p rulemorph --test validation
- cargo test -p rulemorph --test transform_golden
- cargo fmt --check
- git diff --check
- cargo test --quiet
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph --test v2_transform