### PR TITLE
Refactor v2 validator references

### DIFF
--- a/crates/rulemorph/src/v2_validator.rs
+++ b/crates/rulemorph/src/v2_validator.rs
@@ -4,10 +4,11 @@
 //! catching errors that previously only occurred at runtime.
 
 use crate::error::ErrorCode;
-use crate::path::{PathToken, parse_path};
+#[cfg(test)]
+use crate::v2_model::V2Ref;
 use crate::v2_model::{
-    V2Comparison, V2Condition, V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Pipe, V2Ref,
-    V2Start, V2Step,
+    V2Comparison, V2Condition, V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Pipe, V2Start,
+    V2Step,
 };
 use crate::v2_operator::{
     V2OperatorArgScope, is_valid_operator, operator_arg_range, operator_arg_scope,
@@ -15,136 +16,13 @@ use crate::v2_operator::{
 
 mod context;
 mod dependencies;
+mod references;
 mod types;
 
 pub use self::context::{V2Scope, V2ValidationCtx};
 pub use self::dependencies::{collect_out_references, validate_no_cyclic_dependencies};
+pub use self::references::validate_v2_ref;
 pub use self::types::{V2Type, infer_v2_expr_type};
-
-// =============================================================================
-// Reference Validation
-// =============================================================================
-
-/// Validate a v2 reference
-pub fn validate_v2_ref(
-    v2_ref: &V2Ref,
-    base_path: &str,
-    scope: &V2Scope,
-    ctx: &mut V2ValidationCtx<'_>,
-) {
-    match v2_ref {
-        V2Ref::Input(path) => {
-            validate_path_syntax(path, base_path, ctx);
-        }
-        V2Ref::Context(path) => {
-            validate_path_syntax(path, base_path, ctx);
-            ctx.context_referenced = true;
-        }
-        V2Ref::Out(path) => {
-            validate_path_syntax(path, base_path, ctx);
-            validate_out_not_forward(path, base_path, ctx);
-        }
-        V2Ref::Item(path) => {
-            if !scope.allows_item() {
-                ctx.push_error(
-                    ErrorCode::InvalidItemRef,
-                    "@item is only valid inside map/filter operations",
-                    base_path,
-                );
-            } else {
-                validate_item_path(path, base_path, ctx);
-            }
-        }
-        V2Ref::Acc(path) => {
-            if !scope.allows_acc() {
-                ctx.push_error(
-                    ErrorCode::InvalidAccRef,
-                    "@acc is only valid inside reduce/fold operations",
-                    base_path,
-                );
-            } else if !path.is_empty() {
-                validate_path_syntax(path, base_path, ctx);
-            }
-        }
-        V2Ref::Local(name) => {
-            if !scope.has_binding(name) {
-                ctx.push_error(
-                    ErrorCode::UndefinedVariable,
-                    format!("undefined variable: @{}", name),
-                    base_path,
-                );
-            }
-        }
-    }
-}
-
-/// Validate path syntax
-fn validate_path_syntax(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'_>) {
-    if path.is_empty() {
-        return; // Empty path is valid (returns entire namespace)
-    }
-    if parse_path(path).is_err() {
-        ctx.push_error(ErrorCode::InvalidPath, "invalid path syntax", base_path);
-    }
-}
-
-/// Validate @item path (supports @item, @item.path, @item.index)
-fn validate_item_path(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'_>) {
-    if path.is_empty() {
-        return; // @item with no path is valid
-    }
-    if path == "index" || path == "value" {
-        return; // @item.index / @item.value are valid
-    }
-    // Direct field access on item value is also valid
-    validate_path_syntax(path, base_path, ctx);
-}
-
-/// Validate @out reference is not a forward reference
-fn validate_out_not_forward(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'_>) {
-    if ctx.allow_any_out_ref {
-        return;
-    }
-    if path.is_empty() {
-        return;
-    }
-
-    let tokens = match parse_path(path) {
-        Ok(t) => t,
-        Err(_) => return, // Path syntax error handled elsewhere
-    };
-
-    // Extract key tokens (ignore array indices for forward reference check)
-    let key_tokens: Vec<PathToken> = tokens
-        .iter()
-        .filter_map(|t| match t {
-            PathToken::Key(k) => Some(PathToken::Key(k.clone())),
-            PathToken::Index(_) => None,
-        })
-        .collect();
-
-    if key_tokens.is_empty() {
-        ctx.push_error(
-            ErrorCode::ForwardOutReference,
-            "out reference must have at least one key",
-            base_path,
-        );
-        return;
-    }
-
-    // Check if any prefix of the path has been produced
-    for end in (1..=key_tokens.len()).rev() {
-        if ctx.produced_targets.contains(&key_tokens[..end].to_vec()) {
-            return; // Found a matching prefix
-        }
-    }
-
-    ctx.push_error(
-        ErrorCode::ForwardOutReference,
-        "out reference must point to previous mappings",
-        base_path,
-    );
-}
 
 // =============================================================================
 // Step Validation
@@ -652,87 +530,5 @@ mod tests {
                 .iter()
                 .any(|err| err.code == ErrorCode::UnknownOp)
         );
-    }
-
-    // Reference validation tests
-    #[test]
-    fn test_validate_item_ref_outside_map() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let scope = V2Scope::new(); // No @item scope
-        let v2_ref = V2Ref::Item("value".to_string());
-
-        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
-
-        assert!(ctx.has_errors());
-        assert_eq!(ctx.errors()[0].code, ErrorCode::InvalidItemRef);
-    }
-
-    #[test]
-    fn test_validate_item_ref_inside_map() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let scope = V2Scope::new().with_item();
-        let v2_ref = V2Ref::Item("value".to_string());
-
-        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
-
-        assert!(!ctx.has_errors());
-    }
-
-    #[test]
-    fn test_validate_item_index() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let scope = V2Scope::new().with_item();
-        let v2_ref = V2Ref::Item("index".to_string());
-
-        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
-
-        assert!(!ctx.has_errors());
-    }
-
-    #[test]
-    fn test_validate_item_ref_invalid_subpath() {
-        let scope = V2Scope::new().with_item();
-
-        let mut ctx = V2ValidationCtx::new(None);
-        let v2_ref = V2Ref::Item("value..foo".to_string());
-        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
-        assert!(
-            ctx.errors()
-                .iter()
-                .any(|err| err.code == ErrorCode::InvalidPath)
-        );
-
-        let mut ctx = V2ValidationCtx::new(None);
-        let v2_ref = V2Ref::Item("index..foo".to_string());
-        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
-        assert!(
-            ctx.errors()
-                .iter()
-                .any(|err| err.code == ErrorCode::InvalidPath)
-        );
-    }
-
-    #[test]
-    fn test_validate_undefined_local() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let scope = V2Scope::new();
-        let v2_ref = V2Ref::Local("undefined_var".to_string());
-
-        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
-
-        assert!(ctx.has_errors());
-        assert_eq!(ctx.errors()[0].code, ErrorCode::UndefinedVariable);
-    }
-
-    #[test]
-    fn test_validate_defined_local() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let mut scope = V2Scope::new();
-        scope.add_binding("x".to_string());
-        let v2_ref = V2Ref::Local("x".to_string());
-
-        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
-
-        assert!(!ctx.has_errors());
     }
 }

--- a/crates/rulemorph/src/v2_validator/references.rs
+++ b/crates/rulemorph/src/v2_validator/references.rs
@@ -67,7 +67,7 @@ fn validate_path_syntax(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'
     }
 }
 
-/// Validate @item path (supports @item, @item.path, @item.index)
+/// Validate @item path (supports @item, @item.value, @item.index, and @item.path)
 fn validate_item_path(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'_>) {
     if path.is_empty() {
         return; // @item with no path is valid
@@ -112,10 +112,12 @@ fn validate_out_not_forward(path: &str, base_path: &str, ctx: &mut V2ValidationC
     }
 
     // Check if any prefix of the path has been produced
-    for end in (1..=key_tokens.len()).rev() {
-        if ctx.produced_targets.contains(&key_tokens[..end].to_vec()) {
+    let mut candidate = key_tokens;
+    while !candidate.is_empty() {
+        if ctx.produced_targets.contains(&candidate) {
             return; // Found a matching prefix
         }
+        candidate.pop();
     }
 
     ctx.push_error(

--- a/crates/rulemorph/src/v2_validator/references.rs
+++ b/crates/rulemorph/src/v2_validator/references.rs
@@ -1,0 +1,212 @@
+use crate::error::ErrorCode;
+use crate::path::{PathToken, parse_path};
+use crate::v2_model::V2Ref;
+
+use super::{V2Scope, V2ValidationCtx};
+
+/// Validate a v2 reference
+pub fn validate_v2_ref(
+    v2_ref: &V2Ref,
+    base_path: &str,
+    scope: &V2Scope,
+    ctx: &mut V2ValidationCtx<'_>,
+) {
+    match v2_ref {
+        V2Ref::Input(path) => {
+            validate_path_syntax(path, base_path, ctx);
+        }
+        V2Ref::Context(path) => {
+            validate_path_syntax(path, base_path, ctx);
+            ctx.context_referenced = true;
+        }
+        V2Ref::Out(path) => {
+            validate_path_syntax(path, base_path, ctx);
+            validate_out_not_forward(path, base_path, ctx);
+        }
+        V2Ref::Item(path) => {
+            if !scope.allows_item() {
+                ctx.push_error(
+                    ErrorCode::InvalidItemRef,
+                    "@item is only valid inside map/filter operations",
+                    base_path,
+                );
+            } else {
+                validate_item_path(path, base_path, ctx);
+            }
+        }
+        V2Ref::Acc(path) => {
+            if !scope.allows_acc() {
+                ctx.push_error(
+                    ErrorCode::InvalidAccRef,
+                    "@acc is only valid inside reduce/fold operations",
+                    base_path,
+                );
+            } else if !path.is_empty() {
+                validate_path_syntax(path, base_path, ctx);
+            }
+        }
+        V2Ref::Local(name) => {
+            if !scope.has_binding(name) {
+                ctx.push_error(
+                    ErrorCode::UndefinedVariable,
+                    format!("undefined variable: @{}", name),
+                    base_path,
+                );
+            }
+        }
+    }
+}
+
+/// Validate path syntax
+fn validate_path_syntax(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'_>) {
+    if path.is_empty() {
+        return; // Empty path is valid (returns entire namespace)
+    }
+    if parse_path(path).is_err() {
+        ctx.push_error(ErrorCode::InvalidPath, "invalid path syntax", base_path);
+    }
+}
+
+/// Validate @item path (supports @item, @item.path, @item.index)
+fn validate_item_path(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'_>) {
+    if path.is_empty() {
+        return; // @item with no path is valid
+    }
+    if path == "index" || path == "value" {
+        return; // @item.index / @item.value are valid
+    }
+    // Direct field access on item value is also valid
+    validate_path_syntax(path, base_path, ctx);
+}
+
+/// Validate @out reference is not a forward reference
+fn validate_out_not_forward(path: &str, base_path: &str, ctx: &mut V2ValidationCtx<'_>) {
+    if ctx.allow_any_out_ref {
+        return;
+    }
+    if path.is_empty() {
+        return;
+    }
+
+    let tokens = match parse_path(path) {
+        Ok(t) => t,
+        Err(_) => return, // Path syntax error handled elsewhere
+    };
+
+    // Extract key tokens (ignore array indices for forward reference check)
+    let key_tokens: Vec<PathToken> = tokens
+        .iter()
+        .filter_map(|t| match t {
+            PathToken::Key(k) => Some(PathToken::Key(k.clone())),
+            PathToken::Index(_) => None,
+        })
+        .collect();
+
+    if key_tokens.is_empty() {
+        ctx.push_error(
+            ErrorCode::ForwardOutReference,
+            "out reference must have at least one key",
+            base_path,
+        );
+        return;
+    }
+
+    // Check if any prefix of the path has been produced
+    for end in (1..=key_tokens.len()).rev() {
+        if ctx.produced_targets.contains(&key_tokens[..end].to_vec()) {
+            return; // Found a matching prefix
+        }
+    }
+
+    ctx.push_error(
+        ErrorCode::ForwardOutReference,
+        "out reference must point to previous mappings",
+        base_path,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_item_ref_outside_map() {
+        let mut ctx = V2ValidationCtx::new(None);
+        let scope = V2Scope::new(); // No @item scope
+        let v2_ref = V2Ref::Item("value".to_string());
+
+        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
+
+        assert!(ctx.has_errors());
+        assert_eq!(ctx.errors()[0].code, ErrorCode::InvalidItemRef);
+    }
+
+    #[test]
+    fn test_validate_item_ref_inside_map() {
+        let mut ctx = V2ValidationCtx::new(None);
+        let scope = V2Scope::new().with_item();
+        let v2_ref = V2Ref::Item("value".to_string());
+
+        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
+
+        assert!(!ctx.has_errors());
+    }
+
+    #[test]
+    fn test_validate_item_index() {
+        let mut ctx = V2ValidationCtx::new(None);
+        let scope = V2Scope::new().with_item();
+        let v2_ref = V2Ref::Item("index".to_string());
+
+        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
+
+        assert!(!ctx.has_errors());
+    }
+
+    #[test]
+    fn test_validate_item_ref_invalid_subpath() {
+        let scope = V2Scope::new().with_item();
+
+        let mut ctx = V2ValidationCtx::new(None);
+        let v2_ref = V2Ref::Item("value..foo".to_string());
+        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
+        assert!(
+            ctx.errors()
+                .iter()
+                .any(|err| err.code == ErrorCode::InvalidPath)
+        );
+
+        let mut ctx = V2ValidationCtx::new(None);
+        let v2_ref = V2Ref::Item("index..foo".to_string());
+        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
+        assert!(
+            ctx.errors()
+                .iter()
+                .any(|err| err.code == ErrorCode::InvalidPath)
+        );
+    }
+
+    #[test]
+    fn test_validate_undefined_local() {
+        let mut ctx = V2ValidationCtx::new(None);
+        let scope = V2Scope::new();
+        let v2_ref = V2Ref::Local("undefined_var".to_string());
+
+        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
+
+        assert!(ctx.has_errors());
+        assert_eq!(ctx.errors()[0].code, ErrorCode::UndefinedVariable);
+    }
+
+    #[test]
+    fn test_validate_defined_local() {
+        let mut ctx = V2ValidationCtx::new(None);
+        let mut scope = V2Scope::new();
+        scope.add_binding("x".to_string());
+        let v2_ref = V2Ref::Local("x".to_string());
+
+        validate_v2_ref(&v2_ref, "test", &scope, &mut ctx);
+
+        assert!(!ctx.has_errors());
+    }
+}


### PR DESCRIPTION
## Summary
- Move v2 reference validation helpers into v2_validator/references.rs
- Re-export validate_v2_ref from v2_validator.rs to keep the existing import path
- Keep step, condition, operator, dependency, and type-inference validation behavior unchanged

## Tests
- cargo fmt
- cargo test -p rulemorph --lib v2_validator
- cargo test -p rulemorph --test validation
- cargo test -p rulemorph --test v2_conditions
- cargo check -p rulemorph_endpoint
- cargo fmt --check
- git diff --check
- git diff --cached --check