### PR TITLE
Refactor CLI input helpers

### DIFF
--- a/crates/rulemorph_cli/src/input.rs
+++ b/crates/rulemorph_cli/src/input.rs
@@ -1,0 +1,182 @@
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+
+use rulemorph::{
+    InputFormat, NormalizationOptions, RuleFile, RuleFormat, parse_rule_file_with_format,
+};
+
+use super::{FormatOverride, LimitsProfileArg, RulesFormatArg};
+
+pub(super) fn load_rule(
+    path: &PathBuf,
+    override_format: Option<RulesFormatArg>,
+) -> Result<(RuleFile, String), i32> {
+    let yaml = match fs::read_to_string(path) {
+        Ok(data) => data,
+        Err(err) => {
+            eprintln!("failed to read rules: {}", err);
+            return Err(1);
+        }
+    };
+
+    let format = detect_rule_format(path, override_format);
+    let rule = match parse_rule_file_with_format(&yaml, format) {
+        Ok(rule) => rule,
+        Err(err) => {
+            eprintln!("failed to parse rules: {}", err);
+            return Err(1);
+        }
+    };
+
+    Ok((rule, yaml))
+}
+
+pub(super) fn detect_rule_format(
+    path: &PathBuf,
+    override_format: Option<RulesFormatArg>,
+) -> RuleFormat {
+    match override_format {
+        Some(RulesFormatArg::Yaml) => RuleFormat::Yaml,
+        Some(RulesFormatArg::Json) => RuleFormat::Json,
+        None => RuleFormat::from_path(path),
+    }
+}
+
+pub(super) fn rule_base_dir(path: &PathBuf) -> PathBuf {
+    path.parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_path_buf()
+}
+
+pub(super) fn apply_format_override(rule: &mut RuleFile, format: Option<FormatOverride>) {
+    if let Some(format) = format {
+        rule.input.format = match format {
+            FormatOverride::Csv => InputFormat::Csv,
+            FormatOverride::Json => InputFormat::Json,
+        };
+    }
+}
+
+pub(super) fn load_input_bytes_with_limit(
+    path: &PathBuf,
+    max_input_bytes: usize,
+) -> Result<Vec<u8>, i32> {
+    match read_file_with_limit(path, max_input_bytes) {
+        Ok(value) => Ok(value),
+        Err(message) => {
+            eprintln!("failed to read input: {}", message);
+            Err(1)
+        }
+    }
+}
+
+pub(super) fn read_file_with_limit(path: &PathBuf, max_bytes: usize) -> Result<Vec<u8>, String> {
+    let metadata = fs::metadata(path).map_err(|err| err.to_string())?;
+    if metadata.len() > max_bytes as u64 {
+        return Err(format!("input exceeds max_input_bytes ({})", max_bytes));
+    }
+    let mut file = fs::File::open(path).map_err(|err| err.to_string())?;
+    let mut bytes = Vec::new();
+    Read::by_ref(&mut file)
+        .take(max_bytes as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|err| err.to_string())?;
+    if bytes.len() > max_bytes {
+        return Err(format!("input exceeds max_input_bytes ({})", max_bytes));
+    }
+    Ok(bytes)
+}
+
+pub(super) fn load_context(path: &Option<PathBuf>) -> Result<Option<serde_json::Value>, i32> {
+    match path {
+        Some(path) => match fs::read_to_string(path) {
+            Ok(data) => match serde_json::from_str(&data) {
+                Ok(json) => Ok(Some(json)),
+                Err(err) => {
+                    eprintln!("failed to parse context JSON: {}", err);
+                    Err(1)
+                }
+            },
+            Err(err) => {
+                eprintln!("failed to read context: {}", err);
+                Err(1)
+            }
+        },
+        None => Ok(None),
+    }
+}
+
+pub(super) fn load_normalization_options(
+    profile: Option<LimitsProfileArg>,
+    file: Option<&PathBuf>,
+    overrides: &[String],
+) -> Result<NormalizationOptions, String> {
+    let mut options = match profile.unwrap_or(LimitsProfileArg::Default) {
+        LimitsProfileArg::Default => NormalizationOptions::default(),
+        LimitsProfileArg::Large => NormalizationOptions::large(),
+    };
+    if let Some(file) = file {
+        let raw = fs::read_to_string(file)
+            .map_err(|err| format!("failed to read limits file: {}", err))?;
+        let value = raw
+            .parse::<toml::Value>()
+            .map_err(|err| format!("failed to parse limits file: {}", err))?;
+        let table = value
+            .as_table()
+            .ok_or_else(|| "limits file must contain a TOML table".to_string())?;
+        for (name, value) in table {
+            let value = value
+                .as_integer()
+                .ok_or_else(|| format!("limit `{}` must be an integer", name))?;
+            apply_limit_override(&mut options, name, value.into())?;
+        }
+    }
+    for item in overrides {
+        let (name, value) = item
+            .split_once('=')
+            .ok_or_else(|| "limit override must use name=value".to_string())?;
+        let value = value
+            .parse::<i128>()
+            .map_err(|_| format!("limit `{}` must be a positive integer", name))?;
+        apply_limit_override(&mut options, name, value)?;
+    }
+    Ok(options)
+}
+
+pub(super) fn apply_limit_override(
+    options: &mut NormalizationOptions,
+    name: &str,
+    value: i128,
+) -> Result<(), String> {
+    if value <= 0 {
+        return Err(format!("limit `{}` must be a positive integer", name));
+    }
+    let value = usize::try_from(value)
+        .map_err(|_| format!("limit `{}` is too large for this platform", name))?;
+    if value == usize::MAX {
+        return Err(format!("limit `{}` is too large", name));
+    }
+    match name {
+        "input-bytes" => options.max_input_bytes = value,
+        "records" => options.max_records = value,
+        "depth" => options.max_depth = value,
+        "array-len" => options.max_array_len = value,
+        "text-bytes" => options.max_text_bytes = value,
+        "yaml-aliases" => options.max_yaml_aliases = value,
+        "yaml-expanded-nodes" => options.max_yaml_expanded_nodes = value,
+        "xml-nodes" => options.max_xml_nodes = value,
+        "html-nodes" => options.max_html_nodes = value,
+        "excel-zip-entries" => options.max_excel_zip_entries = value,
+        "excel-uncompressed-bytes" => options.max_excel_uncompressed_bytes = value,
+        "excel-entry-uncompressed-bytes" => options.max_excel_entry_uncompressed_bytes = value,
+        "excel-sheets" => options.max_excel_sheets = value,
+        "excel-rows" => options.max_excel_rows = value,
+        "excel-cells" => options.max_excel_cells = value,
+        "excel-shared-strings" => options.max_excel_shared_strings = value,
+        "excel-shared-string-bytes" => options.max_excel_shared_string_bytes = value,
+        "excel-styles" => options.max_excel_styles = value,
+        _ => return Err(format!("unknown limit `{}`", name)),
+    }
+    Ok(())
+}

--- a/crates/rulemorph_cli/src/main.rs
+++ b/crates/rulemorph_cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::PathBuf;
 #[cfg(feature = "server")]
 use std::time::Duration;
@@ -8,8 +8,8 @@ use std::time::Duration;
 use clap::ArgAction;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use rulemorph::{
-    DtoLanguage, InputData, InputFormat, NormalizationOptions, RuleFile, RuleFormat, generate_dto,
-    parse_rule_file_with_format, preflight_validate_input_with_warnings_with_base_dir_and_options,
+    DtoLanguage, InputData, NormalizationOptions, RuleFile, generate_dto,
+    preflight_validate_input_with_warnings_with_base_dir_and_options,
     transform_input_with_warnings_with_base_dir_and_options,
     transform_stream_input_with_base_dir_and_options, validate_rule_file_with_source,
 };
@@ -22,10 +22,15 @@ use rulemorph_server::{
 use rulemorph_trace::TraceStore;
 
 mod emit;
+mod input;
 
 #[cfg(feature = "server")]
 use self::emit::emit_rules_dir_errors;
 use self::emit::{emit_transform_error, emit_transform_warnings, emit_validation_errors};
+use self::input::{
+    apply_format_override, load_context, load_input_bytes_with_limit, load_normalization_options,
+    load_rule, rule_base_dir,
+};
 
 #[derive(Parser)]
 #[command(name = "rulemorph")]
@@ -903,170 +908,4 @@ fn emit_api_key_list(keys: &[ApiKeyInfo], json: bool) {
         }
         println!("---");
     }
-}
-fn load_rule(
-    path: &PathBuf,
-    override_format: Option<RulesFormatArg>,
-) -> Result<(RuleFile, String), i32> {
-    let yaml = match fs::read_to_string(path) {
-        Ok(data) => data,
-        Err(err) => {
-            eprintln!("failed to read rules: {}", err);
-            return Err(1);
-        }
-    };
-
-    let format = detect_rule_format(path, override_format);
-    let rule = match parse_rule_file_with_format(&yaml, format) {
-        Ok(rule) => rule,
-        Err(err) => {
-            eprintln!("failed to parse rules: {}", err);
-            return Err(1);
-        }
-    };
-
-    Ok((rule, yaml))
-}
-
-fn detect_rule_format(path: &PathBuf, override_format: Option<RulesFormatArg>) -> RuleFormat {
-    match override_format {
-        Some(RulesFormatArg::Yaml) => RuleFormat::Yaml,
-        Some(RulesFormatArg::Json) => RuleFormat::Json,
-        None => RuleFormat::from_path(path),
-    }
-}
-
-fn rule_base_dir(path: &PathBuf) -> PathBuf {
-    path.parent()
-        .unwrap_or_else(|| std::path::Path::new("."))
-        .to_path_buf()
-}
-
-fn apply_format_override(rule: &mut RuleFile, format: Option<FormatOverride>) {
-    if let Some(format) = format {
-        rule.input.format = match format {
-            FormatOverride::Csv => InputFormat::Csv,
-            FormatOverride::Json => InputFormat::Json,
-        };
-    }
-}
-
-fn load_input_bytes_with_limit(path: &PathBuf, max_input_bytes: usize) -> Result<Vec<u8>, i32> {
-    match read_file_with_limit(path, max_input_bytes) {
-        Ok(value) => Ok(value),
-        Err(message) => {
-            eprintln!("failed to read input: {}", message);
-            Err(1)
-        }
-    }
-}
-
-fn read_file_with_limit(path: &PathBuf, max_bytes: usize) -> Result<Vec<u8>, String> {
-    let metadata = fs::metadata(path).map_err(|err| err.to_string())?;
-    if metadata.len() > max_bytes as u64 {
-        return Err(format!("input exceeds max_input_bytes ({})", max_bytes));
-    }
-    let mut file = fs::File::open(path).map_err(|err| err.to_string())?;
-    let mut bytes = Vec::new();
-    Read::by_ref(&mut file)
-        .take(max_bytes as u64 + 1)
-        .read_to_end(&mut bytes)
-        .map_err(|err| err.to_string())?;
-    if bytes.len() > max_bytes {
-        return Err(format!("input exceeds max_input_bytes ({})", max_bytes));
-    }
-    Ok(bytes)
-}
-
-fn load_context(path: &Option<PathBuf>) -> Result<Option<serde_json::Value>, i32> {
-    match path {
-        Some(path) => match fs::read_to_string(path) {
-            Ok(data) => match serde_json::from_str(&data) {
-                Ok(json) => Ok(Some(json)),
-                Err(err) => {
-                    eprintln!("failed to parse context JSON: {}", err);
-                    Err(1)
-                }
-            },
-            Err(err) => {
-                eprintln!("failed to read context: {}", err);
-                Err(1)
-            }
-        },
-        None => Ok(None),
-    }
-}
-
-fn load_normalization_options(
-    profile: Option<LimitsProfileArg>,
-    file: Option<&PathBuf>,
-    overrides: &[String],
-) -> Result<NormalizationOptions, String> {
-    let mut options = match profile.unwrap_or(LimitsProfileArg::Default) {
-        LimitsProfileArg::Default => NormalizationOptions::default(),
-        LimitsProfileArg::Large => NormalizationOptions::large(),
-    };
-    if let Some(file) = file {
-        let raw = fs::read_to_string(file)
-            .map_err(|err| format!("failed to read limits file: {}", err))?;
-        let value = raw
-            .parse::<toml::Value>()
-            .map_err(|err| format!("failed to parse limits file: {}", err))?;
-        let table = value
-            .as_table()
-            .ok_or_else(|| "limits file must contain a TOML table".to_string())?;
-        for (name, value) in table {
-            let value = value
-                .as_integer()
-                .ok_or_else(|| format!("limit `{}` must be an integer", name))?;
-            apply_limit_override(&mut options, name, value.into())?;
-        }
-    }
-    for item in overrides {
-        let (name, value) = item
-            .split_once('=')
-            .ok_or_else(|| "limit override must use name=value".to_string())?;
-        let value = value
-            .parse::<i128>()
-            .map_err(|_| format!("limit `{}` must be a positive integer", name))?;
-        apply_limit_override(&mut options, name, value)?;
-    }
-    Ok(options)
-}
-
-fn apply_limit_override(
-    options: &mut NormalizationOptions,
-    name: &str,
-    value: i128,
-) -> Result<(), String> {
-    if value <= 0 {
-        return Err(format!("limit `{}` must be a positive integer", name));
-    }
-    let value = usize::try_from(value)
-        .map_err(|_| format!("limit `{}` is too large for this platform", name))?;
-    if value == usize::MAX {
-        return Err(format!("limit `{}` is too large", name));
-    }
-    match name {
-        "input-bytes" => options.max_input_bytes = value,
-        "records" => options.max_records = value,
-        "depth" => options.max_depth = value,
-        "array-len" => options.max_array_len = value,
-        "text-bytes" => options.max_text_bytes = value,
-        "yaml-aliases" => options.max_yaml_aliases = value,
-        "yaml-expanded-nodes" => options.max_yaml_expanded_nodes = value,
-        "xml-nodes" => options.max_xml_nodes = value,
-        "html-nodes" => options.max_html_nodes = value,
-        "excel-zip-entries" => options.max_excel_zip_entries = value,
-        "excel-uncompressed-bytes" => options.max_excel_uncompressed_bytes = value,
-        "excel-entry-uncompressed-bytes" => options.max_excel_entry_uncompressed_bytes = value,
-        "excel-sheets" => options.max_excel_sheets = value,
-        "excel-rows" => options.max_excel_rows = value,
-        "excel-cells" => options.max_excel_cells = value,
-        "excel-shared-strings" => options.max_excel_shared_strings = value,
-        "excel-shared-string-bytes" => options.max_excel_shared_string_bytes = value,
-        "excel-styles" => options.max_excel_styles = value,
-        _ => return Err(format!("unknown limit `{}`", name)),
-    }
-    Ok(())
 }


### PR DESCRIPTION
## Summary
- Move CLI rule loading, context loading, input byte-limit reading, format override, and normalization limit parsing into input.rs
- Keep clap command surface, command dispatch, transform execution, server commands, and emit helpers unchanged
- Keep CLI output shape, exit codes, transform semantics, and trace schema unchanged

## Invariants
- CLI command names/options/aliases are unchanged
- stdout/stderr messages and JSON/text error shapes are unchanged
- max_input_bytes is still enforced before normalization/transform
- limits profile/file/override validation behavior is unchanged
- No MCP/HTTP contract changes

## Tests
- cargo fmt
- cargo test -p rulemorph_cli --test cli
- cargo test -p rulemorph_cli --features server
- cargo test -p rulemorph_cli
- cargo fmt --check
- git diff --check

Note: cargo test --quiet was intentionally not run for this small PR; per the current refactor operations policy it is reserved for PR/multi-PR milestones.