### PR TITLE
Refactor validator steps module

### DIFF
--- a/crates/rulemorph/src/validator.rs
+++ b/crates/rulemorph/src/validator.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use crate::error::{ErrorCode, RuleError, ValidationResult};
 use crate::locator::YamlLocator;
 use crate::model::RuleFile;
-use crate::path::{PathToken, parse_path};
-use crate::v2_validator::{V2Scope, V2ValidationCtx, validate_no_cyclic_dependencies};
+use crate::path::parse_path;
+use crate::v2_validator::{V2Scope, V2ValidationCtx};
 
 mod bool_expr;
 mod expr;
@@ -14,16 +14,14 @@ mod mapping;
 mod op_inventory;
 mod refs;
 mod scope;
+mod steps;
 mod v2_expr;
 
-use self::bool_expr::validate_when_expr;
-use self::expr::validate_expr;
 use self::input::validate_input;
-use self::mapping::{validate_mappings, validate_mappings_list, validate_record_when};
-use self::scope::LocalScope;
+use self::mapping::{validate_mappings, validate_record_when};
+use self::steps::validate_steps;
 use self::v2_expr::{
-    expr_to_json_value, validate_finalize_wrap_value, validate_v2_condition_expr,
-    validate_v2_condition_expr_with_scope,
+    expr_to_json_value, validate_finalize_wrap_value, validate_v2_condition_expr_with_scope,
 };
 
 pub fn validate_rule_file(rule: &RuleFile) -> ValidationResult {
@@ -49,169 +47,6 @@ fn validate_rule_file_with_locator(
     validate_finalize(rule, &mut ctx);
 
     ctx.finish()
-}
-
-fn validate_steps(rule: &RuleFile, ctx: &mut ValidationCtx<'_>) {
-    let steps = match rule.steps.as_ref() {
-        Some(steps) => steps,
-        None => {
-            if rule.mappings.is_empty() {
-                ctx.push(
-                    ErrorCode::MissingMappings,
-                    "mappings is required when steps is not set",
-                    "mappings",
-                );
-            }
-            return;
-        }
-    };
-
-    if rule.version != 2 {
-        ctx.push(
-            ErrorCode::InvalidStep,
-            "steps is only supported in version 2",
-            "steps",
-        );
-    }
-
-    if !rule.mappings.is_empty() || rule.record_when.is_some() {
-        ctx.push(
-            ErrorCode::StepsMappingExclusive,
-            "steps cannot be combined with mappings or record_when",
-            "steps",
-        );
-    }
-
-    let mut produced_targets: HashSet<Vec<PathToken>> = HashSet::new();
-    let mut v2_targets_with_deps: Vec<(String, HashSet<String>)> = Vec::new();
-
-    for (index, step) in steps.iter().enumerate() {
-        let base = format!("steps[{}]", index);
-        let step_kind_count = [
-            step.mappings.is_some(),
-            step.record_when.is_some(),
-            step.asserts.is_some(),
-            step.branch.is_some(),
-        ]
-        .into_iter()
-        .filter(|v| *v)
-        .count();
-
-        if step_kind_count != 1 {
-            ctx.push(
-                ErrorCode::InvalidStep,
-                "step must contain exactly one of mappings/record_when/asserts/branch",
-                &base,
-            );
-            continue;
-        }
-
-        if let Some(mappings) = &step.mappings {
-            validate_mappings_list(
-                mappings,
-                &format!("{}.mappings", base),
-                &mut produced_targets,
-                &mut v2_targets_with_deps,
-                ctx,
-                rule.version,
-            );
-        }
-
-        if let Some(expr) = &step.record_when {
-            let expr_path = format!("{}.record_when", base);
-            if rule.version == 2 {
-                if let Some(raw_value) = expr_to_json_value(expr) {
-                    validate_v2_condition_expr(&raw_value, &expr_path, &produced_targets, ctx);
-                    continue;
-                }
-            }
-            validate_expr(expr, &expr_path, &produced_targets, ctx, LocalScope::None);
-            validate_when_expr(expr, &expr_path, ctx);
-        }
-
-        if let Some(asserts) = &step.asserts {
-            for (assert_idx, assert) in asserts.iter().enumerate() {
-                let assert_path = format!("{}.asserts[{}]", base, assert_idx);
-                if assert.error.code.trim().is_empty() || assert.error.message.trim().is_empty() {
-                    ctx.push(
-                        ErrorCode::InvalidStep,
-                        "asserts.error.code and message are required",
-                        &format!("{}.error", assert_path),
-                    );
-                }
-
-                if rule.version == 2 {
-                    if let Some(raw_value) = expr_to_json_value(&assert.when) {
-                        validate_v2_condition_expr(
-                            &raw_value,
-                            &format!("{}.when", assert_path),
-                            &produced_targets,
-                            ctx,
-                        );
-                        continue;
-                    }
-                }
-                validate_expr(
-                    &assert.when,
-                    &format!("{}.when", assert_path),
-                    &produced_targets,
-                    ctx,
-                    LocalScope::None,
-                );
-                validate_when_expr(&assert.when, &format!("{}.when", assert_path), ctx);
-            }
-        }
-
-        if let Some(branch) = &step.branch {
-            let branch_path = format!("{}.branch", base);
-            let when_path = format!("{}.when", branch_path);
-            let mut v2_handled = false;
-            if rule.version == 2 {
-                if let Some(raw_value) = expr_to_json_value(&branch.when) {
-                    validate_v2_condition_expr(&raw_value, &when_path, &produced_targets, ctx);
-                    v2_handled = true;
-                }
-            }
-            if !v2_handled {
-                validate_expr(
-                    &branch.when,
-                    &when_path,
-                    &produced_targets,
-                    ctx,
-                    LocalScope::None,
-                );
-                validate_when_expr(&branch.when, &when_path, ctx);
-            }
-
-            if branch.then.trim().is_empty() {
-                ctx.push(
-                    ErrorCode::InvalidStep,
-                    "branch.then is required",
-                    &format!("{}.then", branch_path),
-                );
-            }
-            if let Some(r#else) = &branch.r#else {
-                if r#else.trim().is_empty() {
-                    ctx.push(
-                        ErrorCode::InvalidStep,
-                        "branch.else must not be empty",
-                        &format!("{}.else", branch_path),
-                    );
-                }
-            }
-            if !branch.return_ {
-                ctx.allow_any_out_ref = true;
-            }
-        }
-    }
-
-    if !v2_targets_with_deps.is_empty() {
-        let mut v2_ctx = V2ValidationCtx::new(ctx.locator);
-        validate_no_cyclic_dependencies(&v2_targets_with_deps, "steps", &mut v2_ctx);
-        for err in v2_ctx.errors() {
-            ctx.errors.push(err.clone());
-        }
-    }
 }
 
 fn validate_finalize(rule: &RuleFile, ctx: &mut ValidationCtx<'_>) {

--- a/crates/rulemorph/src/validator/steps.rs
+++ b/crates/rulemorph/src/validator/steps.rs
@@ -1,0 +1,176 @@
+use std::collections::HashSet;
+
+use crate::error::ErrorCode;
+use crate::model::RuleFile;
+use crate::path::PathToken;
+use crate::v2_validator::{V2ValidationCtx, validate_no_cyclic_dependencies};
+
+use super::ValidationCtx;
+use super::bool_expr::validate_when_expr;
+use super::expr::validate_expr;
+use super::mapping::validate_mappings_list;
+use super::scope::LocalScope;
+use super::v2_expr::{expr_to_json_value, validate_v2_condition_expr};
+
+pub(super) fn validate_steps(rule: &RuleFile, ctx: &mut ValidationCtx<'_>) {
+    let steps = match rule.steps.as_ref() {
+        Some(steps) => steps,
+        None => {
+            if rule.mappings.is_empty() {
+                ctx.push(
+                    ErrorCode::MissingMappings,
+                    "mappings is required when steps is not set",
+                    "mappings",
+                );
+            }
+            return;
+        }
+    };
+
+    if rule.version != 2 {
+        ctx.push(
+            ErrorCode::InvalidStep,
+            "steps is only supported in version 2",
+            "steps",
+        );
+    }
+
+    if !rule.mappings.is_empty() || rule.record_when.is_some() {
+        ctx.push(
+            ErrorCode::StepsMappingExclusive,
+            "steps cannot be combined with mappings or record_when",
+            "steps",
+        );
+    }
+
+    let mut produced_targets: HashSet<Vec<PathToken>> = HashSet::new();
+    let mut v2_targets_with_deps: Vec<(String, HashSet<String>)> = Vec::new();
+
+    for (index, step) in steps.iter().enumerate() {
+        let base = format!("steps[{}]", index);
+        let step_kind_count = [
+            step.mappings.is_some(),
+            step.record_when.is_some(),
+            step.asserts.is_some(),
+            step.branch.is_some(),
+        ]
+        .into_iter()
+        .filter(|v| *v)
+        .count();
+
+        if step_kind_count != 1 {
+            ctx.push(
+                ErrorCode::InvalidStep,
+                "step must contain exactly one of mappings/record_when/asserts/branch",
+                &base,
+            );
+            continue;
+        }
+
+        if let Some(mappings) = &step.mappings {
+            validate_mappings_list(
+                mappings,
+                &format!("{}.mappings", base),
+                &mut produced_targets,
+                &mut v2_targets_with_deps,
+                ctx,
+                rule.version,
+            );
+        }
+
+        if let Some(expr) = &step.record_when {
+            let expr_path = format!("{}.record_when", base);
+            if rule.version == 2 {
+                if let Some(raw_value) = expr_to_json_value(expr) {
+                    validate_v2_condition_expr(&raw_value, &expr_path, &produced_targets, ctx);
+                    continue;
+                }
+            }
+            validate_expr(expr, &expr_path, &produced_targets, ctx, LocalScope::None);
+            validate_when_expr(expr, &expr_path, ctx);
+        }
+
+        if let Some(asserts) = &step.asserts {
+            for (assert_idx, assert) in asserts.iter().enumerate() {
+                let assert_path = format!("{}.asserts[{}]", base, assert_idx);
+                if assert.error.code.trim().is_empty() || assert.error.message.trim().is_empty() {
+                    ctx.push(
+                        ErrorCode::InvalidStep,
+                        "asserts.error.code and message are required",
+                        &format!("{}.error", assert_path),
+                    );
+                }
+
+                if rule.version == 2 {
+                    if let Some(raw_value) = expr_to_json_value(&assert.when) {
+                        validate_v2_condition_expr(
+                            &raw_value,
+                            &format!("{}.when", assert_path),
+                            &produced_targets,
+                            ctx,
+                        );
+                        continue;
+                    }
+                }
+                validate_expr(
+                    &assert.when,
+                    &format!("{}.when", assert_path),
+                    &produced_targets,
+                    ctx,
+                    LocalScope::None,
+                );
+                validate_when_expr(&assert.when, &format!("{}.when", assert_path), ctx);
+            }
+        }
+
+        if let Some(branch) = &step.branch {
+            let branch_path = format!("{}.branch", base);
+            let when_path = format!("{}.when", branch_path);
+            let mut v2_handled = false;
+            if rule.version == 2 {
+                if let Some(raw_value) = expr_to_json_value(&branch.when) {
+                    validate_v2_condition_expr(&raw_value, &when_path, &produced_targets, ctx);
+                    v2_handled = true;
+                }
+            }
+            if !v2_handled {
+                validate_expr(
+                    &branch.when,
+                    &when_path,
+                    &produced_targets,
+                    ctx,
+                    LocalScope::None,
+                );
+                validate_when_expr(&branch.when, &when_path, ctx);
+            }
+
+            if branch.then.trim().is_empty() {
+                ctx.push(
+                    ErrorCode::InvalidStep,
+                    "branch.then is required",
+                    &format!("{}.then", branch_path),
+                );
+            }
+            if let Some(r#else) = &branch.r#else {
+                if r#else.trim().is_empty() {
+                    ctx.push(
+                        ErrorCode::InvalidStep,
+                        "branch.else must not be empty",
+                        &format!("{}.else", branch_path),
+                    );
+                }
+            }
+            if !branch.return_ {
+                ctx.allow_any_out_ref = true;
+            }
+        }
+    }
+
+    if !v2_targets_with_deps.is_empty() {
+        let mut v2_ctx = V2ValidationCtx::new(ctx.locator);
+        validate_no_cyclic_dependencies(&v2_targets_with_deps, "steps", &mut v2_ctx);
+        for err in v2_ctx.errors() {
+            ctx.errors.push(err.clone());
+        }
+    }
+}

--- a/crates/rulemorph/tests/validation.rs
+++ b/crates/rulemorph/tests/validation.rs
@@ -508,3 +508,84 @@ fn v2_forward_out_ref_should_fail_validation() {
         "error mismatch for tv26_v02_forward_out_ref"
     );
 }
+
+#[test]
+fn v2_steps_cyclic_out_refs_should_fail_validation() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+steps:
+  - mappings:
+      - target: a
+        expr:
+          - "@out.b"
+  - mappings:
+      - target: b
+        expr:
+          - "@out.a"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let errors = validate_rule_file(&rule).expect_err("cyclic steps should fail");
+
+    assert!(
+        errors
+            .iter()
+            .any(|err| err.code == ErrorCode::CyclicDependency),
+        "expected CyclicDependency, got {errors:?}"
+    );
+}
+
+#[test]
+fn v2_steps_are_exclusive_with_mappings_and_record_when() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+record_when:
+  eq: ["@input.enabled", true]
+mappings:
+  - target: existing
+    value: 1
+steps:
+  - mappings:
+      - target: name
+        source: input.name
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let errors = validate_rule_file(&rule).expect_err("steps exclusivity should fail");
+
+    assert!(
+        errors.iter().any(|err| {
+            err.code == ErrorCode::StepsMappingExclusive && err.path.as_deref() == Some("steps")
+        }),
+        "expected StepsMappingExclusive at steps, got {errors:?}"
+    );
+}
+
+#[test]
+fn v2_step_branch_then_error_includes_source_location() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+steps:
+  - branch:
+      when: { eq: ["@input.kind", "a"] }
+      then: ""
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let errors = validate_rule_file_with_source(&rule, yaml).expect_err("empty then should fail");
+    let error = errors
+        .iter()
+        .find(|err| {
+            err.code == ErrorCode::InvalidStep
+                && err.path.as_deref() == Some("steps[0].branch.then")
+        })
+        .expect("expected InvalidStep for branch.then");
+    let location = error.location.clone().expect("expected location");
+    assert_eq!(location.line, 9);
+}


### PR DESCRIPTION
## Summary
- Move v2 steps validation orchestration from validator.rs into validator/steps.rs
- Add characterization coverage for steps cyclic dependencies, steps exclusivity, and branch.then source locations
- Keep public validation APIs, error ordering/path/location behavior, transform semantics, trace schema, and CLI/MCP/HTTP contracts unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --lib validator
- cargo test -p rulemorph --test validation
- cargo test -p rulemorph --test transform_golden
- cargo test -p rulemorph --test transform_trace
- cargo test -p rulemorph --test transform_trace_semantics
- cargo fmt --check
- git diff --check
- git diff --cached --check