### PR TITLE
Refactor v2 validator conditions

### DIFF
--- a/crates/rulemorph/src/v2_validator.rs
+++ b/crates/rulemorph/src/v2_validator.rs
@@ -6,19 +6,18 @@
 use crate::error::ErrorCode;
 #[cfg(test)]
 use crate::v2_model::V2Ref;
-use crate::v2_model::{
-    V2Comparison, V2Condition, V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Pipe, V2Start,
-    V2Step,
-};
+use crate::v2_model::{V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Pipe, V2Start, V2Step};
 use crate::v2_operator::{
     V2OperatorArgScope, is_valid_operator, operator_arg_range, operator_arg_scope,
 };
 
+mod conditions;
 mod context;
 mod dependencies;
 mod references;
 mod types;
 
+pub use self::conditions::validate_v2_condition;
 pub use self::context::{V2Scope, V2ValidationCtx};
 pub use self::dependencies::{collect_out_references, validate_no_cyclic_dependencies};
 pub use self::references::validate_v2_ref;
@@ -175,74 +174,6 @@ fn validate_v2_map_step(
     for (i, step) in map_step.steps.iter().enumerate() {
         let step_path = format!("{}.map[{}]", base_path, i);
         validate_v2_step(step, &step_path, &mut map_scope, ctx);
-    }
-}
-
-// =============================================================================
-// Condition Validation
-// =============================================================================
-
-/// Validate a v2 condition
-pub fn validate_v2_condition(
-    cond: &V2Condition,
-    base_path: &str,
-    scope: &V2Scope,
-    ctx: &mut V2ValidationCtx<'_>,
-) {
-    match cond {
-        V2Condition::All(conditions) => {
-            for (i, c) in conditions.iter().enumerate() {
-                let path = format!("{}.all[{}]", base_path, i);
-                validate_v2_condition(c, &path, scope, ctx);
-            }
-        }
-        V2Condition::Any(conditions) => {
-            for (i, c) in conditions.iter().enumerate() {
-                let path = format!("{}.any[{}]", base_path, i);
-                validate_v2_condition(c, &path, scope, ctx);
-            }
-        }
-        V2Condition::Comparison(comp) => {
-            validate_v2_comparison(comp, base_path, scope, ctx);
-        }
-        V2Condition::Expr(expr) => {
-            validate_v2_expr(expr, base_path, scope, ctx);
-            // Type check: must be bool or unknown
-            let typ = infer_v2_expr_type(expr);
-            if typ.is_definitely_not_bool() {
-                ctx.push_error(
-                    ErrorCode::InvalidWhenType,
-                    "condition must evaluate to boolean",
-                    base_path,
-                );
-            }
-        }
-    }
-}
-
-/// Validate a v2 comparison
-fn validate_v2_comparison(
-    comp: &V2Comparison,
-    base_path: &str,
-    scope: &V2Scope,
-    ctx: &mut V2ValidationCtx<'_>,
-) {
-    // Comparisons need exactly 2 arguments
-    if comp.args.len() != 2 {
-        ctx.push_error(
-            ErrorCode::InvalidArgs,
-            format!(
-                "comparison requires exactly 2 arguments, got {}",
-                comp.args.len()
-            ),
-            base_path,
-        );
-    }
-
-    // Validate each argument
-    for (i, arg) in comp.args.iter().enumerate() {
-        let arg_path = format!("{}.args[{}]", base_path, i);
-        validate_v2_expr(arg, &arg_path, scope, ctx);
     }
 }
 

--- a/crates/rulemorph/src/v2_validator/conditions.rs
+++ b/crates/rulemorph/src/v2_validator/conditions.rs
@@ -1,0 +1,68 @@
+use crate::error::ErrorCode;
+use crate::v2_model::{V2Comparison, V2Condition};
+
+use super::{V2Scope, V2ValidationCtx, infer_v2_expr_type, validate_v2_expr};
+
+/// Validate a v2 condition
+pub fn validate_v2_condition(
+    cond: &V2Condition,
+    base_path: &str,
+    scope: &V2Scope,
+    ctx: &mut V2ValidationCtx<'_>,
+) {
+    match cond {
+        V2Condition::All(conditions) => {
+            for (i, c) in conditions.iter().enumerate() {
+                let path = format!("{}.all[{}]", base_path, i);
+                validate_v2_condition(c, &path, scope, ctx);
+            }
+        }
+        V2Condition::Any(conditions) => {
+            for (i, c) in conditions.iter().enumerate() {
+                let path = format!("{}.any[{}]", base_path, i);
+                validate_v2_condition(c, &path, scope, ctx);
+            }
+        }
+        V2Condition::Comparison(comp) => {
+            validate_v2_comparison(comp, base_path, scope, ctx);
+        }
+        V2Condition::Expr(expr) => {
+            validate_v2_expr(expr, base_path, scope, ctx);
+            // Type check: must be bool or unknown
+            let typ = infer_v2_expr_type(expr);
+            if typ.is_definitely_not_bool() {
+                ctx.push_error(
+                    ErrorCode::InvalidWhenType,
+                    "condition must evaluate to boolean",
+                    base_path,
+                );
+            }
+        }
+    }
+}
+
+/// Validate a v2 comparison
+fn validate_v2_comparison(
+    comp: &V2Comparison,
+    base_path: &str,
+    scope: &V2Scope,
+    ctx: &mut V2ValidationCtx<'_>,
+) {
+    // Comparisons need exactly 2 arguments
+    if comp.args.len() != 2 {
+        ctx.push_error(
+            ErrorCode::InvalidArgs,
+            format!(
+                "comparison requires exactly 2 arguments, got {}",
+                comp.args.len()
+            ),
+            base_path,
+        );
+    }
+
+    // Validate each argument
+    for (i, arg) in comp.args.iter().enumerate() {
+        let arg_path = format!("{}.args[{}]", base_path, i);
+        validate_v2_expr(arg, &arg_path, scope, ctx);
+    }
+}


### PR DESCRIPTION
## Summary
- Move v2 condition validation helpers into v2_validator/conditions.rs
- Re-export validate_v2_condition from v2_validator.rs to keep the existing import path
- Keep reference, step, operator, dependency, and type-inference validation behavior unchanged

## Tests
- cargo fmt
- cargo test -p rulemorph --lib v2_validator
- cargo test -p rulemorph --test validation
- cargo test -p rulemorph --test v2_conditions
- cargo check -p rulemorph_endpoint
- cargo fmt --check
- git diff --check
- git diff --cached --check