### PR TITLE
Refactor API graph rule descriptors

### DIFF
--- a/crates/rulemorph_server/src/api_graph.rs
+++ b/crates/rulemorph_server/src/api_graph.rs
@@ -5,13 +5,14 @@ use anyhow::Result;
 use rulemorph::serde_guard::parse_yaml_value_strict;
 use rulemorph::{RuleFormat, parse_rule_file_with_format};
 use serde::Serialize;
-use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 
 mod ops;
 mod primitives;
 
-use self::ops::{endpoint_ops, network_ops, normal_ops, resolve_rule_path};
+use self::ops::{
+    EndpointRuleFile, NetworkRuleFile, endpoint_ops, network_ops, normal_ops, resolve_rule_path,
+};
 use self::primitives::{
     collect_rule_files, insert_placeholder, normalize_path, push_edge, rule_id, rule_label,
     rule_path_display,
@@ -48,42 +49,6 @@ pub struct ApiGraphEdge {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub kind: String,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct EndpointRuleFile {
-    #[serde(rename = "type")]
-    _rule_type: String,
-    #[serde(default)]
-    endpoints: Vec<EndpointDef>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct EndpointDef {
-    method: String,
-    path: String,
-    #[serde(default)]
-    steps: Vec<EndpointStep>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct EndpointStep {
-    rule: String,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct NetworkRuleFile {
-    #[serde(rename = "type")]
-    _rule_type: String,
-    request: NetworkRequest,
-    #[serde(default)]
-    body_rule: Option<String>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct NetworkRequest {
-    method: String,
-    url: JsonValue,
 }
 
 pub fn build_api_graph(data_dir: &Path) -> Result<ApiGraphResponse> {
@@ -244,6 +209,7 @@ pub fn build_api_graph(data_dir: &Path) -> Result<ApiGraphResponse> {
 
 #[cfg(test)]
 mod tests {
+    use super::ops::{EndpointDef, EndpointStep, NetworkRequest};
     use super::*;
     use rulemorph::parse_rule_file;
     use serde_json::json;

--- a/crates/rulemorph_server/src/api_graph/ops.rs
+++ b/crates/rulemorph_server/src/api_graph/ops.rs
@@ -1,9 +1,46 @@
 use std::path::{Path, PathBuf};
 
 use rulemorph::{Expr, ExprChain, ExprOp, ExprRef, Mapping, RuleFile};
+use serde_json::Value as JsonValue;
 
+use super::ApiGraphOp;
 use super::primitives::{normalize_path, rule_id};
-use super::{ApiGraphOp, EndpointRuleFile, NetworkRuleFile};
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct EndpointRuleFile {
+    #[serde(rename = "type")]
+    pub(super) _rule_type: String,
+    #[serde(default)]
+    pub(super) endpoints: Vec<EndpointDef>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct EndpointDef {
+    pub(super) method: String,
+    pub(super) path: String,
+    #[serde(default)]
+    pub(super) steps: Vec<EndpointStep>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct EndpointStep {
+    pub(super) rule: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct NetworkRuleFile {
+    #[serde(rename = "type")]
+    pub(super) _rule_type: String,
+    pub(super) request: NetworkRequest,
+    #[serde(default)]
+    pub(super) body_rule: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct NetworkRequest {
+    pub(super) method: String,
+    pub(super) url: JsonValue,
+}
 
 pub(super) fn endpoint_ops(
     rule: &EndpointRuleFile,


### PR DESCRIPTION
## Summary
- Move endpoint/network graph descriptor structs into `api_graph/ops.rs` with the ops extraction logic that consumes them
- Keep `api_graph.rs` focused on graph orchestration and response DTOs
- Leave `/internal/api-graph` response shape, node/edge ids, labels, kinds, and ordering behavior unchanged

## Tests
- `cargo fmt`
- `cargo test -p rulemorph_server api_graph`
- `npm --prefix crates/rulemorph_ui/ui run test`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`

## Review
- Subagent no-behavior-change diff review: no findings