### PR TITLE
Refactor simple transform operator helpers

### DIFF
--- a/crates/rulemorph/src/transform/operators.rs
+++ b/crates/rulemorph/src/transform/operators.rs
@@ -8,6 +8,7 @@ mod json;
 mod lookup;
 mod number;
 mod shared;
+mod simple;
 mod string;
 mod value;
 
@@ -35,6 +36,7 @@ use self::number::{eval_numeric_op, eval_round, eval_to_base};
 pub(super) use self::shared::{
     SortKey, SortKeyKind, compare_sort_keys, locals_with_item, locals_with_precomputed_args,
 };
+use self::simple::{eval_coalesce, eval_concat};
 use self::string::{eval_pad, eval_replace, eval_split, eval_unary_string_op};
 pub(super) use self::value::{cast_value, value_as_bool, value_to_string};
 use self::value::{
@@ -61,61 +63,8 @@ pub(crate) fn eval_op(
     }
 
     match expr_op.op.as_str() {
-        "concat" => {
-            let mut parts = Vec::new();
-            for index in 0..total_len {
-                let arg_path = format!("{}.args[{}]", base_path, index);
-                let value = eval_expr_at_index(
-                    index,
-                    &expr_op.args,
-                    injected,
-                    record,
-                    context,
-                    out,
-                    base_path,
-                    locals,
-                )?;
-                match value {
-                    EvalValue::Missing => return Ok(EvalValue::Missing),
-                    EvalValue::Value(value) => {
-                        if value.is_null() {
-                            return Err(TransformError::new(
-                                TransformErrorKind::ExprError,
-                                "concat does not accept null",
-                            )
-                            .with_path(arg_path));
-                        }
-                        let part = value_to_string(&value, &arg_path)?;
-                        parts.push(part);
-                    }
-                }
-            }
-            Ok(EvalValue::Value(JsonValue::String(parts.join(""))))
-        }
-        "coalesce" => {
-            for index in 0..total_len {
-                let value = eval_expr_at_index(
-                    index,
-                    &expr_op.args,
-                    injected,
-                    record,
-                    context,
-                    out,
-                    base_path,
-                    locals,
-                )?;
-                match value {
-                    EvalValue::Missing => continue,
-                    EvalValue::Value(value) => {
-                        if value.is_null() {
-                            continue;
-                        }
-                        return Ok(EvalValue::Value(value));
-                    }
-                }
-            }
-            Ok(EvalValue::Missing)
-        }
+        "concat" => eval_concat(expr_op, injected, record, context, out, base_path, locals),
+        "coalesce" => eval_coalesce(expr_op, injected, record, context, out, base_path, locals),
         "to_string" => eval_unary_string_op(
             &expr_op.args,
             injected,

--- a/crates/rulemorph/src/transform/operators/simple.rs
+++ b/crates/rulemorph/src/transform/operators/simple.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::transform) fn eval_concat(
+    expr_op: &ExprOp,
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(&expr_op.args, injected);
+    let mut parts = Vec::new();
+    for index in 0..total_len {
+        let arg_path = format!("{}.args[{}]", base_path, index);
+        let value = eval_expr_at_index(
+            index,
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        )?;
+        match value {
+            EvalValue::Missing => return Ok(EvalValue::Missing),
+            EvalValue::Value(value) => {
+                if value.is_null() {
+                    return Err(TransformError::new(
+                        TransformErrorKind::ExprError,
+                        "concat does not accept null",
+                    )
+                    .with_path(arg_path));
+                }
+                let part = value_to_string(&value, &arg_path)?;
+                parts.push(part);
+            }
+        }
+    }
+    Ok(EvalValue::Value(JsonValue::String(parts.join(""))))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::transform) fn eval_coalesce(
+    expr_op: &ExprOp,
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(&expr_op.args, injected);
+    for index in 0..total_len {
+        let value = eval_expr_at_index(
+            index,
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        )?;
+        match value {
+            EvalValue::Missing => continue,
+            EvalValue::Value(value) => {
+                if value.is_null() {
+                    continue;
+                }
+                return Ok(EvalValue::Value(value));
+            }
+        }
+    }
+    Ok(EvalValue::Missing)
+}


### PR DESCRIPTION
## Summary
- move v1 concat/coalesce operator implementations from transform/operators.rs into transform/operators/simple.rs
- keep dispatcher operator names and behavior unchanged
- leave transform semantics and trace JSON schema unchanged

## Verification
- cargo fmt
- cargo fmt --check
- cargo test -p rulemorph --test transform_trace_semantics trace_v1_missing_short_circuit_does_not_evaluate_later_invalid_arg
- cargo test -p rulemorph --test transform_trace_semantics trace_v1_coalesce_does_not_evaluate_short_circuited_arg
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives
- cargo test -p rulemorph --test transform_trace trace_v1_expression_operator_lifecycle
- cargo test -p rulemorph --test transform_golden t04_json_root_coalesce_default
- cargo test -p rulemorph --test transform_golden t13_expr_extended
- cargo test -p rulemorph --test transform_golden
- cargo test -p rulemorph --test transform_trace_semantics
- git diff --check
- git diff --cached --check

## Notes
- no public API names or exports changed
- no trace JSON schema changes
- docs/plans/codebase-refactor-execution-log.md was updated locally only and remains ignored