### PR TITLE
Refactor TypeScript DTO parser

### DIFF
--- a/crates/rulemorph_mcp/src/dto_parse.rs
+++ b/crates/rulemorph_mcp/src/dto_parse.rs
@@ -1,18 +1,18 @@
 use std::collections::HashMap;
 
 use crate::dto_language::DtoSourceLanguage;
-use crate::dto_normalize::{
-    normalize_java_text, normalize_kotlin_text, normalize_swift_text, normalize_typescript_text,
-};
+use crate::dto_normalize::{normalize_java_text, normalize_kotlin_text, normalize_swift_text};
 use crate::dto_schema::{DtoField, DtoFieldType, DtoSchema, DtoType, PrimitiveKind};
 
 mod go;
 mod python;
 mod rust_dto;
+mod typescript;
 
 use self::go::parse_go_types;
 use self::python::parse_python_types;
 use self::rust_dto::parse_rust_types;
+use self::typescript::parse_typescript_types;
 
 pub(crate) fn parse_dto_schema(
     text: &str,
@@ -38,104 +38,6 @@ pub(crate) fn parse_dto_schema(
     };
 
     Ok(DtoSchema { root, types })
-}
-
-fn parse_typescript_types(text: &str) -> Result<(HashMap<String, DtoType>, Vec<String>), String> {
-    let mut types: HashMap<String, DtoType> = HashMap::new();
-    let mut order = Vec::new();
-    let mut current: Option<String> = None;
-    let mut pending_json_key: Option<String> = None;
-
-    let normalized = normalize_typescript_text(text);
-    for raw_line in normalized.lines() {
-        let mut line = raw_line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        if line.starts_with("export interface ") || line.starts_with("interface ") {
-            let line = line.strip_prefix("export ").unwrap_or(line);
-            let name_part = line.strip_prefix("interface ").unwrap_or(line).trim();
-            let name = name_part
-                .split(|ch: char| ch.is_whitespace() || ch == '{')
-                .next()
-                .unwrap_or("")
-                .trim();
-            if name.is_empty() {
-                continue;
-            }
-            current = Some(name.to_string());
-            pending_json_key = None;
-            types
-                .entry(name.to_string())
-                .or_insert_with(|| DtoType { fields: Vec::new() });
-            order.push(name.to_string());
-            continue;
-        }
-
-        let Some(current_name) = current.clone() else {
-            continue;
-        };
-        if line.starts_with('}') {
-            current = None;
-            pending_json_key = None;
-            continue;
-        }
-
-        if let Some((json_key, rest)) = parse_json_comment(line) {
-            pending_json_key = Some(json_key);
-            line = rest.trim();
-            if line.is_empty() {
-                continue;
-            }
-        }
-
-        if !line.contains(':') {
-            continue;
-        }
-
-        let line = line.trim_end_matches(';').trim();
-        let mut parts = line.splitn(2, ':');
-        let name_part = parts.next().unwrap_or("").trim();
-        let type_part = parts.next().unwrap_or("").trim();
-        if name_part.is_empty() || type_part.is_empty() {
-            continue;
-        }
-        let optional = name_part.ends_with('?');
-        let field_name = name_part.trim_end_matches('?').trim().to_string();
-
-        let type_token = type_part
-            .split(|ch| ch == '|' || ch == '&')
-            .next()
-            .unwrap_or("")
-            .trim()
-            .trim_end_matches(';');
-        let field_type = if type_token.contains('[') {
-            DtoFieldType::Unknown
-        } else {
-            match type_token {
-                "string" => DtoFieldType::Primitive(PrimitiveKind::String),
-                "number" => DtoFieldType::Primitive(PrimitiveKind::Float),
-                "boolean" => DtoFieldType::Primitive(PrimitiveKind::Bool),
-                "unknown" | "any" => DtoFieldType::Unknown,
-                "" => DtoFieldType::Unknown,
-                other => DtoFieldType::Object(other.to_string()),
-            }
-        };
-
-        let json_key = pending_json_key
-            .take()
-            .unwrap_or_else(|| field_name.clone());
-        if let Some(dto_type) = types.get_mut(&current_name) {
-            dto_type.fields.push(DtoField {
-                json_key,
-                field_type,
-                optional,
-            });
-        }
-    }
-
-    Ok((types, order))
 }
 
 fn parse_first_quoted_value(text: &str) -> Option<String> {
@@ -771,19 +673,4 @@ fn push_swift_case(cases: &mut Vec<(String, String)>, text: &str) {
         .and_then(|value| parse_first_quoted_value(value))
         .unwrap_or_else(|| name.to_string());
     cases.push((name.to_string(), rename));
-}
-
-fn parse_json_comment(line: &str) -> Option<(String, &str)> {
-    let marker = line.find("json:")?;
-    let after_marker = &line[marker + 5..];
-    let quote_start = after_marker.find('"')?;
-    let after_quote = &after_marker[quote_start + 1..];
-    let quote_end = after_quote.find('"')?;
-    let json_key = after_quote[..quote_end].to_string();
-    let rest = if let Some(end) = line.find("*/") {
-        &line[end + 2..]
-    } else {
-        ""
-    };
-    Some((json_key, rest))
 }

--- a/crates/rulemorph_mcp/src/dto_parse/typescript.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/typescript.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+
+use crate::dto_normalize::normalize_typescript_text;
+use crate::dto_schema::{DtoField, DtoFieldType, DtoType, PrimitiveKind};
+
+pub(super) fn parse_typescript_types(
+    text: &str,
+) -> Result<(HashMap<String, DtoType>, Vec<String>), String> {
+    let mut types: HashMap<String, DtoType> = HashMap::new();
+    let mut order = Vec::new();
+    let mut current: Option<String> = None;
+    let mut pending_json_key: Option<String> = None;
+
+    let normalized = normalize_typescript_text(text);
+    for raw_line in normalized.lines() {
+        let mut line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if line.starts_with("export interface ") || line.starts_with("interface ") {
+            let line = line.strip_prefix("export ").unwrap_or(line);
+            let name_part = line.strip_prefix("interface ").unwrap_or(line).trim();
+            let name = name_part
+                .split(|ch: char| ch.is_whitespace() || ch == '{')
+                .next()
+                .unwrap_or("")
+                .trim();
+            if name.is_empty() {
+                continue;
+            }
+            current = Some(name.to_string());
+            pending_json_key = None;
+            types
+                .entry(name.to_string())
+                .or_insert_with(|| DtoType { fields: Vec::new() });
+            order.push(name.to_string());
+            continue;
+        }
+
+        let Some(current_name) = current.clone() else {
+            continue;
+        };
+        if line.starts_with('}') {
+            current = None;
+            pending_json_key = None;
+            continue;
+        }
+
+        if let Some((json_key, rest)) = parse_json_comment(line) {
+            pending_json_key = Some(json_key);
+            line = rest.trim();
+            if line.is_empty() {
+                continue;
+            }
+        }
+
+        if !line.contains(':') {
+            continue;
+        }
+
+        let line = line.trim_end_matches(';').trim();
+        let mut parts = line.splitn(2, ':');
+        let name_part = parts.next().unwrap_or("").trim();
+        let type_part = parts.next().unwrap_or("").trim();
+        if name_part.is_empty() || type_part.is_empty() {
+            continue;
+        }
+        let optional = name_part.ends_with('?');
+        let field_name = name_part.trim_end_matches('?').trim().to_string();
+
+        let type_token = type_part
+            .split(|ch| ch == '|' || ch == '&')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_end_matches(';');
+        let field_type = if type_token.contains('[') {
+            DtoFieldType::Unknown
+        } else {
+            match type_token {
+                "string" => DtoFieldType::Primitive(PrimitiveKind::String),
+                "number" => DtoFieldType::Primitive(PrimitiveKind::Float),
+                "boolean" => DtoFieldType::Primitive(PrimitiveKind::Bool),
+                "unknown" | "any" => DtoFieldType::Unknown,
+                "" => DtoFieldType::Unknown,
+                other => DtoFieldType::Object(other.to_string()),
+            }
+        };
+
+        let json_key = pending_json_key
+            .take()
+            .unwrap_or_else(|| field_name.clone());
+        if let Some(dto_type) = types.get_mut(&current_name) {
+            dto_type.fields.push(DtoField {
+                json_key,
+                field_type,
+                optional,
+            });
+        }
+    }
+
+    Ok((types, order))
+}
+
+fn parse_json_comment(line: &str) -> Option<(String, &str)> {
+    let marker = line.find("json:")?;
+    let after_marker = &line[marker + 5..];
+    let quote_start = after_marker.find('"')?;
+    let after_quote = &after_marker[quote_start + 1..];
+    let quote_end = after_quote.find('"')?;
+    let json_key = after_quote[..quote_end].to_string();
+    let rest = if let Some(end) = line.find("*/") {
+        &line[end + 2..]
+    } else {
+        ""
+    };
+    Some((json_key, rest))
+}

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -1789,6 +1789,65 @@ export interface Profile {
 }
 
 #[test]
+fn generate_rules_from_dto_typescript_json_comment_rename() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let dto_text = r#"export interface Record {
+  /* json: "user_id" */ id: string;
+  profile?: Profile;
+}
+
+export interface Profile {
+  /* json: "city_name" */ city: string;
+}"#;
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1502,
+        "method": "tools/call",
+        "params": {
+            "name": "generate_rules_from_dto",
+            "arguments": {
+                "dto_text": dto_text,
+                "dto_language": "typescript",
+                "input_json": {
+                    "user_id": "001",
+                    "profile": {
+                        "city_name": "Tokyo"
+                    }
+                }
+            }
+        }
+    });
+
+    let response = server.send(&request);
+    let output_text = response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("output text");
+    let rule = parse_rule_file(output_text).expect("parse output rules");
+
+    let id_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "user_id")
+        .expect("user_id mapping");
+    assert_eq!(id_mapping.source.as_deref(), Some("user_id"));
+    assert_eq!(id_mapping.value_type.as_deref(), Some("string"));
+    assert!(id_mapping.required);
+
+    let city_mapping = rule
+        .mappings
+        .iter()
+        .find(|mapping| mapping.target == "profile.city_name")
+        .expect("profile.city_name mapping");
+    assert_eq!(city_mapping.source.as_deref(), Some("profile.city_name"));
+    assert!(!city_mapping.required);
+
+    server.shutdown();
+}
+
+#[test]
 fn generate_rules_from_dto_invalid_language_returns_json_rpc_error() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
## Summary
- Move the MCP TypeScript DTO parser into `dto_parse/typescript.rs`
- Keep `dto_parse.rs` as the parser dispatcher/facade
- Add characterization coverage for TypeScript `/* json: "..." */` rename comments before the split

## No behavior changes
- MCP tool names/schema and JSON-RPC response shapes are unchanged
- generated rules shape and DTO parser language inventory are unchanged
- transform semantics and trace JSON schema are untouched
- other language parsers are untouched

## Tests
- `cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_typescript_json_comment_rename`
- `cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_success`
- `cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_single_line_interface`
- `cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_csv_uses_scalar_type_boost`
- `cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_nested_optional_object_keeps_required_semantics`
- `cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto`
- `cargo test -p rulemorph_mcp`
- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`

## Review
- Subagent staged-diff review: no findings