### PR TITLE
Refactor trace store facade

### DIFF
--- a/crates/rulemorph_trace/src/trace_store.rs
+++ b/crates/rulemorph_trace/src/trace_store.rs
@@ -23,6 +23,7 @@ mod manifest_budget;
 mod manifest_trace;
 mod meta;
 mod purge;
+mod store;
 #[cfg(test)]
 mod tests;
 mod trace_id_path;
@@ -48,6 +49,7 @@ use self::meta::{is_manifest, read_trace_json_with_limit_async};
 use self::purge::purge_trace_metas;
 #[cfg(test)]
 use self::purge::resolve_trace_timestamp;
+pub use self::store::TraceStore;
 #[cfg(test)]
 use self::trace_id_path::{fallback_trace_id_for_path, path_hash_for_trace_id};
 
@@ -356,71 +358,6 @@ impl TraceBackend for FileTraceBackend {
 
     fn data_root(&self) -> &Path {
         &self.data_dir
-    }
-}
-
-#[derive(Clone)]
-pub struct TraceStore {
-    backend: Arc<dyn TraceBackend>,
-}
-
-impl TraceStore {
-    pub async fn new(data_dir: PathBuf) -> Result<Self> {
-        let backend = FileTraceBackend::new(data_dir).await?;
-        Ok(Self::with_backend(Arc::new(backend)))
-    }
-
-    pub fn with_backend(backend: Arc<dyn TraceBackend>) -> Self {
-        Self { backend }
-    }
-
-    pub async fn list(&self) -> Result<Vec<TraceMeta>> {
-        self.backend.list().await
-    }
-
-    pub async fn get(&self, trace_id: &str) -> Result<Option<Value>> {
-        self.backend.get(trace_id).await
-    }
-
-    pub async fn get_manifest(&self, trace_id: &str) -> Result<Option<TraceManifest>> {
-        self.backend.get_manifest(trace_id).await
-    }
-
-    pub async fn get_records_chunk(
-        &self,
-        trace_id: &str,
-        chunk_index: usize,
-    ) -> Result<Option<Vec<Value>>> {
-        self.backend.get_records_chunk(trace_id, chunk_index).await
-    }
-
-    pub async fn get_nodes_chunk(
-        &self,
-        trace_id: &str,
-        chunk_index: usize,
-    ) -> Result<Option<Vec<TraceNodeChunkEntry>>> {
-        self.backend.get_nodes_chunk(trace_id, chunk_index).await
-    }
-
-    pub async fn get_finalize_chunk(&self, trace_id: &str) -> Result<Option<Value>> {
-        self.backend.get_finalize_chunk(trace_id).await
-    }
-
-    pub async fn import_bundle(&self, bundle_path: &Path) -> Result<ImportResult> {
-        self.backend.import_bundle(bundle_path).await
-    }
-
-    pub async fn purge_traces(&self, retention: Duration, dry_run: bool) -> Result<PurgeReport> {
-        self.backend.purge_traces(retention, dry_run).await
-    }
-
-    pub async fn seed_sample(&self) -> Result<()> {
-        let _ = self.list().await?;
-        Ok(())
-    }
-
-    pub fn data_dir(&self) -> &Path {
-        self.backend.data_root()
     }
 }
 

--- a/crates/rulemorph_trace/src/trace_store/store.rs
+++ b/crates/rulemorph_trace/src/trace_store/store.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+#[derive(Clone)]
+pub struct TraceStore {
+    backend: Arc<dyn TraceBackend>,
+}
+
+impl TraceStore {
+    pub async fn new(data_dir: PathBuf) -> Result<Self> {
+        let backend = FileTraceBackend::new(data_dir).await?;
+        Ok(Self::with_backend(Arc::new(backend)))
+    }
+
+    pub fn with_backend(backend: Arc<dyn TraceBackend>) -> Self {
+        Self { backend }
+    }
+
+    pub async fn list(&self) -> Result<Vec<TraceMeta>> {
+        self.backend.list().await
+    }
+
+    pub async fn get(&self, trace_id: &str) -> Result<Option<Value>> {
+        self.backend.get(trace_id).await
+    }
+
+    pub async fn get_manifest(&self, trace_id: &str) -> Result<Option<TraceManifest>> {
+        self.backend.get_manifest(trace_id).await
+    }
+
+    pub async fn get_records_chunk(
+        &self,
+        trace_id: &str,
+        chunk_index: usize,
+    ) -> Result<Option<Vec<Value>>> {
+        self.backend.get_records_chunk(trace_id, chunk_index).await
+    }
+
+    pub async fn get_nodes_chunk(
+        &self,
+        trace_id: &str,
+        chunk_index: usize,
+    ) -> Result<Option<Vec<TraceNodeChunkEntry>>> {
+        self.backend.get_nodes_chunk(trace_id, chunk_index).await
+    }
+
+    pub async fn get_finalize_chunk(&self, trace_id: &str) -> Result<Option<Value>> {
+        self.backend.get_finalize_chunk(trace_id).await
+    }
+
+    pub async fn import_bundle(&self, bundle_path: &Path) -> Result<ImportResult> {
+        self.backend.import_bundle(bundle_path).await
+    }
+
+    pub async fn purge_traces(&self, retention: Duration, dry_run: bool) -> Result<PurgeReport> {
+        self.backend.purge_traces(retention, dry_run).await
+    }
+
+    pub async fn seed_sample(&self) -> Result<()> {
+        let _ = self.list().await?;
+        Ok(())
+    }
+
+    pub fn data_dir(&self) -> &Path {
+        self.backend.data_root()
+    }
+}


### PR DESCRIPTION
## Summary
- move the public TraceStore facade from trace_store.rs into trace_store/store.rs
- keep rulemorph_trace::trace_store::TraceStore available via re-export
- leave FileTraceBackend, import/chunk/purge behavior, and trace JSON schema unchanged

## Verification
- cargo fmt
- cargo fmt --check
- cargo test -p rulemorph_trace --lib trace_store
- cargo test -p rulemorph_trace --test trace_store
- cargo test -p rulemorph_trace
- git diff --check
- git diff --cached --check

## Notes
- no public API import path changes
- no trace JSON schema changes
- docs/plans/codebase-refactor-execution-log.md was updated locally only and remains ignored