### PR TITLE
Refactor v2 parser condition tests

### DIFF
--- a/crates/rulemorph/src/v2_parser.rs
+++ b/crates/rulemorph/src/v2_parser.rs
@@ -9,11 +9,11 @@
 //! - Pipe arrays: `[start_value, step1, step2, ...]`
 
 #[cfg(test)]
+use crate::v2_model::V2Condition;
+#[cfg(test)]
 use crate::v2_model::V2Ref;
 #[cfg(test)]
 use crate::v2_model::V2Step;
-#[cfg(test)]
-use crate::v2_model::{V2ComparisonOp, V2Condition};
 // Note: V2Step::Ref variant is used for reference steps like "@doubled"
 
 mod condition;
@@ -171,156 +171,6 @@ mod v2_ref_parser_tests {
         assert!(!is_v2_ref("input.name"));
         assert!(!is_v2_ref("$"));
         assert!(!is_v2_ref("lit:@input"));
-    }
-}
-
-// =============================================================================
-// v2 Condition Parser Tests (T05)
-// =============================================================================
-
-#[cfg(test)]
-mod v2_condition_parser_tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_parse_condition_all() {
-        let value = json!({
-            "all": [
-                { "eq": ["@input.status", "active"] },
-                { "gt": ["@input.age", 18] }
-            ]
-        });
-
-        let cond = parse_v2_condition(&value).unwrap();
-        if let V2Condition::All(conditions) = cond {
-            assert_eq!(conditions.len(), 2);
-        } else {
-            panic!("Expected All condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_any() {
-        let value = json!({
-            "any": [
-                { "eq": ["@input.role", "admin"] },
-                { "eq": ["@input.role", "moderator"] }
-            ]
-        });
-
-        let cond = parse_v2_condition(&value).unwrap();
-        if let V2Condition::Any(conditions) = cond {
-            assert_eq!(conditions.len(), 2);
-        } else {
-            panic!("Expected Any condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_eq() {
-        let value = json!({ "eq": ["@input.name", "John"] });
-        let cond = parse_v2_condition(&value).unwrap();
-
-        if let V2Condition::Comparison(comp) = cond {
-            assert_eq!(comp.op, V2ComparisonOp::Eq);
-            assert_eq!(comp.args.len(), 2);
-        } else {
-            panic!("Expected Comparison condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_ne() {
-        let value = json!({ "ne": ["@input.status", "deleted"] });
-        let cond = parse_v2_condition(&value).unwrap();
-
-        if let V2Condition::Comparison(comp) = cond {
-            assert_eq!(comp.op, V2ComparisonOp::Ne);
-        } else {
-            panic!("Expected Comparison condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_gt() {
-        let value = json!({ "gt": ["@input.age", 18] });
-        let cond = parse_v2_condition(&value).unwrap();
-
-        if let V2Condition::Comparison(comp) = cond {
-            assert_eq!(comp.op, V2ComparisonOp::Gt);
-        } else {
-            panic!("Expected Comparison condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_gte() {
-        let value = json!({ "gte": ["@input.score", 60] });
-        let cond = parse_v2_condition(&value).unwrap();
-
-        if let V2Condition::Comparison(comp) = cond {
-            assert_eq!(comp.op, V2ComparisonOp::Gte);
-        } else {
-            panic!("Expected Comparison condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_lt() {
-        let value = json!({ "lt": ["@input.count", 100] });
-        let cond = parse_v2_condition(&value).unwrap();
-
-        if let V2Condition::Comparison(comp) = cond {
-            assert_eq!(comp.op, V2ComparisonOp::Lt);
-        } else {
-            panic!("Expected Comparison condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_lte() {
-        let value = json!({ "lte": ["@input.retries", 3] });
-        let cond = parse_v2_condition(&value).unwrap();
-
-        if let V2Condition::Comparison(comp) = cond {
-            assert_eq!(comp.op, V2ComparisonOp::Lte);
-        } else {
-            panic!("Expected Comparison condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_condition_match() {
-        let value = json!({ "match": ["@input.email", "^[a-z]+@"] });
-        let cond = parse_v2_condition(&value).unwrap();
-
-        if let V2Condition::Comparison(comp) = cond {
-            assert_eq!(comp.op, V2ComparisonOp::Match);
-        } else {
-            panic!("Expected Comparison condition");
-        }
-    }
-
-    #[test]
-    fn test_parse_nested_conditions() {
-        let value = json!({
-            "all": [
-                { "any": [
-                    { "eq": ["@input.type", "A"] },
-                    { "eq": ["@input.type", "B"] }
-                ]},
-                { "gt": ["@input.value", 0] }
-            ]
-        });
-
-        let cond = parse_v2_condition(&value).unwrap();
-        if let V2Condition::All(conditions) = cond {
-            assert_eq!(conditions.len(), 2);
-            assert!(matches!(conditions[0], V2Condition::Any(_)));
-        } else {
-            panic!("Expected All condition");
-        }
     }
 }
 

--- a/crates/rulemorph/src/v2_parser/condition.rs
+++ b/crates/rulemorph/src/v2_parser/condition.rs
@@ -74,3 +74,149 @@ fn parse_comparison_from_object(
 
     Ok(None)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_parse_condition_all() {
+        let value = json!({
+            "all": [
+                { "eq": ["@input.status", "active"] },
+                { "gt": ["@input.age", 18] }
+            ]
+        });
+
+        let cond = parse_v2_condition(&value).unwrap();
+        if let V2Condition::All(conditions) = cond {
+            assert_eq!(conditions.len(), 2);
+        } else {
+            panic!("Expected All condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_any() {
+        let value = json!({
+            "any": [
+                { "eq": ["@input.role", "admin"] },
+                { "eq": ["@input.role", "moderator"] }
+            ]
+        });
+
+        let cond = parse_v2_condition(&value).unwrap();
+        if let V2Condition::Any(conditions) = cond {
+            assert_eq!(conditions.len(), 2);
+        } else {
+            panic!("Expected Any condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_eq() {
+        let value = json!({ "eq": ["@input.name", "John"] });
+        let cond = parse_v2_condition(&value).unwrap();
+
+        if let V2Condition::Comparison(comp) = cond {
+            assert_eq!(comp.op, V2ComparisonOp::Eq);
+            assert_eq!(comp.args.len(), 2);
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_ne() {
+        let value = json!({ "ne": ["@input.status", "deleted"] });
+        let cond = parse_v2_condition(&value).unwrap();
+
+        if let V2Condition::Comparison(comp) = cond {
+            assert_eq!(comp.op, V2ComparisonOp::Ne);
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_gt() {
+        let value = json!({ "gt": ["@input.age", 18] });
+        let cond = parse_v2_condition(&value).unwrap();
+
+        if let V2Condition::Comparison(comp) = cond {
+            assert_eq!(comp.op, V2ComparisonOp::Gt);
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_gte() {
+        let value = json!({ "gte": ["@input.score", 60] });
+        let cond = parse_v2_condition(&value).unwrap();
+
+        if let V2Condition::Comparison(comp) = cond {
+            assert_eq!(comp.op, V2ComparisonOp::Gte);
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_lt() {
+        let value = json!({ "lt": ["@input.count", 100] });
+        let cond = parse_v2_condition(&value).unwrap();
+
+        if let V2Condition::Comparison(comp) = cond {
+            assert_eq!(comp.op, V2ComparisonOp::Lt);
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_lte() {
+        let value = json!({ "lte": ["@input.retries", 3] });
+        let cond = parse_v2_condition(&value).unwrap();
+
+        if let V2Condition::Comparison(comp) = cond {
+            assert_eq!(comp.op, V2ComparisonOp::Lte);
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_condition_match() {
+        let value = json!({ "match": ["@input.email", "^[a-z]+@"] });
+        let cond = parse_v2_condition(&value).unwrap();
+
+        if let V2Condition::Comparison(comp) = cond {
+            assert_eq!(comp.op, V2ComparisonOp::Match);
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+
+    #[test]
+    fn test_parse_nested_conditions() {
+        let value = json!({
+            "all": [
+                { "any": [
+                    { "eq": ["@input.type", "A"] },
+                    { "eq": ["@input.type", "B"] }
+                ]},
+                { "gt": ["@input.value", 0] }
+            ]
+        });
+
+        let cond = parse_v2_condition(&value).unwrap();
+        if let V2Condition::All(conditions) = cond {
+            assert_eq!(conditions.len(), 2);
+            assert!(matches!(conditions[0], V2Condition::Any(_)));
+        } else {
+            panic!("Expected All condition");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move v2 condition parser unit tests from v2_parser.rs into v2_parser/condition.rs
- Keep parse_v2_condition implementation and public parser facade unchanged
- Preserve all existing condition parser semantic cases

## Tests
- cargo fmt
- cargo test -p rulemorph --lib v2_parser::condition
- cargo test -p rulemorph --lib v2_parser
- cargo test -p rulemorph --test v2_conditions
- cargo test -p rulemorph --test validation
- cargo fmt --check
- git diff --check
- git diff --cached --check

## Note
- A subagent review was started but timed out without findings before completion; this remains a test-only mechanical move and is left for PR review as well.