### PR TITLE
Refactor server router module

### DIFF
--- a/crates/rulemorph_server/src/server.rs
+++ b/crates/rulemorph_server/src/server.rs
@@ -1,12 +1,5 @@
 use std::sync::Arc;
 
-use axum::{
-    Router,
-    extract::DefaultBodyLimit,
-    middleware::from_fn_with_state,
-    routing::{any, get, post},
-};
-
 use crate::TenantResolver;
 use rulemorph_endpoint::ApiMode;
 #[cfg(test)]
@@ -18,37 +11,24 @@ mod auth;
 mod error;
 mod import_zip;
 mod rate_limit;
+mod router;
 mod rules_api;
 mod tenant_registry;
 mod trace_routes;
 mod ui;
 
-use self::api_import::{
-    handle_api_import_only, handle_api_import_or_rules, handle_api_import_or_rules_strict,
-    import_bundle_path,
-};
-use self::api_key_routes::{issue_api_key, list_api_keys, revoke_api_key, rotate_api_key};
 #[cfg(test)]
 use self::auth::pre_auth_rate_limit_key;
-use self::auth::{
-    api_rate_limit, internal_auth, internal_auth_required, internal_tenant, pre_auth_rate_limit,
-    v1_auth,
-};
 use self::error::ApiError;
 #[cfg(test)]
 use self::import_zip::copy_zip_entry_bounded;
 #[cfg(test)]
 use self::import_zip::extract_zip;
 pub use self::rate_limit::RateLimiter;
-use self::rules_api::{handle_rules_api, inject_default_resources};
+pub use self::router::build_router;
 pub(crate) use self::tenant_registry::internal_auth_path_allowlist;
 pub use self::tenant_registry::{TenantRegistry, TenantResources};
-use self::trace_routes::{
-    get_api_graph, get_trace, get_trace_finalize, get_trace_manifest, get_trace_nodes_chunk,
-    get_trace_records_chunk, list_traces, stream_traces,
-};
 pub use self::ui::UiSource;
-use self::ui::apply_ui_source_fallback;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -65,115 +45,6 @@ pub struct AppState {
 const IMPORT_ZIP_MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 const IMPORT_ZIP_MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
 const IMPORT_ZIP_MAX_ENTRIES: usize = 4096;
-
-pub fn build_router(state: AppState, ui_enabled: bool) -> Router {
-    let api = match state.api_mode {
-        ApiMode::UiOnly => {
-            if ui_enabled {
-                Router::new()
-                    .route("/api/import", any(handle_api_import_only))
-                    .route_layer(DefaultBodyLimit::max(IMPORT_ZIP_MAX_TOTAL_BYTES as usize))
-            } else {
-                Router::new()
-            }
-        }
-        ApiMode::Rules => {
-            let mut api_router = Router::new().route("/api/*path", any(handle_rules_api));
-            let api_import = if ui_enabled {
-                Router::new()
-                    .route("/api/import", any(handle_api_import_or_rules))
-                    .route_layer(DefaultBodyLimit::max(IMPORT_ZIP_MAX_TOTAL_BYTES as usize))
-            } else {
-                Router::new()
-                    .route("/api/import", any(handle_api_import_or_rules_strict))
-                    .route_layer(DefaultBodyLimit::max(IMPORT_ZIP_MAX_TOTAL_BYTES as usize))
-            };
-            if state.rate_limiter.is_some() {
-                api_router = api_router.layer(from_fn_with_state(state.clone(), api_rate_limit));
-            }
-            if state.tenant_resolver.is_some() {
-                api_router = api_router.layer(from_fn_with_state(state.clone(), v1_auth));
-                if state.rate_limiter.is_some() {
-                    api_router =
-                        api_router.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
-                }
-            }
-            let api = Router::new().merge(api_import).merge(api_router);
-            if state.tenant_resolver.is_some() {
-                let mut v1 = Router::new().route("/v1/*path", any(handle_rules_api));
-                if state.rate_limiter.is_some() {
-                    v1 = v1.layer(from_fn_with_state(state.clone(), api_rate_limit));
-                }
-                v1 = v1.layer(from_fn_with_state(state.clone(), v1_auth));
-                if state.rate_limiter.is_some() {
-                    v1 = v1.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
-                }
-                api.merge(v1)
-            } else {
-                api
-            }
-        }
-    };
-
-    let mut app = Router::new().merge(api);
-
-    if ui_enabled {
-        let mut internal = Router::new()
-            .route("/internal/traces", get(list_traces))
-            .route("/internal/traces/:id", get(get_trace))
-            .route("/internal/traces/:id/manifest", get(get_trace_manifest))
-            .route(
-                "/internal/traces/:id/records/:chunk",
-                get(get_trace_records_chunk),
-            )
-            .route(
-                "/internal/traces/:id/nodes/:chunk",
-                get(get_trace_nodes_chunk),
-            )
-            .route("/internal/traces/:id/finalize", get(get_trace_finalize))
-            .route("/internal/stream", get(stream_traces))
-            .route("/internal/api-graph", get(get_api_graph))
-            .route("/internal/import", post(import_bundle_path));
-
-        let mut internal_admin = Router::new()
-            .route("/internal/api-keys", get(list_api_keys).post(issue_api_key))
-            .route("/internal/api-keys/:id/revoke", post(revoke_api_key))
-            .route("/internal/api-keys/:id/rotate", post(rotate_api_key));
-
-        if state.rate_limiter.is_some() {
-            internal = internal.layer(from_fn_with_state(state.clone(), api_rate_limit));
-            internal_admin =
-                internal_admin.layer(from_fn_with_state(state.clone(), api_rate_limit));
-        }
-        if state.tenant_resolver.is_some() {
-            internal = internal.layer(from_fn_with_state(state.clone(), internal_tenant));
-            internal_admin =
-                internal_admin.layer(from_fn_with_state(state.clone(), internal_tenant));
-        }
-        if !state.allow_unauth_internal
-            || state.internal_api_key.is_some()
-            || state.tenant_resolver.is_some()
-        {
-            internal = internal.layer(from_fn_with_state(state.clone(), internal_auth));
-        }
-        internal_admin =
-            internal_admin.layer(from_fn_with_state(state.clone(), internal_auth_required));
-        if state.rate_limiter.is_some() {
-            internal = internal.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
-            internal_admin =
-                internal_admin.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
-        }
-
-        app = app.merge(internal);
-        app = app.merge(internal_admin);
-        if let Some(ui_source) = state.ui_source.clone() {
-            app = apply_ui_source_fallback(app, ui_source);
-        }
-    }
-
-    app.layer(from_fn_with_state(state.clone(), inject_default_resources))
-        .with_state(state)
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rulemorph_server/src/server/router.rs
+++ b/crates/rulemorph_server/src/server/router.rs
@@ -1,0 +1,133 @@
+use axum::{
+    Router,
+    extract::DefaultBodyLimit,
+    middleware::from_fn_with_state,
+    routing::{any, get, post},
+};
+use rulemorph_endpoint::ApiMode;
+
+use super::api_import::{
+    handle_api_import_only, handle_api_import_or_rules, handle_api_import_or_rules_strict,
+    import_bundle_path,
+};
+use super::api_key_routes::{issue_api_key, list_api_keys, revoke_api_key, rotate_api_key};
+use super::auth::{
+    api_rate_limit, internal_auth, internal_auth_required, internal_tenant, pre_auth_rate_limit,
+    v1_auth,
+};
+use super::rules_api::{handle_rules_api, inject_default_resources};
+use super::trace_routes::{
+    get_api_graph, get_trace, get_trace_finalize, get_trace_manifest, get_trace_nodes_chunk,
+    get_trace_records_chunk, list_traces, stream_traces,
+};
+use super::ui::apply_ui_source_fallback;
+use super::{AppState, IMPORT_ZIP_MAX_TOTAL_BYTES};
+
+pub fn build_router(state: AppState, ui_enabled: bool) -> Router {
+    let api = match state.api_mode {
+        ApiMode::UiOnly => {
+            if ui_enabled {
+                Router::new()
+                    .route("/api/import", any(handle_api_import_only))
+                    .route_layer(DefaultBodyLimit::max(IMPORT_ZIP_MAX_TOTAL_BYTES as usize))
+            } else {
+                Router::new()
+            }
+        }
+        ApiMode::Rules => {
+            let mut api_router = Router::new().route("/api/*path", any(handle_rules_api));
+            let api_import = if ui_enabled {
+                Router::new()
+                    .route("/api/import", any(handle_api_import_or_rules))
+                    .route_layer(DefaultBodyLimit::max(IMPORT_ZIP_MAX_TOTAL_BYTES as usize))
+            } else {
+                Router::new()
+                    .route("/api/import", any(handle_api_import_or_rules_strict))
+                    .route_layer(DefaultBodyLimit::max(IMPORT_ZIP_MAX_TOTAL_BYTES as usize))
+            };
+            if state.rate_limiter.is_some() {
+                api_router = api_router.layer(from_fn_with_state(state.clone(), api_rate_limit));
+            }
+            if state.tenant_resolver.is_some() {
+                api_router = api_router.layer(from_fn_with_state(state.clone(), v1_auth));
+                if state.rate_limiter.is_some() {
+                    api_router =
+                        api_router.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
+                }
+            }
+            let api = Router::new().merge(api_import).merge(api_router);
+            if state.tenant_resolver.is_some() {
+                let mut v1 = Router::new().route("/v1/*path", any(handle_rules_api));
+                if state.rate_limiter.is_some() {
+                    v1 = v1.layer(from_fn_with_state(state.clone(), api_rate_limit));
+                }
+                v1 = v1.layer(from_fn_with_state(state.clone(), v1_auth));
+                if state.rate_limiter.is_some() {
+                    v1 = v1.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
+                }
+                api.merge(v1)
+            } else {
+                api
+            }
+        }
+    };
+
+    let mut app = Router::new().merge(api);
+
+    if ui_enabled {
+        let mut internal = Router::new()
+            .route("/internal/traces", get(list_traces))
+            .route("/internal/traces/:id", get(get_trace))
+            .route("/internal/traces/:id/manifest", get(get_trace_manifest))
+            .route(
+                "/internal/traces/:id/records/:chunk",
+                get(get_trace_records_chunk),
+            )
+            .route(
+                "/internal/traces/:id/nodes/:chunk",
+                get(get_trace_nodes_chunk),
+            )
+            .route("/internal/traces/:id/finalize", get(get_trace_finalize))
+            .route("/internal/stream", get(stream_traces))
+            .route("/internal/api-graph", get(get_api_graph))
+            .route("/internal/import", post(import_bundle_path));
+
+        let mut internal_admin = Router::new()
+            .route("/internal/api-keys", get(list_api_keys).post(issue_api_key))
+            .route("/internal/api-keys/:id/revoke", post(revoke_api_key))
+            .route("/internal/api-keys/:id/rotate", post(rotate_api_key));
+
+        if state.rate_limiter.is_some() {
+            internal = internal.layer(from_fn_with_state(state.clone(), api_rate_limit));
+            internal_admin =
+                internal_admin.layer(from_fn_with_state(state.clone(), api_rate_limit));
+        }
+        if state.tenant_resolver.is_some() {
+            internal = internal.layer(from_fn_with_state(state.clone(), internal_tenant));
+            internal_admin =
+                internal_admin.layer(from_fn_with_state(state.clone(), internal_tenant));
+        }
+        if !state.allow_unauth_internal
+            || state.internal_api_key.is_some()
+            || state.tenant_resolver.is_some()
+        {
+            internal = internal.layer(from_fn_with_state(state.clone(), internal_auth));
+        }
+        internal_admin =
+            internal_admin.layer(from_fn_with_state(state.clone(), internal_auth_required));
+        if state.rate_limiter.is_some() {
+            internal = internal.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
+            internal_admin =
+                internal_admin.layer(from_fn_with_state(state.clone(), pre_auth_rate_limit));
+        }
+
+        app = app.merge(internal);
+        app = app.merge(internal_admin);
+        if let Some(ui_source) = state.ui_source.clone() {
+            app = apply_ui_source_fallback(app, ui_source);
+        }
+    }
+
+    app.layer(from_fn_with_state(state.clone(), inject_default_resources))
+        .with_state(state)
+}


### PR DESCRIPTION
## Summary
- Move build_router route assembly into server/router.rs
- Keep AppState, handler modules, auth/rate-limit/import/rules/trace/API key behavior, and UI fallback implementation unchanged
- Preserve route surface, middleware ordering, auth ordering, tenant initialization timing, and response shape

## Tests
- cargo fmt
- cargo test -p rulemorph_server unauth_internal_is_not_allowed_with_tenant_resolver
- cargo test -p rulemorph_server --test cloud_scenarios api_import_dispatch_rate_limits_before_tenant_resolver
- cargo test -p rulemorph_server --test cloud_scenarios internal_unauthorized_request_does_not_initialize_tenant
- cargo test -p rulemorph_server --test cloud_scenarios v1_rate_limit_returns_429
- cargo test -p rulemorph_server --test cloud_scenarios
- cargo test -p rulemorph_server
- cargo fmt --check
- git diff --check
- git diff --cached --check