### PR TITLE
Refactor Rust DTO parser

### DIFF
--- a/crates/rulemorph_mcp/src/dto_parse.rs
+++ b/crates/rulemorph_mcp/src/dto_parse.rs
@@ -2,14 +2,16 @@ use std::collections::HashMap;
 
 use crate::dto_language::DtoSourceLanguage;
 use crate::dto_normalize::{
-    normalize_java_text, normalize_kotlin_text, normalize_python_text, normalize_rust_text,
-    normalize_swift_text, normalize_typescript_text,
+    normalize_java_text, normalize_kotlin_text, normalize_python_text, normalize_swift_text,
+    normalize_typescript_text,
 };
 use crate::dto_schema::{DtoField, DtoFieldType, DtoSchema, DtoType, PrimitiveKind};
 
 mod go;
+mod rust_dto;
 
 use self::go::parse_go_types;
+use self::rust_dto::parse_rust_types;
 
 pub(crate) fn parse_dto_schema(
     text: &str,
@@ -123,113 +125,6 @@ fn parse_typescript_types(text: &str) -> Result<(HashMap<String, DtoType>, Vec<S
         let json_key = pending_json_key
             .take()
             .unwrap_or_else(|| field_name.clone());
-        if let Some(dto_type) = types.get_mut(&current_name) {
-            dto_type.fields.push(DtoField {
-                json_key,
-                field_type,
-                optional,
-            });
-        }
-    }
-
-    Ok((types, order))
-}
-
-fn parse_rust_types(text: &str) -> Result<(HashMap<String, DtoType>, Vec<String>), String> {
-    let mut types: HashMap<String, DtoType> = HashMap::new();
-    let mut order = Vec::new();
-    let mut current: Option<String> = None;
-    let mut pending_json_key: Option<String> = None;
-
-    let normalized = normalize_rust_text(text);
-    for raw_line in normalized.lines() {
-        let mut line = raw_line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        if line.starts_with("pub struct ") {
-            let name_part = line.strip_prefix("pub struct ").unwrap_or(line).trim();
-            let name = name_part
-                .split(|ch: char| ch.is_whitespace() || ch == '{')
-                .next()
-                .unwrap_or("")
-                .trim();
-            if name.is_empty() {
-                continue;
-            }
-            current = Some(name.to_string());
-            pending_json_key = None;
-            types
-                .entry(name.to_string())
-                .or_insert_with(|| DtoType { fields: Vec::new() });
-            order.push(name.to_string());
-            continue;
-        }
-
-        let Some(current_name) = current.clone() else {
-            continue;
-        };
-        if line.starts_with('}') {
-            current = None;
-            pending_json_key = None;
-            continue;
-        }
-
-        if line.starts_with("#[serde") {
-            if let Some(rename) = parse_serde_rename(line) {
-                pending_json_key = Some(rename);
-            }
-            if let Some(end) = line.find(']') {
-                let rest = line[end + 1..].trim();
-                if rest.is_empty() {
-                    continue;
-                }
-                line = rest;
-            } else {
-                continue;
-            }
-        }
-
-        if !line.starts_with("pub ") {
-            continue;
-        }
-
-        let line = line.trim_end_matches(',');
-        let rest = line.strip_prefix("pub ").unwrap_or(line).trim();
-        let mut parts = rest.splitn(2, ':');
-        let field_name = parts.next().unwrap_or("").trim();
-        let type_part = parts.next().unwrap_or("").trim();
-        if field_name.is_empty() || type_part.is_empty() {
-            continue;
-        }
-
-        let compact = type_part.replace(' ', "");
-        let (type_name, optional) = if compact.starts_with("Option<") && compact.ends_with('>') {
-            (compact[7..compact.len() - 1].to_string(), true)
-        } else {
-            (compact, false)
-        };
-
-        let type_key = type_name
-            .rsplit("::")
-            .next()
-            .unwrap_or(&type_name)
-            .to_string();
-        let field_type = match type_key.as_str() {
-            "String" => DtoFieldType::Primitive(PrimitiveKind::String),
-            "bool" => DtoFieldType::Primitive(PrimitiveKind::Bool),
-            "i8" | "i16" | "i32" | "i64" | "isize" | "u8" | "u16" | "u32" | "u64" | "usize" => {
-                DtoFieldType::Primitive(PrimitiveKind::Int)
-            }
-            "f32" | "f64" => DtoFieldType::Primitive(PrimitiveKind::Float),
-            _ if type_key.ends_with("Value") => DtoFieldType::Unknown,
-            _ => DtoFieldType::Object(type_key),
-        };
-
-        let json_key = pending_json_key
-            .take()
-            .unwrap_or_else(|| field_name.to_string());
         if let Some(dto_type) = types.get_mut(&current_name) {
             dto_type.fields.push(DtoField {
                 json_key,
@@ -1044,13 +939,4 @@ fn parse_json_comment(line: &str) -> Option<(String, &str)> {
         ""
     };
     Some((json_key, rest))
-}
-
-fn parse_serde_rename(line: &str) -> Option<String> {
-    let marker = line.find("rename")?;
-    let after_marker = &line[marker..];
-    let quote_start = after_marker.find('"')?;
-    let after_quote = &after_marker[quote_start + 1..];
-    let quote_end = after_quote.find('"')?;
-    Some(after_quote[..quote_end].to_string())
 }

--- a/crates/rulemorph_mcp/src/dto_parse/rust_dto.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/rust_dto.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+
+use crate::dto_normalize::normalize_rust_text;
+use crate::dto_schema::{DtoField, DtoFieldType, DtoType, PrimitiveKind};
+
+pub(super) fn parse_rust_types(
+    text: &str,
+) -> Result<(HashMap<String, DtoType>, Vec<String>), String> {
+    let mut types: HashMap<String, DtoType> = HashMap::new();
+    let mut order = Vec::new();
+    let mut current: Option<String> = None;
+    let mut pending_json_key: Option<String> = None;
+
+    let normalized = normalize_rust_text(text);
+    for raw_line in normalized.lines() {
+        let mut line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if line.starts_with("pub struct ") {
+            let name_part = line.strip_prefix("pub struct ").unwrap_or(line).trim();
+            let name = name_part
+                .split(|ch: char| ch.is_whitespace() || ch == '{')
+                .next()
+                .unwrap_or("")
+                .trim();
+            if name.is_empty() {
+                continue;
+            }
+            current = Some(name.to_string());
+            pending_json_key = None;
+            types
+                .entry(name.to_string())
+                .or_insert_with(|| DtoType { fields: Vec::new() });
+            order.push(name.to_string());
+            continue;
+        }
+
+        let Some(current_name) = current.clone() else {
+            continue;
+        };
+        if line.starts_with('}') {
+            current = None;
+            pending_json_key = None;
+            continue;
+        }
+
+        if line.starts_with("#[serde") {
+            if let Some(rename) = parse_serde_rename(line) {
+                pending_json_key = Some(rename);
+            }
+            if let Some(end) = line.find(']') {
+                let rest = line[end + 1..].trim();
+                if rest.is_empty() {
+                    continue;
+                }
+                line = rest;
+            } else {
+                continue;
+            }
+        }
+
+        if !line.starts_with("pub ") {
+            continue;
+        }
+
+        let line = line.trim_end_matches(',');
+        let rest = line.strip_prefix("pub ").unwrap_or(line).trim();
+        let mut parts = rest.splitn(2, ':');
+        let field_name = parts.next().unwrap_or("").trim();
+        let type_part = parts.next().unwrap_or("").trim();
+        if field_name.is_empty() || type_part.is_empty() {
+            continue;
+        }
+
+        let compact = type_part.replace(' ', "");
+        let (type_name, optional) = if compact.starts_with("Option<") && compact.ends_with('>') {
+            (compact[7..compact.len() - 1].to_string(), true)
+        } else {
+            (compact, false)
+        };
+
+        let type_key = type_name
+            .rsplit("::")
+            .next()
+            .unwrap_or(&type_name)
+            .to_string();
+        let field_type = match type_key.as_str() {
+            "String" => DtoFieldType::Primitive(PrimitiveKind::String),
+            "bool" => DtoFieldType::Primitive(PrimitiveKind::Bool),
+            "i8" | "i16" | "i32" | "i64" | "isize" | "u8" | "u16" | "u32" | "u64" | "usize" => {
+                DtoFieldType::Primitive(PrimitiveKind::Int)
+            }
+            "f32" | "f64" => DtoFieldType::Primitive(PrimitiveKind::Float),
+            _ if type_key.ends_with("Value") => DtoFieldType::Unknown,
+            _ => DtoFieldType::Object(type_key),
+        };
+
+        let json_key = pending_json_key
+            .take()
+            .unwrap_or_else(|| field_name.to_string());
+        if let Some(dto_type) = types.get_mut(&current_name) {
+            dto_type.fields.push(DtoField {
+                json_key,
+                field_type,
+                optional,
+            });
+        }
+    }
+
+    Ok((types, order))
+}
+
+fn parse_serde_rename(line: &str) -> Option<String> {
+    let marker = line.find("rename")?;
+    let after_marker = &line[marker..];
+    let quote_start = after_marker.find('"')?;
+    let after_quote = &after_marker[quote_start + 1..];
+    let quote_end = after_quote.find('"')?;
+    Some(after_quote[..quote_end].to_string())
+}

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -1932,6 +1932,122 @@ fn generate_rules_from_dto_single_line_rust_struct() {
 }
 
 #[test]
+fn generate_rules_from_dto_rust_multiline_struct_shape() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let dto_text = r#"
+pub struct Record {
+    #[serde(rename = "user_id")]
+    pub id: String,
+    pub name: Option<String>,
+    pub active: bool,
+    pub count: i64,
+    pub ratio: f32,
+    pub profile: Option<Profile>,
+    pub metadata: serde_json::Value,
+}
+
+pub struct Profile {
+    #[serde(rename = "city_name")]
+    pub city: String,
+}
+"#;
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1901,
+        "method": "tools/call",
+        "params": {
+            "name": "generate_rules_from_dto",
+            "arguments": {
+                "dto_text": dto_text,
+                "dto_language": "rust",
+                "input_json": {
+                    "user_id": "001",
+                    "name": "Ada",
+                    "active": true,
+                    "count": 7,
+                    "ratio": 1.5,
+                    "profile": {
+                        "city_name": "Tokyo"
+                    },
+                    "metadata": {
+                        "team": "core"
+                    }
+                }
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    let output_text = response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("output text");
+    let rule = parse_rule_file(output_text).expect("parse output rules");
+
+    let id_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "user_id")
+        .expect("user_id mapping");
+    assert_eq!(id_mapping.source.as_deref(), Some("user_id"));
+    assert_eq!(id_mapping.value_type.as_deref(), Some("string"));
+    assert!(id_mapping.required);
+
+    let name_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "name")
+        .expect("name mapping");
+    assert_eq!(name_mapping.source.as_deref(), Some("name"));
+    assert!(!name_mapping.required);
+
+    let active_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "active")
+        .expect("active mapping");
+    assert_eq!(active_mapping.value_type.as_deref(), Some("bool"));
+
+    let count_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "count")
+        .expect("count mapping");
+    assert_eq!(count_mapping.value_type.as_deref(), Some("int"));
+
+    let ratio_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "ratio")
+        .expect("ratio mapping");
+    assert_eq!(ratio_mapping.value_type.as_deref(), Some("float"));
+
+    let profile_city_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "profile.city_name")
+        .expect("profile.city_name mapping");
+    assert_eq!(
+        profile_city_mapping.source.as_deref(),
+        Some("profile.city_name")
+    );
+    assert_eq!(profile_city_mapping.value_type.as_deref(), Some("string"));
+    assert!(!profile_city_mapping.required);
+
+    let metadata_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "metadata")
+        .expect("metadata mapping");
+    assert_eq!(metadata_mapping.source, None);
+    assert_eq!(metadata_mapping.value_type, None);
+
+    server.shutdown();
+}
+
+#[test]
 fn generate_rules_from_dto_python_single_line_alias() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- Add a Rust DTO parser characterization test covering multiline structs, serde rename, nested objects, primitives, Option, and serde_json::Value unknown fields.
- Move the Rust DTO parser implementation from dto_parse.rs into dto_parse/rust_dto.rs.
- Keep parse_dto_schema dispatch and MCP tool behavior unchanged.

## Behavior
- No MCP tool name, schema, JSON-RPC error, allowed-root, or path-security changes.
- No transform semantics or trace schema changes.
- No CLI/HTTP contract changes.

## Verification
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_single_line_rust_struct
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_rust_
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_success
- cargo test -p rulemorph_mcp
- cargo fmt
- cargo fmt --check
- git diff --check
- git diff --cached --check

## Review
- Subagent review: no findings