### PR TITLE
Refactor Python DTO parser

### DIFF
--- a/crates/rulemorph_mcp/src/dto_parse.rs
+++ b/crates/rulemorph_mcp/src/dto_parse.rs
@@ -2,15 +2,16 @@ use std::collections::HashMap;
 
 use crate::dto_language::DtoSourceLanguage;
 use crate::dto_normalize::{
-    normalize_java_text, normalize_kotlin_text, normalize_python_text, normalize_swift_text,
-    normalize_typescript_text,
+    normalize_java_text, normalize_kotlin_text, normalize_swift_text, normalize_typescript_text,
 };
 use crate::dto_schema::{DtoField, DtoFieldType, DtoSchema, DtoType, PrimitiveKind};
 
 mod go;
+mod python;
 mod rust_dto;
 
 use self::go::parse_go_types;
+use self::python::parse_python_types;
 use self::rust_dto::parse_rust_types;
 
 pub(crate) fn parse_dto_schema(
@@ -206,160 +207,6 @@ fn strip_leading_annotations(
     }
 
     rest.to_string()
-}
-
-fn parse_python_alias(line: &str) -> Option<String> {
-    parse_named_argument(line, "alias")
-}
-
-fn parse_python_types(text: &str) -> Result<(HashMap<String, DtoType>, Vec<String>), String> {
-    let mut types: HashMap<String, DtoType> = HashMap::new();
-    let mut order = Vec::new();
-    let mut current: Option<String> = None;
-    let mut current_indent: Option<usize> = None;
-    let normalized = normalize_python_text(text);
-
-    for raw_line in normalized.lines() {
-        let indent = raw_line.chars().take_while(|ch| ch.is_whitespace()).count();
-        let mut line = raw_line.trim();
-        let mut class_line = false;
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        if line.starts_with("class ") {
-            class_line = true;
-            let name_part = line.strip_prefix("class ").unwrap_or(line).trim();
-            let name = name_part
-                .split(|ch: char| ch.is_whitespace() || ch == '(' || ch == ':')
-                .next()
-                .unwrap_or("")
-                .trim();
-            if name.is_empty() {
-                continue;
-            }
-            current = Some(name.to_string());
-            current_indent = Some(indent);
-            types
-                .entry(name.to_string())
-                .or_insert_with(|| DtoType { fields: Vec::new() });
-            order.push(name.to_string());
-            if let Some(colon_pos) = line.find(':') {
-                line = line[colon_pos + 1..].trim();
-                if line.is_empty() {
-                    continue;
-                }
-            } else {
-                continue;
-            }
-        }
-
-        if let Some(indent_level) = current_indent {
-            if !class_line && indent <= indent_level && !line.is_empty() {
-                current = None;
-                current_indent = None;
-            }
-        }
-
-        let Some(current_name) = current.clone() else {
-            continue;
-        };
-
-        if line.starts_with('@') {
-            continue;
-        }
-
-        if let Some(comment_pos) = line.find('#') {
-            line = line[..comment_pos].trim();
-        }
-        if line.is_empty() || !line.contains(':') {
-            continue;
-        }
-
-        let mut parts = line.splitn(2, ':');
-        let field_name = parts.next().unwrap_or("").trim();
-        let mut rest = parts.next().unwrap_or("").trim();
-        rest = rest.trim_end_matches(';').trim();
-        if field_name.is_empty() || rest.is_empty() {
-            continue;
-        }
-
-        let mut optional = false;
-        if let Some(eq_pos) = rest.find('=') {
-            let (type_part, value_part) = rest.split_at(eq_pos);
-            rest = type_part.trim();
-            if value_part.contains("None") {
-                optional = true;
-            }
-        }
-
-        if rest.contains("Optional[")
-            || rest.contains("None")
-            || rest.contains("| None")
-            || rest.contains("None |")
-        {
-            optional = true;
-        }
-
-        let mut type_token = rest.trim();
-        if let Some(start) = type_token.find("Optional[") {
-            let after = &type_token[start + "Optional[".len()..];
-            if let Some(end) = after.find(']') {
-                type_token = after[..end].trim();
-            }
-        } else if let Some(start) = type_token.find("Union[") {
-            let after = &type_token[start + "Union[".len()..];
-            if let Some(end) = after.find(']') {
-                let inner = &after[..end];
-                if let Some(first) = inner
-                    .split(',')
-                    .map(|item| item.trim())
-                    .find(|item| !item.contains("None"))
-                {
-                    type_token = first;
-                }
-            }
-        } else if type_token.contains('|') {
-            if let Some(first) = type_token
-                .split('|')
-                .map(|item| item.trim())
-                .find(|item| !item.contains("None"))
-            {
-                type_token = first;
-            }
-        }
-
-        let type_token = type_token.trim_start_matches("typing.");
-        let field_type = if type_token.contains('[')
-            || type_token.contains("List")
-            || type_token.contains("Dict")
-            || type_token.contains("list")
-            || type_token.contains("dict")
-        {
-            DtoFieldType::Unknown
-        } else {
-            match type_token {
-                "str" | "string" => DtoFieldType::Primitive(PrimitiveKind::String),
-                "int" => DtoFieldType::Primitive(PrimitiveKind::Int),
-                "float" => DtoFieldType::Primitive(PrimitiveKind::Float),
-                "bool" | "boolean" => DtoFieldType::Primitive(PrimitiveKind::Bool),
-                "Any" | "any" => DtoFieldType::Unknown,
-                "" => DtoFieldType::Unknown,
-                other => DtoFieldType::Object(other.to_string()),
-            }
-        };
-
-        let json_key = parse_python_alias(line).unwrap_or_else(|| field_name.to_string());
-        if let Some(dto_type) = types.get_mut(&current_name) {
-            dto_type.fields.push(DtoField {
-                json_key,
-                field_type,
-                optional,
-            });
-        }
-    }
-
-    Ok((types, order))
 }
 
 fn parse_java_types(text: &str) -> Result<(HashMap<String, DtoType>, Vec<String>), String> {

--- a/crates/rulemorph_mcp/src/dto_parse/python.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/python.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+
+use crate::dto_normalize::normalize_python_text;
+use crate::dto_schema::{DtoField, DtoFieldType, DtoType, PrimitiveKind};
+
+use super::parse_named_argument;
+
+pub(super) fn parse_python_types(
+    text: &str,
+) -> Result<(HashMap<String, DtoType>, Vec<String>), String> {
+    let mut types: HashMap<String, DtoType> = HashMap::new();
+    let mut order = Vec::new();
+    let mut current: Option<String> = None;
+    let mut current_indent: Option<usize> = None;
+    let normalized = normalize_python_text(text);
+
+    for raw_line in normalized.lines() {
+        let indent = raw_line.chars().take_while(|ch| ch.is_whitespace()).count();
+        let mut line = raw_line.trim();
+        let mut class_line = false;
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if line.starts_with("class ") {
+            class_line = true;
+            let name_part = line.strip_prefix("class ").unwrap_or(line).trim();
+            let name = name_part
+                .split(|ch: char| ch.is_whitespace() || ch == '(' || ch == ':')
+                .next()
+                .unwrap_or("")
+                .trim();
+            if name.is_empty() {
+                continue;
+            }
+            current = Some(name.to_string());
+            current_indent = Some(indent);
+            types
+                .entry(name.to_string())
+                .or_insert_with(|| DtoType { fields: Vec::new() });
+            order.push(name.to_string());
+            if let Some(colon_pos) = line.find(':') {
+                line = line[colon_pos + 1..].trim();
+                if line.is_empty() {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
+
+        if let Some(indent_level) = current_indent {
+            if !class_line && indent <= indent_level && !line.is_empty() {
+                current = None;
+                current_indent = None;
+            }
+        }
+
+        let Some(current_name) = current.clone() else {
+            continue;
+        };
+
+        if line.starts_with('@') {
+            continue;
+        }
+
+        if let Some(comment_pos) = line.find('#') {
+            line = line[..comment_pos].trim();
+        }
+        if line.is_empty() || !line.contains(':') {
+            continue;
+        }
+
+        let mut parts = line.splitn(2, ':');
+        let field_name = parts.next().unwrap_or("").trim();
+        let mut rest = parts.next().unwrap_or("").trim();
+        rest = rest.trim_end_matches(';').trim();
+        if field_name.is_empty() || rest.is_empty() {
+            continue;
+        }
+
+        let mut optional = false;
+        if let Some(eq_pos) = rest.find('=') {
+            let (type_part, value_part) = rest.split_at(eq_pos);
+            rest = type_part.trim();
+            if value_part.contains("None") {
+                optional = true;
+            }
+        }
+
+        if rest.contains("Optional[")
+            || rest.contains("None")
+            || rest.contains("| None")
+            || rest.contains("None |")
+        {
+            optional = true;
+        }
+
+        let mut type_token = rest.trim();
+        if let Some(start) = type_token.find("Optional[") {
+            let after = &type_token[start + "Optional[".len()..];
+            if let Some(end) = after.find(']') {
+                type_token = after[..end].trim();
+            }
+        } else if let Some(start) = type_token.find("Union[") {
+            let after = &type_token[start + "Union[".len()..];
+            if let Some(end) = after.find(']') {
+                let inner = &after[..end];
+                if let Some(first) = inner
+                    .split(',')
+                    .map(|item| item.trim())
+                    .find(|item| !item.contains("None"))
+                {
+                    type_token = first;
+                }
+            }
+        } else if type_token.contains('|') {
+            if let Some(first) = type_token
+                .split('|')
+                .map(|item| item.trim())
+                .find(|item| !item.contains("None"))
+            {
+                type_token = first;
+            }
+        }
+
+        let type_token = type_token.trim_start_matches("typing.");
+        let field_type = if type_token.contains('[')
+            || type_token.contains("List")
+            || type_token.contains("Dict")
+            || type_token.contains("list")
+            || type_token.contains("dict")
+        {
+            DtoFieldType::Unknown
+        } else {
+            match type_token {
+                "str" | "string" => DtoFieldType::Primitive(PrimitiveKind::String),
+                "int" => DtoFieldType::Primitive(PrimitiveKind::Int),
+                "float" => DtoFieldType::Primitive(PrimitiveKind::Float),
+                "bool" | "boolean" => DtoFieldType::Primitive(PrimitiveKind::Bool),
+                "Any" | "any" => DtoFieldType::Unknown,
+                "" => DtoFieldType::Unknown,
+                other => DtoFieldType::Object(other.to_string()),
+            }
+        };
+
+        let json_key = parse_python_alias(line).unwrap_or_else(|| field_name.to_string());
+        if let Some(dto_type) = types.get_mut(&current_name) {
+            dto_type.fields.push(DtoField {
+                json_key,
+                field_type,
+                optional,
+            });
+        }
+    }
+
+    Ok((types, order))
+}
+
+fn parse_python_alias(line: &str) -> Option<String> {
+    parse_named_argument(line, "alias")
+}

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -2106,6 +2106,143 @@ fn generate_rules_from_dto_python_single_line_alias() {
 }
 
 #[test]
+fn generate_rules_from_dto_python_multiline_model_shape() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let dto_text = r#"
+from typing import Any, Optional
+from pydantic import BaseModel, Field
+
+class Record(BaseModel):
+    id: str = Field(alias="user_id")
+    name: typing.Optional[str] = None
+    active: bool
+    count: int
+    ratio: float
+    profile: Profile
+    metadata: dict[str, Any]
+    tags: list[str]
+
+class Profile(BaseModel):
+    city: str = Field(alias="city_name")
+    nickname: str | None = None
+"#;
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 20,
+        "method": "tools/call",
+        "params": {
+            "name": "generate_rules_from_dto",
+            "arguments": {
+                "dto_text": dto_text,
+                "dto_language": "python",
+                "input_json": {
+                    "user_id": "001",
+                    "name": "Ada",
+                    "active": true,
+                    "count": 3,
+                    "ratio": 1.5,
+                    "profile": {
+                        "city_name": "Paris",
+                        "nickname": null
+                    },
+                    "metadata": { "source": "api" },
+                    "tags": ["vip"]
+                }
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    let output_text = response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("output text");
+    let rule = parse_rule_file(output_text).expect("parse output rules");
+
+    let id_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "user_id")
+        .expect("user_id mapping");
+    assert_eq!(id_mapping.source.as_deref(), Some("user_id"));
+    assert_eq!(id_mapping.value_type.as_deref(), Some("string"));
+    assert!(id_mapping.required);
+
+    let name_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "name")
+        .expect("name mapping");
+    assert_eq!(name_mapping.source.as_deref(), Some("name"));
+    assert_eq!(name_mapping.value_type.as_deref(), Some("string"));
+    assert!(!name_mapping.required);
+
+    let active_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "active")
+        .expect("active mapping");
+    assert_eq!(active_mapping.value_type.as_deref(), Some("bool"));
+    assert!(active_mapping.required);
+
+    let count_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "count")
+        .expect("count mapping");
+    assert_eq!(count_mapping.value_type.as_deref(), Some("int"));
+
+    let ratio_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "ratio")
+        .expect("ratio mapping");
+    assert_eq!(ratio_mapping.value_type.as_deref(), Some("float"));
+
+    let profile_city_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "profile.city_name")
+        .expect("profile.city_name mapping");
+    assert_eq!(
+        profile_city_mapping.source.as_deref(),
+        Some("profile.city_name")
+    );
+    assert_eq!(profile_city_mapping.value_type.as_deref(), Some("string"));
+
+    let profile_nickname_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "profile.nickname")
+        .expect("profile.nickname mapping");
+    assert_eq!(
+        profile_nickname_mapping.source.as_deref(),
+        Some("profile.nickname")
+    );
+    assert!(!profile_nickname_mapping.required);
+
+    let metadata_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "metadata")
+        .expect("metadata mapping");
+    assert_eq!(metadata_mapping.source, None);
+    assert_eq!(metadata_mapping.value_type, None);
+
+    let tags_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "tags")
+        .expect("tags mapping");
+    assert_eq!(tags_mapping.source.as_deref(), Some("tags"));
+    assert_eq!(tags_mapping.value_type, None);
+
+    server.shutdown();
+}
+
+#[test]
 fn generate_rules_from_dto_go_single_line_tags() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- Move the Python DTO parser from dto_parse.rs into dto_parse/python.rs
- Keep the parent dto_parse facade and parser dispatch unchanged
- Add characterization coverage for multiline Pydantic models, aliases, optional fields, nested objects, primitives, and unknown list/dict fields

## No behavior/API changes
- MCP tool names and schemas are unchanged
- JSON-RPC error shape is unchanged
- Generated rules shape is intended to remain compatible
- CLI/HTTP contracts, transform semantics, and trace JSON schema are unchanged

## Tests
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_python_single_line_alias
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_python_multiline_model_shape
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_python
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_success
- cargo test -p rulemorph_mcp
- cargo fmt
- cargo fmt --check
- git diff --check
- git diff --cached --check

## Review
- Subagent no findings