### PR TITLE
Refactor CLI core commands

### DIFF
--- a/crates/rulemorph_cli/src/core_commands.rs
+++ b/crates/rulemorph_cli/src/core_commands.rs
@@ -1,0 +1,283 @@
+use std::io::Write;
+use std::path::PathBuf;
+
+use clap::Args;
+use rulemorph::{
+    InputData, NormalizationOptions, RuleFile,
+    preflight_validate_input_with_warnings_with_base_dir_and_options,
+    transform_input_with_warnings_with_base_dir_and_options,
+    transform_stream_input_with_base_dir_and_options, validate_rule_file_with_source,
+};
+
+use super::emit::{emit_transform_error, emit_transform_warnings, emit_validation_errors};
+use super::input::{
+    apply_format_override, load_context, load_input_bytes_with_limit, load_normalization_options,
+    load_rule, rule_base_dir,
+};
+use super::output::{
+    create_output_writer, emit_text_output, serialize_json_output, write_json_line,
+};
+use super::{ErrorFormat, FormatOverride, LimitsProfileArg, RulesFormatArg};
+
+#[derive(Args)]
+pub(super) struct ValidateArgs {
+    #[arg(short = 'r', long)]
+    rules: PathBuf,
+    #[arg(long)]
+    rules_format: Option<RulesFormatArg>,
+    #[arg(short = 'e', long, default_value = "text")]
+    error_format: ErrorFormat,
+}
+
+#[derive(Args)]
+pub(super) struct PreflightArgs {
+    #[arg(short = 'r', long)]
+    rules: PathBuf,
+    #[arg(long)]
+    rules_format: Option<RulesFormatArg>,
+    #[arg(short = 'i', long)]
+    input: PathBuf,
+    #[arg(short = 'f', long)]
+    format: Option<FormatOverride>,
+    #[arg(short = 'c', long)]
+    context: Option<PathBuf>,
+    #[arg(short = 'e', long, default_value = "text")]
+    error_format: ErrorFormat,
+    #[arg(long = "limit")]
+    limits: Vec<String>,
+    #[arg(long, value_enum)]
+    limits_profile: Option<LimitsProfileArg>,
+    #[arg(long)]
+    limits_file: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub(super) struct TransformArgs {
+    #[arg(short = 'r', long)]
+    rules: PathBuf,
+    #[arg(long)]
+    rules_format: Option<RulesFormatArg>,
+    #[arg(short = 'i', long)]
+    input: PathBuf,
+    #[arg(short = 'f', long)]
+    format: Option<FormatOverride>,
+    #[arg(short = 'c', long)]
+    context: Option<PathBuf>,
+    #[arg(short = 'o', long)]
+    output: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Emit one JSON object per line. This streams output, but input normalization is bounded by the configured limits."
+    )]
+    ndjson: bool,
+    #[arg(short = 'v', long)]
+    validate: bool,
+    #[arg(short = 'e', long, default_value = "text")]
+    error_format: ErrorFormat,
+    #[arg(long = "limit")]
+    limits: Vec<String>,
+    #[arg(long, value_enum)]
+    limits_profile: Option<LimitsProfileArg>,
+    #[arg(long)]
+    limits_file: Option<PathBuf>,
+}
+
+pub(super) fn run_validate(args: ValidateArgs) -> i32 {
+    let (rule, yaml) = match load_rule(&args.rules, args.rules_format) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    match validate_rule_file_with_source(&rule, &yaml) {
+        Ok(()) => 0,
+        Err(errors) => {
+            emit_validation_errors(&errors, args.error_format);
+            2
+        }
+    }
+}
+
+pub(super) fn run_preflight(args: PreflightArgs) -> i32 {
+    let (mut rule, _) = match load_rule(&args.rules, args.rules_format) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    apply_format_override(&mut rule, args.format);
+
+    let options = match load_normalization_options(
+        args.limits_profile,
+        args.limits_file.as_ref(),
+        &args.limits,
+    ) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{}", message);
+            return 2;
+        }
+    };
+
+    let input = match load_input_bytes_with_limit(&args.input, options.max_input_bytes) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    let context_value = match load_context(&args.context) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    let base_dir = rule_base_dir(&args.rules);
+    let warnings = match preflight_validate_input_with_warnings_with_base_dir_and_options(
+        &rule,
+        InputData::Bytes(&input),
+        context_value.as_ref(),
+        &base_dir,
+        &options,
+    ) {
+        Ok(warnings) => warnings,
+        Err(err) => {
+            emit_transform_error(&err, args.error_format);
+            return 3;
+        }
+    };
+
+    emit_transform_warnings(&warnings, args.error_format);
+
+    0
+}
+
+pub(super) fn run_transform(args: TransformArgs) -> i32 {
+    let (mut rule, yaml) = match load_rule(&args.rules, args.rules_format) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    apply_format_override(&mut rule, args.format);
+
+    if args.validate {
+        if let Err(errors) = validate_rule_file_with_source(&rule, &yaml) {
+            emit_validation_errors(&errors, args.error_format);
+            return 2;
+        }
+    }
+
+    let options = match load_normalization_options(
+        args.limits_profile,
+        args.limits_file.as_ref(),
+        &args.limits,
+    ) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{}", message);
+            return 2;
+        }
+    };
+
+    let input = match load_input_bytes_with_limit(&args.input, options.max_input_bytes) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    let context_value = match load_context(&args.context) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    if args.ndjson {
+        return run_transform_ndjson(
+            &rule,
+            &input,
+            context_value.as_ref(),
+            args.output,
+            args.error_format,
+            &args.rules,
+            &options,
+        );
+    }
+
+    let base_dir = rule_base_dir(&args.rules);
+    let (output, warnings) = match transform_input_with_warnings_with_base_dir_and_options(
+        &rule,
+        InputData::Bytes(&input),
+        context_value.as_ref(),
+        &base_dir,
+        &options,
+    ) {
+        Ok(result) => result,
+        Err(err) => {
+            emit_transform_error(&err, args.error_format);
+            return 3;
+        }
+    };
+
+    let output_text = match serialize_json_output(&output) {
+        Ok(text) => text,
+        Err(()) => return 1,
+    };
+
+    emit_transform_warnings(&warnings, args.error_format);
+
+    if emit_text_output(&output_text, args.output.as_ref()).is_err() {
+        return 1;
+    }
+
+    0
+}
+
+fn run_transform_ndjson(
+    rule: &RuleFile,
+    input: &[u8],
+    context: Option<&serde_json::Value>,
+    output: Option<PathBuf>,
+    error_format: ErrorFormat,
+    rules_path: &PathBuf,
+    options: &NormalizationOptions,
+) -> i32 {
+    let base_dir = rule_base_dir(rules_path);
+    let stream = match transform_stream_input_with_base_dir_and_options(
+        rule,
+        InputData::Bytes(input),
+        context,
+        &base_dir,
+        options,
+    ) {
+        Ok(stream) => stream,
+        Err(err) => {
+            emit_transform_error(&err, error_format);
+            return 3;
+        }
+    };
+
+    let mut writer = match create_output_writer(output.as_ref()) {
+        Ok(writer) => writer,
+        Err(()) => return 1,
+    };
+
+    for item in stream {
+        let item = match item {
+            Ok(item) => item,
+            Err(err) => {
+                emit_transform_error(&err, error_format);
+                return 3;
+            }
+        };
+
+        emit_transform_warnings(&item.warnings, error_format);
+
+        let output = match item.output {
+            Some(output) => output,
+            None => continue,
+        };
+        if write_json_line(&mut writer, &output).is_err() {
+            return 1;
+        }
+    }
+
+    if let Err(err) = writer.flush() {
+        eprintln!("failed to write output: {}", err);
+        return 1;
+    }
+
+    0
+}

--- a/crates/rulemorph_cli/src/main.rs
+++ b/crates/rulemorph_cli/src/main.rs
@@ -1,31 +1,14 @@
-use std::io::Write;
-use std::path::PathBuf;
-
-use clap::{Args, Parser, Subcommand, ValueEnum};
-use rulemorph::{
-    InputData, NormalizationOptions, RuleFile,
-    preflight_validate_input_with_warnings_with_base_dir_and_options,
-    transform_input_with_warnings_with_base_dir_and_options,
-    transform_stream_input_with_base_dir_and_options, validate_rule_file_with_source,
-};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[cfg(feature = "server")]
 mod api_keys;
+mod core_commands;
 mod emit;
 mod generate;
 mod input;
 mod output;
 #[cfg(feature = "server")]
 mod server_commands;
-
-use self::emit::{emit_transform_error, emit_transform_warnings, emit_validation_errors};
-use self::input::{
-    apply_format_override, load_context, load_input_bytes_with_limit, load_normalization_options,
-    load_rule, rule_base_dir,
-};
-use self::output::{
-    create_output_writer, emit_text_output, serialize_json_output, write_json_line,
-};
 
 #[derive(Parser)]
 #[command(name = "rulemorph")]
@@ -37,11 +20,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    Validate(ValidateArgs),
+    Validate(core_commands::ValidateArgs),
     #[cfg(feature = "server")]
     ValidateRulesDir(server_commands::ValidateRulesDirArgs),
-    Preflight(PreflightArgs),
-    Transform(TransformArgs),
+    Preflight(core_commands::PreflightArgs),
+    Transform(core_commands::TransformArgs),
     Generate(generate::GenerateArgs),
     #[cfg(feature = "server")]
     Ui(server_commands::UiArgs),
@@ -49,69 +32,6 @@ enum Commands {
     PurgeTraces(server_commands::PurgeTracesArgs),
     #[cfg(feature = "server")]
     ApiKeys(api_keys::ApiKeysArgs),
-}
-
-#[derive(Args)]
-struct ValidateArgs {
-    #[arg(short = 'r', long)]
-    rules: PathBuf,
-    #[arg(long)]
-    rules_format: Option<RulesFormatArg>,
-    #[arg(short = 'e', long, default_value = "text")]
-    error_format: ErrorFormat,
-}
-
-#[derive(Args)]
-struct PreflightArgs {
-    #[arg(short = 'r', long)]
-    rules: PathBuf,
-    #[arg(long)]
-    rules_format: Option<RulesFormatArg>,
-    #[arg(short = 'i', long)]
-    input: PathBuf,
-    #[arg(short = 'f', long)]
-    format: Option<FormatOverride>,
-    #[arg(short = 'c', long)]
-    context: Option<PathBuf>,
-    #[arg(short = 'e', long, default_value = "text")]
-    error_format: ErrorFormat,
-    #[arg(long = "limit")]
-    limits: Vec<String>,
-    #[arg(long, value_enum)]
-    limits_profile: Option<LimitsProfileArg>,
-    #[arg(long)]
-    limits_file: Option<PathBuf>,
-}
-
-#[derive(Args)]
-struct TransformArgs {
-    #[arg(short = 'r', long)]
-    rules: PathBuf,
-    #[arg(long)]
-    rules_format: Option<RulesFormatArg>,
-    #[arg(short = 'i', long)]
-    input: PathBuf,
-    #[arg(short = 'f', long)]
-    format: Option<FormatOverride>,
-    #[arg(short = 'c', long)]
-    context: Option<PathBuf>,
-    #[arg(short = 'o', long)]
-    output: Option<PathBuf>,
-    #[arg(
-        long,
-        help = "Emit one JSON object per line. This streams output, but input normalization is bounded by the configured limits."
-    )]
-    ndjson: bool,
-    #[arg(short = 'v', long)]
-    validate: bool,
-    #[arg(short = 'e', long, default_value = "text")]
-    error_format: ErrorFormat,
-    #[arg(long = "limit")]
-    limits: Vec<String>,
-    #[arg(long, value_enum)]
-    limits_profile: Option<LimitsProfileArg>,
-    #[arg(long)]
-    limits_file: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -141,11 +61,11 @@ enum LimitsProfileArg {
 fn main() {
     let cli = Cli::parse();
     let exit_code = match cli.command {
-        Commands::Validate(args) => run_validate(args),
+        Commands::Validate(args) => core_commands::run_validate(args),
         #[cfg(feature = "server")]
         Commands::ValidateRulesDir(args) => server_commands::run_validate_rules_dir(args),
-        Commands::Preflight(args) => run_preflight(args),
-        Commands::Transform(args) => run_transform(args),
+        Commands::Preflight(args) => core_commands::run_preflight(args),
+        Commands::Transform(args) => core_commands::run_transform(args),
         Commands::Generate(args) => generate::run(args),
         #[cfg(feature = "server")]
         Commands::Ui(args) => server_commands::run_ui(args),
@@ -155,204 +75,4 @@ fn main() {
         Commands::ApiKeys(args) => api_keys::run(args),
     };
     std::process::exit(exit_code);
-}
-
-fn run_validate(args: ValidateArgs) -> i32 {
-    let (rule, yaml) = match load_rule(&args.rules, args.rules_format) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    match validate_rule_file_with_source(&rule, &yaml) {
-        Ok(()) => 0,
-        Err(errors) => {
-            emit_validation_errors(&errors, args.error_format);
-            2
-        }
-    }
-}
-
-fn run_preflight(args: PreflightArgs) -> i32 {
-    let (mut rule, _) = match load_rule(&args.rules, args.rules_format) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    apply_format_override(&mut rule, args.format);
-
-    let options = match load_normalization_options(
-        args.limits_profile,
-        args.limits_file.as_ref(),
-        &args.limits,
-    ) {
-        Ok(options) => options,
-        Err(message) => {
-            eprintln!("{}", message);
-            return 2;
-        }
-    };
-
-    let input = match load_input_bytes_with_limit(&args.input, options.max_input_bytes) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    let context_value = match load_context(&args.context) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    let base_dir = rule_base_dir(&args.rules);
-    let warnings = match preflight_validate_input_with_warnings_with_base_dir_and_options(
-        &rule,
-        InputData::Bytes(&input),
-        context_value.as_ref(),
-        &base_dir,
-        &options,
-    ) {
-        Ok(warnings) => warnings,
-        Err(err) => {
-            emit_transform_error(&err, args.error_format);
-            return 3;
-        }
-    };
-
-    emit_transform_warnings(&warnings, args.error_format);
-
-    0
-}
-
-fn run_transform(args: TransformArgs) -> i32 {
-    let (mut rule, yaml) = match load_rule(&args.rules, args.rules_format) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    apply_format_override(&mut rule, args.format);
-
-    if args.validate {
-        if let Err(errors) = validate_rule_file_with_source(&rule, &yaml) {
-            emit_validation_errors(&errors, args.error_format);
-            return 2;
-        }
-    }
-
-    let options = match load_normalization_options(
-        args.limits_profile,
-        args.limits_file.as_ref(),
-        &args.limits,
-    ) {
-        Ok(options) => options,
-        Err(message) => {
-            eprintln!("{}", message);
-            return 2;
-        }
-    };
-
-    let input = match load_input_bytes_with_limit(&args.input, options.max_input_bytes) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    let context_value = match load_context(&args.context) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    if args.ndjson {
-        return run_transform_ndjson(
-            &rule,
-            &input,
-            context_value.as_ref(),
-            args.output,
-            args.error_format,
-            &args.rules,
-            &options,
-        );
-    }
-
-    let base_dir = rule_base_dir(&args.rules);
-    let (output, warnings) = match transform_input_with_warnings_with_base_dir_and_options(
-        &rule,
-        InputData::Bytes(&input),
-        context_value.as_ref(),
-        &base_dir,
-        &options,
-    ) {
-        Ok(result) => result,
-        Err(err) => {
-            emit_transform_error(&err, args.error_format);
-            return 3;
-        }
-    };
-
-    let output_text = match serialize_json_output(&output) {
-        Ok(text) => text,
-        Err(()) => return 1,
-    };
-
-    emit_transform_warnings(&warnings, args.error_format);
-
-    if emit_text_output(&output_text, args.output.as_ref()).is_err() {
-        return 1;
-    }
-
-    0
-}
-
-fn run_transform_ndjson(
-    rule: &RuleFile,
-    input: &[u8],
-    context: Option<&serde_json::Value>,
-    output: Option<PathBuf>,
-    error_format: ErrorFormat,
-    rules_path: &PathBuf,
-    options: &NormalizationOptions,
-) -> i32 {
-    let base_dir = rule_base_dir(rules_path);
-    let stream = match transform_stream_input_with_base_dir_and_options(
-        rule,
-        InputData::Bytes(input),
-        context,
-        &base_dir,
-        options,
-    ) {
-        Ok(stream) => stream,
-        Err(err) => {
-            emit_transform_error(&err, error_format);
-            return 3;
-        }
-    };
-
-    let mut writer = match create_output_writer(output.as_ref()) {
-        Ok(writer) => writer,
-        Err(()) => return 1,
-    };
-
-    for item in stream {
-        let item = match item {
-            Ok(item) => item,
-            Err(err) => {
-                emit_transform_error(&err, error_format);
-                return 3;
-            }
-        };
-
-        emit_transform_warnings(&item.warnings, error_format);
-
-        let output = match item.output {
-            Some(output) => output,
-            None => continue,
-        };
-        if write_json_line(&mut writer, &output).is_err() {
-            return 1;
-        }
-    }
-
-    if let Err(err) = writer.flush() {
-        eprintln!("failed to write output: {}", err);
-        return 1;
-    }
-
-    0
 }


### PR DESCRIPTION
## Summary
- Move validate/preflight/transform CLI args and run implementations from main.rs into core_commands.rs
- Keep main.rs focused on clap command dispatch and shared argument enums
- Leave CLI flags, stdout/stderr, exit codes, transform behavior, and JSON/NDJSON output unchanged

## Tests
- cargo fmt
- cargo test -p rulemorph_cli --test cli validate_success_returns_zero
- cargo test -p rulemorph_cli --test cli validate_json_errors
- cargo test -p rulemorph_cli --test cli preflight_success_returns_zero
- cargo test -p rulemorph_cli --test cli preflight_json_errors
- cargo test -p rulemorph_cli --test cli transform_outputs_json
- cargo test -p rulemorph_cli --test cli transform_outputs_ndjson
- cargo test -p rulemorph_cli --test cli transform_validate_flag_reports_validation_error
- cargo test -p rulemorph_cli --test cli
- cargo test -p rulemorph_cli
- cargo fmt --check
- git diff --check
- git diff --cached --check