### PR TITLE
Refactor DTO Rust and TypeScript renderers

### DIFF
--- a/crates/rulemorph/src/dto/render.rs
+++ b/crates/rulemorph/src/dto/render.rs
@@ -1,138 +1,19 @@
 use std::collections::HashMap;
 
+mod rust;
+mod typescript;
+
 use super::schema::{
     Field, FieldType, PrimitiveType, SchemaNode, node_has_required, node_uses_json,
 };
 use super::support::{
     NameRegistry, collect_types, field_identifier, go_json_tag_literal, json_string_literal,
-    rust_string_literal, safe_comment_text, swift_string_literal,
+    safe_comment_text, swift_string_literal,
 };
 use super::{DtoError, DtoLanguage};
 
-pub(super) fn render_rust(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
-    let mut registry = NameRegistry::new(name);
-    let mut defs = Vec::new();
-    collect_types(schema, Vec::new(), &mut registry, &mut defs);
-
-    let mut out = String::new();
-    out.push_str("use serde::{Deserialize, Serialize};\n");
-    if node_uses_json(schema) {
-        out.push_str("use serde_json::Value;\n");
-    }
-    out.push('\n');
-
-    for def in defs {
-        out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
-        out.push_str(&format!("pub struct {} {{\n", def.name));
-
-        let mut used = HashMap::new();
-        for field in &def.node.fields {
-            let ident = field_identifier(DtoLanguage::Rust, &field.key, &mut used);
-            let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
-            let field_type = rust_type_for_field(field, &def.path, &registry);
-
-            let mut attrs = Vec::new();
-            if optional {
-                attrs.push("default".to_string());
-                attrs.push("skip_serializing_if = \"Option::is_none\"".to_string());
-            }
-            if rename {
-                attrs.push(format!("rename = {}", rust_string_literal(&field.key)));
-            }
-
-            if !attrs.is_empty() {
-                out.push_str(&format!("    #[serde({})]\n", attrs.join(", ")));
-            }
-
-            let final_type = if optional {
-                format!("Option<{}>", field_type)
-            } else {
-                field_type
-            };
-            out.push_str(&format!("    pub {}: {},\n", ident, final_type));
-        }
-
-        out.push_str("}\n\n");
-    }
-
-    Ok(out.trim_end().to_string())
-}
-
-fn rust_type_for_field(field: &Field, parent_path: &[String], registry: &NameRegistry) -> String {
-    match &field.field_type {
-        FieldType::Primitive(PrimitiveType::String) => "String".to_string(),
-        FieldType::Primitive(PrimitiveType::Int) => "i64".to_string(),
-        FieldType::Primitive(PrimitiveType::Float) => "f64".to_string(),
-        FieldType::Primitive(PrimitiveType::Bool) => "bool".to_string(),
-        FieldType::JsonValue => "Value".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
-        }
-    }
-}
-
-pub(super) fn render_typescript(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
-    let mut registry = NameRegistry::new(name);
-    let mut defs = Vec::new();
-    collect_types(schema, Vec::new(), &mut registry, &mut defs);
-
-    let mut out = String::new();
-    for def in defs {
-        out.push_str(&format!("export interface {} {{\n", def.name));
-        let mut used = HashMap::new();
-        for field in &def.node.fields {
-            let ident = field_identifier(DtoLanguage::TypeScript, &field.key, &mut used);
-            let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
-            let field_type = typescript_type_for_field(field, &def.path, &registry);
-            if rename {
-                out.push_str(&format!(
-                    "  /** json: {} */\n",
-                    json_string_literal(&safe_comment_text(&field.key))
-                ));
-            }
-            let suffix = if optional { "?" } else { "" };
-            out.push_str(&format!("  {}{}: {};\n", ident, suffix, field_type));
-        }
-        out.push_str("}\n\n");
-    }
-
-    Ok(out.trim_end().to_string())
-}
-
-fn typescript_type_for_field(
-    field: &Field,
-    parent_path: &[String],
-    registry: &NameRegistry,
-) -> String {
-    match &field.field_type {
-        FieldType::Primitive(PrimitiveType::String) => "string".to_string(),
-        FieldType::Primitive(PrimitiveType::Int) => "number".to_string(),
-        FieldType::Primitive(PrimitiveType::Float) => "number".to_string(),
-        FieldType::Primitive(PrimitiveType::Bool) => "boolean".to_string(),
-        FieldType::JsonValue => "unknown".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
-        }
-    }
-}
+pub(super) use self::rust::render_rust;
+pub(super) use self::typescript::render_typescript;
 
 pub(super) fn render_python(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
     let mut registry = NameRegistry::new(name);

--- a/crates/rulemorph/src/dto/render/rust.rs
+++ b/crates/rulemorph/src/dto/render/rust.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use crate::dto::schema::{
+    Field, FieldType, PrimitiveType, SchemaNode, node_has_required, node_uses_json,
+};
+use crate::dto::support::{NameRegistry, collect_types, field_identifier, rust_string_literal};
+use crate::dto::{DtoError, DtoLanguage};
+
+pub(in crate::dto) fn render_rust(schema: &SchemaNode, name: &str) -> Result<String, DtoError> {
+    let mut registry = NameRegistry::new(name);
+    let mut defs = Vec::new();
+    collect_types(schema, Vec::new(), &mut registry, &mut defs);
+
+    let mut out = String::new();
+    out.push_str("use serde::{Deserialize, Serialize};\n");
+    if node_uses_json(schema) {
+        out.push_str("use serde_json::Value;\n");
+    }
+    out.push('\n');
+
+    for def in defs {
+        out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+        out.push_str(&format!("pub struct {} {{\n", def.name));
+
+        let mut used = HashMap::new();
+        for field in &def.node.fields {
+            let ident = field_identifier(DtoLanguage::Rust, &field.key, &mut used);
+            let rename = ident != field.key;
+            let optional = match &field.field_type {
+                FieldType::Object(child) => !node_has_required(child),
+                _ => field.optional,
+            };
+            let field_type = rust_type_for_field(field, &def.path, &registry);
+
+            let mut attrs = Vec::new();
+            if optional {
+                attrs.push("default".to_string());
+                attrs.push("skip_serializing_if = \"Option::is_none\"".to_string());
+            }
+            if rename {
+                attrs.push(format!("rename = {}", rust_string_literal(&field.key)));
+            }
+
+            if !attrs.is_empty() {
+                out.push_str(&format!("    #[serde({})]\n", attrs.join(", ")));
+            }
+
+            let final_type = if optional {
+                format!("Option<{}>", field_type)
+            } else {
+                field_type
+            };
+            out.push_str(&format!("    pub {}: {},\n", ident, final_type));
+        }
+
+        out.push_str("}\n\n");
+    }
+
+    Ok(out.trim_end().to_string())
+}
+
+fn rust_type_for_field(field: &Field, parent_path: &[String], registry: &NameRegistry) -> String {
+    match &field.field_type {
+        FieldType::Primitive(PrimitiveType::String) => "String".to_string(),
+        FieldType::Primitive(PrimitiveType::Int) => "i64".to_string(),
+        FieldType::Primitive(PrimitiveType::Float) => "f64".to_string(),
+        FieldType::Primitive(PrimitiveType::Bool) => "bool".to_string(),
+        FieldType::JsonValue => "Value".to_string(),
+        FieldType::Object(_) => {
+            let mut path = parent_path.to_vec();
+            path.push(field.key.clone());
+            registry
+                .get(&path)
+                .cloned()
+                .unwrap_or_else(|| "Record".to_string())
+        }
+    }
+}

--- a/crates/rulemorph/src/dto/render/typescript.rs
+++ b/crates/rulemorph/src/dto/render/typescript.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use crate::dto::schema::{Field, FieldType, PrimitiveType, SchemaNode, node_has_required};
+use crate::dto::support::{
+    NameRegistry, collect_types, field_identifier, json_string_literal, safe_comment_text,
+};
+use crate::dto::{DtoError, DtoLanguage};
+
+pub(in crate::dto) fn render_typescript(
+    schema: &SchemaNode,
+    name: &str,
+) -> Result<String, DtoError> {
+    let mut registry = NameRegistry::new(name);
+    let mut defs = Vec::new();
+    collect_types(schema, Vec::new(), &mut registry, &mut defs);
+
+    let mut out = String::new();
+    for def in defs {
+        out.push_str(&format!("export interface {} {{\n", def.name));
+        let mut used = HashMap::new();
+        for field in &def.node.fields {
+            let ident = field_identifier(DtoLanguage::TypeScript, &field.key, &mut used);
+            let rename = ident != field.key;
+            let optional = match &field.field_type {
+                FieldType::Object(child) => !node_has_required(child),
+                _ => field.optional,
+            };
+            let field_type = typescript_type_for_field(field, &def.path, &registry);
+            if rename {
+                out.push_str(&format!(
+                    "  /** json: {} */\n",
+                    json_string_literal(&safe_comment_text(&field.key))
+                ));
+            }
+            let suffix = if optional { "?" } else { "" };
+            out.push_str(&format!("  {}{}: {};\n", ident, suffix, field_type));
+        }
+        out.push_str("}\n\n");
+    }
+
+    Ok(out.trim_end().to_string())
+}
+
+fn typescript_type_for_field(
+    field: &Field,
+    parent_path: &[String],
+    registry: &NameRegistry,
+) -> String {
+    match &field.field_type {
+        FieldType::Primitive(PrimitiveType::String) => "string".to_string(),
+        FieldType::Primitive(PrimitiveType::Int) => "number".to_string(),
+        FieldType::Primitive(PrimitiveType::Float) => "number".to_string(),
+        FieldType::Primitive(PrimitiveType::Bool) => "boolean".to_string(),
+        FieldType::JsonValue => "unknown".to_string(),
+        FieldType::Object(_) => {
+            let mut path = parent_path.to_vec();
+            path.push(field.key.clone());
+            registry
+                .get(&path)
+                .cloned()
+                .unwrap_or_else(|| "Record".to_string())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move Rust DTO rendering and Rust type resolution into `dto/render/rust.rs`
- Move TypeScript DTO rendering and TypeScript type resolution into `dto/render/typescript.rs`
- Keep `dto/render.rs` re-exporting both renderers and leave generated DTO output unchanged

## Tests
- `cargo fmt`
- `cargo test -p rulemorph --test dto_golden`
- `cargo test -p rulemorph --test dto_security`
- `cargo test -p rulemorph_cli --test cli generate_outputs_rust_dto`
- `cargo test -p rulemorph_mcp --test stdio generate_dto_typescript`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`