### PR TITLE
Refactor v2 eval value helpers

### DIFF
--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -19,6 +19,7 @@ mod reference;
 #[cfg(test)]
 mod tests;
 mod v1_bridge;
+mod value;
 
 use cast::eval_type_cast;
 use collection::eval_collection_op;
@@ -31,6 +32,10 @@ pub use control::{
 use lookup::eval_lookup_op;
 pub use reference::{eval_v2_ref, eval_v2_start};
 use v1_bridge::eval_v2_op_with_v1_fallback;
+use value::{
+    eval_v2_expr_or_null, eval_value_as_number, eval_value_as_string, value_as_bool,
+    value_to_string,
+};
 
 // =============================================================================
 // v2 Reference Evaluation (T13)
@@ -43,115 +48,6 @@ use v1_bridge::eval_v2_op_with_v1_fallback;
 // =============================================================================
 // v2 Op Step Evaluation (T15)
 // =============================================================================
-
-/// Helper to convert EvalValue to string
-fn eval_value_as_string(value: &EvalValue, path: &str) -> Result<String, TransformError> {
-    match value {
-        EvalValue::Missing => Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expected string, got missing value",
-        )
-        .with_path(path)),
-        EvalValue::Value(v) => match v {
-            JsonValue::String(s) => Ok(s.clone()),
-            JsonValue::Number(n) => Ok(n.to_string()),
-            JsonValue::Bool(b) => Ok(b.to_string()),
-            _ => Err(TransformError::new(
-                TransformErrorKind::ExprError,
-                format!("expected string, got {:?}", v),
-            )
-            .with_path(path)),
-        },
-    }
-}
-
-/// Helper to convert EvalValue to number
-fn eval_value_as_number(value: &EvalValue, path: &str) -> Result<f64, TransformError> {
-    match value {
-        EvalValue::Missing => Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expected number, got missing value",
-        )
-        .with_path(path)),
-        EvalValue::Value(v) => match v {
-            JsonValue::Number(n) => n.as_f64().ok_or_else(|| {
-                TransformError::new(TransformErrorKind::ExprError, "number conversion failed")
-                    .with_path(path)
-            }),
-            JsonValue::String(s) => s.parse::<f64>().map_err(|_| {
-                TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "failed to parse string as number",
-                )
-                .with_path(path)
-            }),
-            _ => Err(TransformError::new(
-                TransformErrorKind::ExprError,
-                format!("expected number, got {:?}", v),
-            )
-            .with_path(path)),
-        },
-    }
-}
-
-fn value_as_bool(value: &JsonValue, path: &str) -> Result<bool, TransformError> {
-    match value {
-        JsonValue::Bool(flag) => Ok(*flag),
-        _ => Err(
-            TransformError::new(TransformErrorKind::ExprError, "value must be a boolean")
-                .with_path(path),
-        ),
-    }
-}
-
-fn eval_v2_expr_or_null<'a>(
-    expr: &V2Expr,
-    record: &'a JsonValue,
-    context: Option<&'a JsonValue>,
-    out: &'a JsonValue,
-    path: &str,
-    ctx: &V2EvalContext<'a>,
-) -> Result<JsonValue, TransformError> {
-    match eval_v2_expr(expr, record, context, out, path, ctx)? {
-        EvalValue::Missing => Ok(JsonValue::Null),
-        EvalValue::Value(value) => Ok(value),
-    }
-}
-
-fn number_to_string(number: &serde_json::Number) -> String {
-    if let Some(i) = number.as_i64() {
-        return i.to_string();
-    }
-    if let Some(u) = number.as_u64() {
-        return u.to_string();
-    }
-    if let Some(f) = number.as_f64() {
-        let mut s = format!("{}", f);
-        if s.contains('.') {
-            while s.ends_with('0') {
-                s.pop();
-            }
-            if s.ends_with('.') {
-                s.pop();
-            }
-        }
-        return s;
-    }
-    number.to_string()
-}
-
-fn value_to_string(value: &JsonValue, path: &str) -> Result<String, TransformError> {
-    match value {
-        JsonValue::String(s) => Ok(s.clone()),
-        JsonValue::Number(n) => Ok(number_to_string(n)),
-        JsonValue::Bool(b) => Ok(b.to_string()),
-        _ => Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "value must be string/number/bool",
-        )
-        .with_path(path)),
-    }
-}
 
 /// Evaluate a v2 op step with a pipe value as implicit first argument
 pub fn eval_v2_op_step<'a>(

--- a/crates/rulemorph/src/v2_eval/value.rs
+++ b/crates/rulemorph/src/v2_eval/value.rs
@@ -1,0 +1,126 @@
+use serde_json::Value as JsonValue;
+
+use super::{EvalValue, V2EvalContext, eval_v2_expr};
+use crate::error::{TransformError, TransformErrorKind};
+use crate::v2_model::V2Expr;
+
+/// Helper to convert EvalValue to string
+pub(in crate::v2_eval) fn eval_value_as_string(
+    value: &EvalValue,
+    path: &str,
+) -> Result<String, TransformError> {
+    match value {
+        EvalValue::Missing => Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expected string, got missing value",
+        )
+        .with_path(path)),
+        EvalValue::Value(v) => match v {
+            JsonValue::String(s) => Ok(s.clone()),
+            JsonValue::Number(n) => Ok(n.to_string()),
+            JsonValue::Bool(b) => Ok(b.to_string()),
+            _ => Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                format!("expected string, got {:?}", v),
+            )
+            .with_path(path)),
+        },
+    }
+}
+
+/// Helper to convert EvalValue to number
+pub(in crate::v2_eval) fn eval_value_as_number(
+    value: &EvalValue,
+    path: &str,
+) -> Result<f64, TransformError> {
+    match value {
+        EvalValue::Missing => Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expected number, got missing value",
+        )
+        .with_path(path)),
+        EvalValue::Value(v) => match v {
+            JsonValue::Number(n) => n.as_f64().ok_or_else(|| {
+                TransformError::new(TransformErrorKind::ExprError, "number conversion failed")
+                    .with_path(path)
+            }),
+            JsonValue::String(s) => s.parse::<f64>().map_err(|_| {
+                TransformError::new(
+                    TransformErrorKind::ExprError,
+                    "failed to parse string as number",
+                )
+                .with_path(path)
+            }),
+            _ => Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                format!("expected number, got {:?}", v),
+            )
+            .with_path(path)),
+        },
+    }
+}
+
+pub(in crate::v2_eval) fn value_as_bool(
+    value: &JsonValue,
+    path: &str,
+) -> Result<bool, TransformError> {
+    match value {
+        JsonValue::Bool(flag) => Ok(*flag),
+        _ => Err(
+            TransformError::new(TransformErrorKind::ExprError, "value must be a boolean")
+                .with_path(path),
+        ),
+    }
+}
+
+pub(in crate::v2_eval) fn eval_v2_expr_or_null<'a>(
+    expr: &V2Expr,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<JsonValue, TransformError> {
+    match eval_v2_expr(expr, record, context, out, path, ctx)? {
+        EvalValue::Missing => Ok(JsonValue::Null),
+        EvalValue::Value(value) => Ok(value),
+    }
+}
+
+fn number_to_string(number: &serde_json::Number) -> String {
+    if let Some(i) = number.as_i64() {
+        return i.to_string();
+    }
+    if let Some(u) = number.as_u64() {
+        return u.to_string();
+    }
+    if let Some(f) = number.as_f64() {
+        let mut s = format!("{}", f);
+        if s.contains('.') {
+            while s.ends_with('0') {
+                s.pop();
+            }
+            if s.ends_with('.') {
+                s.pop();
+            }
+        }
+        return s;
+    }
+    number.to_string()
+}
+
+pub(in crate::v2_eval) fn value_to_string(
+    value: &JsonValue,
+    path: &str,
+) -> Result<String, TransformError> {
+    match value {
+        JsonValue::String(s) => Ok(s.clone()),
+        JsonValue::Number(n) => Ok(number_to_string(n)),
+        JsonValue::Bool(b) => Ok(b.to_string()),
+        _ => Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "value must be string/number/bool",
+        )
+        .with_path(path)),
+    }
+}


### PR DESCRIPTION
## Summary
- Move v2 eval value conversion helpers into an internal value module.
- Keep v2 op dispatch, transform semantics, and trace schema unchanged.
- Keep public API names and exports unchanged.

## Verification
- cargo test -p rulemorph --lib v2_eval
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives
- cargo test -p rulemorph --test transform_trace_semantics
- cargo fmt
- cargo fmt --check
- git diff --check
- git diff --cached --check