### PR TITLE
Refactor UI trace list helpers

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -22,6 +22,22 @@ import {
   getInternalKey
 } from "./auth";
 import { __resetTenantCachesForTest, getTenantId } from "./tenant";
+import {
+  TIME_RANGE_OPTIONS,
+  applyTraceFilters,
+  formatDuration,
+  formatDurationParts,
+  formatTime,
+  isErrorStatus,
+  resolveDurationUs,
+  resolveRuleLabel,
+  resolveTraceStatus,
+  resolveTraceDurationUs,
+  type DurationUnit,
+  type TimeRange,
+  type TraceListItem,
+  type TraceSummary
+} from "./trace_list_helpers";
 import { shouldResetInitialCenter } from "./view_mode";
 
 export { getApiKey, getInternalKey } from "./auth";
@@ -31,24 +47,6 @@ export function __resetAuthCachesForTest(): void {
   resetAuthCachesForTest();
   __resetTenantCachesForTest();
 }
-
-type TraceSummary = {
-  record_total?: number;
-  record_success?: number;
-  record_failed?: number;
-  duration_us?: number;
-  duration_ms?: number;
-};
-
-type TraceListItem = {
-  trace_id: string;
-  status?: string;
-  timestamp?: string;
-  duration_us?: number;
-  duration_ms?: number;
-  rule?: { name?: string; path?: string; type?: string; version?: number };
-  summary?: TraceSummary;
-};
 
 export type TraceNode = {
   id: string;
@@ -78,9 +76,6 @@ export type TraceRecord = {
   nodes?: TraceNode[];
   error?: { code?: string; message?: string; path?: string };
 };
-
-type DurationUnit = "us" | "ms";
-type TimeRange = "all" | "1h" | "24h" | "7d" | "30d";
 
 export type EndpointSpec = {
   method: string;
@@ -372,121 +367,6 @@ async function loadFinalize(traceId: string) {
     throw new Error("finalize chunk load failed");
   }
   return payload.finalize ?? null;
-}
-
-function formatTime(value?: string) {
-  if (!value) return "-";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString();
-}
-
-function formatDurationParts(valueUs: number | undefined, unit: DurationUnit) {
-  if (valueUs == null) return null;
-  if (unit === "ms") {
-    const valueMs = valueUs / 1000;
-    const formatted =
-      valueMs >= 100 ? valueMs.toFixed(0) : valueMs >= 10 ? valueMs.toFixed(1) : valueMs.toFixed(2);
-    return { value: formatted, unit: "ms" as const };
-  }
-  return { value: `${valueUs}`, unit: "μs" as const };
-}
-
-function formatDuration(valueUs: number | undefined, unit: DurationUnit) {
-  const parts = formatDurationParts(valueUs, unit);
-  return parts ? `${parts.value} ${parts.unit}` : "-";
-}
-
-function resolveDurationUs(durationUs?: number, durationMs?: number) {
-  if (typeof durationUs === "number") return durationUs;
-  if (typeof durationMs === "number") return durationMs * 1000;
-  return undefined;
-}
-
-function resolveTraceDurationUs(trace?: TracePayload) {
-  if (!trace) return undefined;
-  const fromSummary = resolveDurationUs(trace.summary?.duration_us, trace.summary?.duration_ms);
-  if (fromSummary !== undefined) return fromSummary;
-  const record = trace.records?.[0];
-  return resolveDurationUs(record?.duration_us, record?.duration_ms);
-}
-
-const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; ms: number | null }[] = [
-  { value: "all", label: "全期間", ms: null },
-  { value: "1h", label: "1時間", ms: 60 * 60 * 1000 },
-  { value: "24h", label: "24時間", ms: 24 * 60 * 60 * 1000 },
-  { value: "7d", label: "7日", ms: 7 * 24 * 60 * 60 * 1000 },
-  { value: "30d", label: "30日", ms: 30 * 24 * 60 * 60 * 1000 }
-];
-
-function resolveTraceStatus(item: TraceListItem) {
-  return (item.status ?? "ok").toLowerCase();
-}
-
-function resolveRuleLabel(item: TraceListItem) {
-  return item.rule?.path ?? item.rule?.name ?? null;
-}
-
-function matchesTraceQuery(item: TraceListItem, query: string) {
-  if (!query) return true;
-  const lowered = query.trim().toLowerCase();
-  if (!lowered) return true;
-  const haystack = [
-    item.trace_id,
-    item.rule?.name,
-    item.rule?.path,
-    item.status
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-  return haystack.includes(lowered);
-}
-
-function isWithinTimeRange(item: TraceListItem, range: TimeRange) {
-  if (range === "all") return true;
-  const threshold = TIME_RANGE_OPTIONS.find((opt) => opt.value === range)?.ms;
-  if (!threshold) return true;
-  if (!item.timestamp) return false;
-  const parsed = Date.parse(item.timestamp);
-  if (Number.isNaN(parsed)) return false;
-  const now = Date.now();
-  const diff = now - parsed;
-  if (diff < 0) return true;
-  return diff <= threshold;
-}
-
-function applyTraceFilters(
-  items: TraceListItem[],
-  filters: {
-    status: string;
-    rule: string;
-    query: string;
-    range: TimeRange;
-  }
-) {
-  return items.filter((item) => {
-    if (filters.status !== "all" && resolveTraceStatus(item) !== filters.status) {
-      return false;
-    }
-    if (filters.rule !== "all") {
-      const ruleLabel = resolveRuleLabel(item);
-      if (!ruleLabel || ruleLabel !== filters.rule) {
-        return false;
-      }
-    }
-    if (!matchesTraceQuery(item, filters.query)) {
-      return false;
-    }
-    if (!isWithinTimeRange(item, filters.range)) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function isErrorStatus(status?: string) {
-  return status?.toLowerCase() === "error";
 }
 
 function formatEdgeDurationMs(valueUs: number | undefined) {

--- a/crates/rulemorph_ui/ui/src/__tests__/trace_list_helpers.test.ts
+++ b/crates/rulemorph_ui/ui/src/__tests__/trace_list_helpers.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyTraceFilters,
+  formatDuration,
+  formatDurationParts,
+  isErrorStatus,
+  isWithinTimeRange,
+  matchesTraceQuery,
+  resolveDurationUs,
+  resolveRuleLabel,
+  resolveTraceDurationUs,
+  resolveTraceStatus,
+  type TraceListItem
+} from "../trace_list_helpers";
+
+const traces: TraceListItem[] = [
+  {
+    trace_id: "trace-a",
+    status: "ok",
+    timestamp: "2026-05-17T10:30:00.000Z",
+    rule: { name: "Alpha", path: "rules/alpha.json" },
+    summary: { duration_ms: 2 }
+  },
+  {
+    trace_id: "trace-b",
+    status: "ERROR",
+    timestamp: "2026-05-16T08:00:00.000Z",
+    rule: { name: "Beta", path: "rules/beta.json" },
+    duration_us: 500
+  },
+  {
+    trace_id: "trace-c",
+    timestamp: "not-a-date",
+    rule: { name: "Gamma" }
+  }
+];
+
+describe("trace list helpers", () => {
+  it("resolves display status and rule label defaults", () => {
+    expect(resolveTraceStatus(traces[1])).toBe("error");
+    expect(resolveTraceStatus(traces[2])).toBe("ok");
+    expect(resolveRuleLabel(traces[0])).toBe("rules/alpha.json");
+    expect(resolveRuleLabel(traces[2])).toBe("Gamma");
+  });
+
+  it("matches trace queries against id, rule, path, and status", () => {
+    expect(matchesTraceQuery(traces[0], "alpha")).toBe(true);
+    expect(matchesTraceQuery(traces[1], "rules/beta")).toBe(true);
+    expect(matchesTraceQuery(traces[1], "error")).toBe(true);
+    expect(matchesTraceQuery(traces[2], "trace-c")).toBe(true);
+    expect(matchesTraceQuery(traces[2], "missing")).toBe(false);
+  });
+
+  it("filters by status, rule, query, and time range", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-17T11:00:00.000Z"));
+
+    try {
+      expect(
+        applyTraceFilters(traces, {
+          status: "ok",
+          rule: "all",
+          query: "",
+          range: "all"
+        }).map((trace) => trace.trace_id)
+      ).toEqual(["trace-a", "trace-c"]);
+
+      expect(
+        applyTraceFilters(traces, {
+          status: "all",
+          rule: "rules/beta.json",
+          query: "beta",
+          range: "30d"
+        }).map((trace) => trace.trace_id)
+      ).toEqual(["trace-b"]);
+
+      expect(
+        applyTraceFilters(traces, {
+          status: "all",
+          rule: "all",
+          query: "",
+          range: "1h"
+        }).map((trace) => trace.trace_id)
+      ).toEqual(["trace-a"]);
+
+      expect(isWithinTimeRange(traces[0], "1h")).toBe(true);
+      expect(isWithinTimeRange(traces[1], "1h")).toBe(false);
+      expect(isWithinTimeRange(traces[2], "1h")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("formats and resolves durations without changing unit behavior", () => {
+    expect(resolveDurationUs(undefined, 2.5)).toBe(2500);
+    expect(resolveTraceDurationUs({ summary: { duration_ms: 2 } })).toBe(2000);
+    expect(resolveTraceDurationUs({ records: [{ duration_us: 7 }] })).toBe(7);
+    expect(formatDurationParts(1234, "us")).toEqual({ value: "1234", unit: "μs" });
+    expect(formatDurationParts(1234, "ms")).toEqual({ value: "1.23", unit: "ms" });
+    expect(formatDuration(undefined, "ms")).toBe("-");
+  });
+
+  it("detects error status case-insensitively", () => {
+    expect(isErrorStatus("ERROR")).toBe(true);
+    expect(isErrorStatus("error")).toBe(true);
+    expect(isErrorStatus("ok")).toBe(false);
+    expect(isErrorStatus()).toBe(false);
+  });
+});

--- a/crates/rulemorph_ui/ui/src/trace_list_helpers.ts
+++ b/crates/rulemorph_ui/ui/src/trace_list_helpers.ts
@@ -1,0 +1,145 @@
+export type TraceSummary = {
+  record_total?: number;
+  record_success?: number;
+  record_failed?: number;
+  duration_us?: number;
+  duration_ms?: number;
+};
+
+export type TraceListItem = {
+  trace_id: string;
+  status?: string;
+  timestamp?: string;
+  duration_us?: number;
+  duration_ms?: number;
+  rule?: { name?: string; path?: string; type?: string; version?: number };
+  summary?: TraceSummary;
+};
+
+export type DurationUnit = "us" | "ms";
+export type TimeRange = "all" | "1h" | "24h" | "7d" | "30d";
+
+type DurationSource = {
+  duration_us?: number;
+  duration_ms?: number;
+};
+
+type TraceDurationPayload = {
+  summary?: TraceSummary;
+  records?: DurationSource[];
+};
+
+export function formatTime(value?: string) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+export function formatDurationParts(valueUs: number | undefined, unit: DurationUnit) {
+  if (valueUs == null) return null;
+  if (unit === "ms") {
+    const valueMs = valueUs / 1000;
+    const formatted =
+      valueMs >= 100 ? valueMs.toFixed(0) : valueMs >= 10 ? valueMs.toFixed(1) : valueMs.toFixed(2);
+    return { value: formatted, unit: "ms" as const };
+  }
+  return { value: `${valueUs}`, unit: "μs" as const };
+}
+
+export function formatDuration(valueUs: number | undefined, unit: DurationUnit) {
+  const parts = formatDurationParts(valueUs, unit);
+  return parts ? `${parts.value} ${parts.unit}` : "-";
+}
+
+export function resolveDurationUs(durationUs?: number, durationMs?: number) {
+  if (typeof durationUs === "number") return durationUs;
+  if (typeof durationMs === "number") return durationMs * 1000;
+  return undefined;
+}
+
+export function resolveTraceDurationUs(trace?: TraceDurationPayload) {
+  if (!trace) return undefined;
+  const fromSummary = resolveDurationUs(trace.summary?.duration_us, trace.summary?.duration_ms);
+  if (fromSummary !== undefined) return fromSummary;
+  const record = trace.records?.[0];
+  return resolveDurationUs(record?.duration_us, record?.duration_ms);
+}
+
+export const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; ms: number | null }[] = [
+  { value: "all", label: "全期間", ms: null },
+  { value: "1h", label: "1時間", ms: 60 * 60 * 1000 },
+  { value: "24h", label: "24時間", ms: 24 * 60 * 60 * 1000 },
+  { value: "7d", label: "7日", ms: 7 * 24 * 60 * 60 * 1000 },
+  { value: "30d", label: "30日", ms: 30 * 24 * 60 * 60 * 1000 }
+];
+
+export function resolveTraceStatus(item: TraceListItem) {
+  return (item.status ?? "ok").toLowerCase();
+}
+
+export function resolveRuleLabel(item: TraceListItem) {
+  return item.rule?.path ?? item.rule?.name ?? null;
+}
+
+export function matchesTraceQuery(item: TraceListItem, query: string) {
+  if (!query) return true;
+  const lowered = query.trim().toLowerCase();
+  if (!lowered) return true;
+  const haystack = [
+    item.trace_id,
+    item.rule?.name,
+    item.rule?.path,
+    item.status
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(lowered);
+}
+
+export function isWithinTimeRange(item: TraceListItem, range: TimeRange) {
+  if (range === "all") return true;
+  const threshold = TIME_RANGE_OPTIONS.find((opt) => opt.value === range)?.ms;
+  if (!threshold) return true;
+  if (!item.timestamp) return false;
+  const parsed = Date.parse(item.timestamp);
+  if (Number.isNaN(parsed)) return false;
+  const now = Date.now();
+  const diff = now - parsed;
+  if (diff < 0) return true;
+  return diff <= threshold;
+}
+
+export function applyTraceFilters(
+  items: TraceListItem[],
+  filters: {
+    status: string;
+    rule: string;
+    query: string;
+    range: TimeRange;
+  }
+) {
+  return items.filter((item) => {
+    if (filters.status !== "all" && resolveTraceStatus(item) !== filters.status) {
+      return false;
+    }
+    if (filters.rule !== "all") {
+      const ruleLabel = resolveRuleLabel(item);
+      if (!ruleLabel || ruleLabel !== filters.rule) {
+        return false;
+      }
+    }
+    if (!matchesTraceQuery(item, filters.query)) {
+      return false;
+    }
+    if (!isWithinTimeRange(item, filters.range)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function isErrorStatus(status?: string) {
+  return status?.toLowerCase() === "error";
+}


### PR DESCRIPTION
## Summary
- Move trace list time, duration, status, rule, query, and range helpers out of App.tsx into trace_list_helpers.ts
- Add focused unit coverage for the extracted helper behavior
- Keep UI render tree, trace schema, API paths, auth, tenant handling, and graph logic unchanged

## Verification
- npm --prefix crates/rulemorph_ui/ui run test -- trace_list_helpers
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- Chrome browser smoke at http://127.0.0.1:5174/
- git diff --check
- git diff --cached --check