### PR TITLE
Refactor transform trace API helpers

### DIFF
--- a/crates/rulemorph/src/transform/api.rs
+++ b/crates/rulemorph/src/transform/api.rs
@@ -4,18 +4,18 @@ use std::path::Path;
 use crate::error::{TransformError, TransformWarning};
 use crate::model::RuleFile;
 use crate::normalization::{InputData, NormalizationOptions};
-use crate::trace::{
-    TraceCollector, TraceEventKind, TracePhase, TransformRecordTraceResult, TransformTraceError,
-    TransformTraceOptions, TransformTraceResult,
-};
 
 use super::records::input_records_iter_with_options;
 use super::stream::{
     transform_stream_input_with_base_dir_and_options, transform_stream_input_with_options,
 };
-use super::{
-    BranchContext, apply_finalize, apply_finalize_traced, apply_rule_to_record,
-    apply_rule_to_record_traced,
+use super::{BranchContext, apply_finalize, apply_rule_to_record};
+
+mod trace;
+
+pub use trace::{
+    transform_input_with_trace, transform_input_with_trace_with_base_dir_and_options,
+    transform_record_with_trace,
 };
 
 pub fn transform(
@@ -32,52 +32,6 @@ pub fn transform_input(
     context: Option<&JsonValue>,
 ) -> Result<JsonValue, TransformError> {
     transform_input_with_warnings(rule, input, context).map(|(output, _)| output)
-}
-
-pub fn transform_input_with_trace(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    trace_options: &TransformTraceOptions,
-) -> Result<TransformTraceResult, TransformTraceError> {
-    transform_input_with_trace_with_base_dir_and_options(
-        rule,
-        input,
-        context,
-        None,
-        &NormalizationOptions::default(),
-        trace_options,
-    )
-}
-
-pub fn transform_input_with_trace_with_base_dir_and_options(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: Option<&Path>,
-    options: &NormalizationOptions,
-    trace_options: &TransformTraceOptions,
-) -> Result<TransformTraceResult, TransformTraceError> {
-    let mut collector = TraceCollector::new(trace_options.clone());
-    match transform_with_warnings_inner_traced(
-        rule,
-        input,
-        context,
-        base_dir,
-        options,
-        &mut collector,
-    ) {
-        Ok((output, warnings)) => Ok(TransformTraceResult {
-            output,
-            warnings,
-            trace: collector.finish(),
-        }),
-        Err((error, warnings)) => Err(TransformTraceError {
-            error,
-            warnings,
-            trace: collector.finish(),
-        }),
-    }
 }
 
 pub fn transform_with_options(
@@ -304,66 +258,6 @@ fn transform_with_warnings_inner(
     Ok((output, warnings))
 }
 
-fn transform_with_warnings_inner_traced(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: Option<&Path>,
-    options: &NormalizationOptions,
-    collector: &mut TraceCollector,
-) -> Result<(JsonValue, Vec<TransformWarning>), (TransformError, Vec<TransformWarning>)> {
-    let mut warnings = Vec::new();
-    let mut output_records = Vec::new();
-    let mut records = input_records_iter_with_options(rule, input, options)
-        .map_err(|error| (error, warnings.clone()))?;
-    let mut record_index = 0usize;
-    while let Some(record) = records.next() {
-        let record = record.map_err(|error| (error, warnings.clone()))?;
-        collector.start_record(record_index, &record);
-        record_index += 1;
-        let mut record_warnings = Vec::new();
-        let mut branch_context = BranchContext::default();
-        match apply_rule_to_record_traced(
-            rule,
-            &record,
-            context,
-            &mut record_warnings,
-            base_dir,
-            &mut branch_context,
-            collector,
-        ) {
-            Ok(Some(output)) => output_records.push(output),
-            Ok(None) => {}
-            Err(error) => {
-                warnings.extend(record_warnings);
-                return Err((error, warnings));
-            }
-        }
-        warnings.extend(record_warnings);
-    }
-
-    let mut output = JsonValue::Array(output_records);
-    if let Some(finalize) = &rule.finalize {
-        collector.start_finalize(&output);
-        match apply_finalize_traced(finalize, output, context, collector) {
-            Ok(finalized) => {
-                output = finalized;
-                collector
-                    .end_span(TraceEventKind::FinalizeEnd, TracePhase::End)
-                    .finish(collector);
-            }
-            Err(error) => {
-                collector
-                    .error_span(TraceEventKind::Error, "FINALIZE_ERROR", "finalize failed")
-                    .finish(collector);
-                return Err((error, warnings));
-            }
-        }
-    }
-
-    Ok((output, warnings))
-}
-
 pub fn transform_record(
     rule: &RuleFile,
     record: &JsonValue,
@@ -371,74 +265,6 @@ pub fn transform_record(
 ) -> Result<Option<JsonValue>, TransformError> {
     let (output, _warnings) = transform_record_with_warnings(rule, record, context)?;
     Ok(output)
-}
-
-pub fn transform_record_with_trace(
-    rule: &RuleFile,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    trace_options: &TransformTraceOptions,
-) -> Result<TransformRecordTraceResult, TransformTraceError> {
-    let mut collector = TraceCollector::new(trace_options.clone());
-    collector.start_record(0, record);
-    let mut warnings = Vec::new();
-    let mut branch_context = BranchContext::default();
-    let result = apply_rule_to_record_traced(
-        rule,
-        record,
-        context,
-        &mut warnings,
-        None,
-        &mut branch_context,
-        &mut collector,
-    );
-    match result {
-        Ok(output) => {
-            let output = if let Some(finalize) = &rule.finalize {
-                let Some(value) = output else {
-                    return Ok(TransformRecordTraceResult {
-                        output: None,
-                        warnings,
-                        trace: collector.finish(),
-                    });
-                };
-                let mut records = Vec::new();
-                records.push(value);
-                let array = JsonValue::Array(records);
-                collector.start_finalize(&array);
-                match apply_finalize_traced(finalize, array, context, &mut collector) {
-                    Ok(finalized) => {
-                        collector
-                            .end_span(TraceEventKind::FinalizeEnd, TracePhase::End)
-                            .finish(&mut collector);
-                        Some(finalized)
-                    }
-                    Err(error) => {
-                        collector
-                            .error_span(TraceEventKind::Error, "FINALIZE_ERROR", "finalize failed")
-                            .finish(&mut collector);
-                        return Err(TransformTraceError {
-                            error,
-                            warnings,
-                            trace: collector.finish(),
-                        });
-                    }
-                }
-            } else {
-                output
-            };
-            Ok(TransformRecordTraceResult {
-                output,
-                warnings,
-                trace: collector.finish(),
-            })
-        }
-        Err(error) => Err(TransformTraceError {
-            error,
-            warnings,
-            trace: collector.finish(),
-        }),
-    }
 }
 
 pub fn transform_record_with_base_dir(

--- a/crates/rulemorph/src/transform/api/trace.rs
+++ b/crates/rulemorph/src/transform/api/trace.rs
@@ -1,0 +1,189 @@
+use serde_json::Value as JsonValue;
+use std::path::Path;
+
+use crate::error::{TransformError, TransformWarning};
+use crate::model::RuleFile;
+use crate::normalization::{InputData, NormalizationOptions};
+use crate::trace::{
+    TraceCollector, TraceEventKind, TracePhase, TransformRecordTraceResult, TransformTraceError,
+    TransformTraceOptions, TransformTraceResult,
+};
+
+use super::super::{
+    BranchContext, apply_finalize_traced, apply_rule_to_record_traced,
+    records::input_records_iter_with_options,
+};
+
+pub fn transform_input_with_trace(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    trace_options: &TransformTraceOptions,
+) -> Result<TransformTraceResult, TransformTraceError> {
+    transform_input_with_trace_with_base_dir_and_options(
+        rule,
+        input,
+        context,
+        None,
+        &NormalizationOptions::default(),
+        trace_options,
+    )
+}
+
+pub fn transform_input_with_trace_with_base_dir_and_options(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: Option<&Path>,
+    options: &NormalizationOptions,
+    trace_options: &TransformTraceOptions,
+) -> Result<TransformTraceResult, TransformTraceError> {
+    let mut collector = TraceCollector::new(trace_options.clone());
+    match transform_with_warnings_inner_traced(
+        rule,
+        input,
+        context,
+        base_dir,
+        options,
+        &mut collector,
+    ) {
+        Ok((output, warnings)) => Ok(TransformTraceResult {
+            output,
+            warnings,
+            trace: collector.finish(),
+        }),
+        Err((error, warnings)) => Err(TransformTraceError {
+            error,
+            warnings,
+            trace: collector.finish(),
+        }),
+    }
+}
+
+fn transform_with_warnings_inner_traced(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: Option<&Path>,
+    options: &NormalizationOptions,
+    collector: &mut TraceCollector,
+) -> Result<(JsonValue, Vec<TransformWarning>), (TransformError, Vec<TransformWarning>)> {
+    let mut warnings = Vec::new();
+    let mut output_records = Vec::new();
+    let mut records = input_records_iter_with_options(rule, input, options)
+        .map_err(|error| (error, warnings.clone()))?;
+    let mut record_index = 0usize;
+    while let Some(record) = records.next() {
+        let record = record.map_err(|error| (error, warnings.clone()))?;
+        collector.start_record(record_index, &record);
+        record_index += 1;
+        let mut record_warnings = Vec::new();
+        let mut branch_context = BranchContext::default();
+        match apply_rule_to_record_traced(
+            rule,
+            &record,
+            context,
+            &mut record_warnings,
+            base_dir,
+            &mut branch_context,
+            collector,
+        ) {
+            Ok(Some(output)) => output_records.push(output),
+            Ok(None) => {}
+            Err(error) => {
+                warnings.extend(record_warnings);
+                return Err((error, warnings));
+            }
+        }
+        warnings.extend(record_warnings);
+    }
+
+    let mut output = JsonValue::Array(output_records);
+    if let Some(finalize) = &rule.finalize {
+        collector.start_finalize(&output);
+        match apply_finalize_traced(finalize, output, context, collector) {
+            Ok(finalized) => {
+                output = finalized;
+                collector
+                    .end_span(TraceEventKind::FinalizeEnd, TracePhase::End)
+                    .finish(collector);
+            }
+            Err(error) => {
+                collector
+                    .error_span(TraceEventKind::Error, "FINALIZE_ERROR", "finalize failed")
+                    .finish(collector);
+                return Err((error, warnings));
+            }
+        }
+    }
+
+    Ok((output, warnings))
+}
+
+pub fn transform_record_with_trace(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    trace_options: &TransformTraceOptions,
+) -> Result<TransformRecordTraceResult, TransformTraceError> {
+    let mut collector = TraceCollector::new(trace_options.clone());
+    collector.start_record(0, record);
+    let mut warnings = Vec::new();
+    let mut branch_context = BranchContext::default();
+    let result = apply_rule_to_record_traced(
+        rule,
+        record,
+        context,
+        &mut warnings,
+        None,
+        &mut branch_context,
+        &mut collector,
+    );
+    match result {
+        Ok(output) => {
+            let output = if let Some(finalize) = &rule.finalize {
+                let Some(value) = output else {
+                    return Ok(TransformRecordTraceResult {
+                        output: None,
+                        warnings,
+                        trace: collector.finish(),
+                    });
+                };
+                let mut records = Vec::new();
+                records.push(value);
+                let array = JsonValue::Array(records);
+                collector.start_finalize(&array);
+                match apply_finalize_traced(finalize, array, context, &mut collector) {
+                    Ok(finalized) => {
+                        collector
+                            .end_span(TraceEventKind::FinalizeEnd, TracePhase::End)
+                            .finish(&mut collector);
+                        Some(finalized)
+                    }
+                    Err(error) => {
+                        collector
+                            .error_span(TraceEventKind::Error, "FINALIZE_ERROR", "finalize failed")
+                            .finish(&mut collector);
+                        return Err(TransformTraceError {
+                            error,
+                            warnings,
+                            trace: collector.finish(),
+                        });
+                    }
+                }
+            } else {
+                output
+            };
+            Ok(TransformRecordTraceResult {
+                output,
+                warnings,
+                trace: collector.finish(),
+            })
+        }
+        Err(error) => Err(TransformTraceError {
+            error,
+            warnings,
+            trace: collector.finish(),
+        }),
+    }
+}


### PR DESCRIPTION
## Summary
- move transform trace entrypoints from transform/api.rs into transform/api/trace.rs
- keep the existing public transform API names re-exported from transform/api.rs
- leave transform semantics and trace JSON schema unchanged

## Verification
- cargo fmt
- cargo fmt --check
- cargo test -p rulemorph --test transform_trace
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test -p rulemorph --test transform_golden
- cargo test -p rulemorph transform_record
- git diff --check
- git diff --cached --check

## Notes
- docs/plans/codebase-refactor-execution-log.md was updated locally only and remains ignored
- no public API names or exports changed