### PR TITLE
Refactor UI trace payload helpers

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -35,99 +35,31 @@ import {
   resolveTraceDurationUs,
   type DurationUnit,
   type TimeRange,
-  type TraceListItem,
-  type TraceSummary
+  type TraceListItem
 } from "./trace_list_helpers";
+import {
+  mergeNodesIntoRecords,
+  normalizeRecord,
+  normalizeTracePayload,
+  parseNumericIndex,
+  type EndpointRule,
+  type TraceDetailRef,
+  type TraceManifest,
+  type TraceNode,
+  type TraceNodeChunkEntry,
+  type TracePayload,
+  type TraceRecord
+} from "./trace_payload";
 import { shouldResetInitialCenter } from "./view_mode";
 
 export { getApiKey, getInternalKey } from "./auth";
 export { __getTenantIdFromQueryOrStorageForTest, resolveTenantId } from "./tenant";
+export type { EndpointRule, EndpointSpec, TraceNode, TracePayload, TraceRecord } from "./trace_payload";
 
 export function __resetAuthCachesForTest(): void {
   resetAuthCachesForTest();
   __resetTenantCachesForTest();
 }
-
-export type TraceNode = {
-  id: string;
-  kind: string;
-  label: string;
-  status?: string;
-  duration_us?: number;
-  duration_ms?: number;
-  input?: unknown;
-  output?: unknown;
-  pipe_value?: unknown;
-  args?: unknown[];
-  pipe_steps?: { index: number; label: string; input?: unknown; output?: unknown }[];
-  children?: TraceNode[];
-  child_trace?: TracePayload;
-  error?: { code?: string; message?: string; path?: string };
-  meta?: Record<string, unknown>;
-};
-
-export type TraceRecord = {
-  index: number;
-  status?: string;
-  duration_us?: number;
-  duration_ms?: number;
-  input?: unknown;
-  output?: unknown;
-  nodes?: TraceNode[];
-  error?: { code?: string; message?: string; path?: string };
-};
-
-export type EndpointSpec = {
-  method: string;
-  path: string;
-  steps: { rule: string }[];
-  reply?: { status?: number; body?: string };
-};
-
-export type EndpointRule = {
-  version: number;
-  type: "endpoint";
-  endpoints: EndpointSpec[];
-};
-
-type TraceChunkRef = {
-  path: string;
-  format: string;
-  compression: string;
-  record_start?: number;
-  record_end?: number;
-  node_start?: number;
-  node_end?: number;
-  bytes?: number;
-};
-
-type TraceDetailRef = {
-  layout: string;
-  status: string;
-  reason?: string[];
-  records?: TraceChunkRef[];
-  nodes?: TraceChunkRef[];
-  finalize?: TraceChunkRef;
-};
-
-type TraceManifest = {
-  trace_schema_version: number;
-  trace_id: string;
-  timestamp?: string;
-  status?: string;
-  rule?: { name?: string; path?: string; type?: string; version?: number };
-  input_format?: string;
-  summary?: TraceSummary;
-  max_chunk_bytes_uncompressed?: number;
-  detail?: TraceDetailRef;
-  masking?: { enabled: boolean; rules?: string[] };
-  rule_source?: EndpointRule;
-};
-
-type TraceNodeChunkEntry = {
-  record_index: number;
-  node: TraceNode;
-};
 
 type TraceNodeData = {
   label: string;
@@ -143,26 +75,6 @@ function DetailNode({ data }: { data: TraceNodeData }) {
     </div>
   );
 }
-
-export type TracePayload = {
-  trace_id?: string;
-  timestamp?: string;
-  status?: string;
-  rule?: { name?: string; path?: string; type?: string; version?: number };
-  rule_source?: EndpointRule;
-  detail?: TraceDetailRef;
-  records?: TraceRecord[];
-  finalize?: {
-    nodes?: TraceNode[];
-    input?: unknown;
-    output?: unknown;
-    status?: string;
-    duration_us?: number;
-    duration_ms?: number;
-  };
-  summary?: TraceSummary;
-  input_format?: string;
-};
 
 type ApiGraphOp = {
   label: string;
@@ -234,86 +146,6 @@ async function fetchJson<T>(path: string, auth: FetchAuth = "api"): Promise<T | 
     console.error("fetch failed", err);
     return null;
   }
-}
-
-function parseNumericIndex(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (!Number.isNaN(parsed)) return parsed;
-  }
-  return null;
-}
-
-function normalizeRecordIndex(value: unknown, fallback: number) {
-  const parsed = parseNumericIndex(value);
-  return parsed ?? fallback;
-}
-
-function normalizeInlineNodeValue(value: unknown, fallbackId: string): TraceNode {
-  const node =
-    value && typeof value === "object" && !Array.isArray(value)
-      ? { ...(value as Record<string, unknown>) }
-      : { value };
-  if (typeof node.id !== "string" || node.id.length === 0) {
-    node.id = fallbackId;
-  }
-  if (typeof node.kind !== "string" || node.kind.length === 0) {
-    node.kind = "value";
-  }
-  if (typeof node.label !== "string" || node.label.length === 0) {
-    node.label =
-      typeof node.value === "string" ? node.value : node.kind ?? "value";
-  }
-  return node as TraceNode;
-}
-
-function normalizeInlineNodes(value: unknown, prefix: string): TraceNode[] {
-  if (Array.isArray(value)) {
-    return value.map((node, index) =>
-      normalizeInlineNodeValue(node, `${prefix}-${index}`)
-    );
-  }
-  if (value === null || value === undefined) {
-    return [];
-  }
-  return [normalizeInlineNodeValue(value, `${prefix}-0`)];
-}
-
-function normalizeRecord(record: TraceRecord, fallbackIndex: number): TraceRecord {
-  const index = normalizeRecordIndex(record.index, fallbackIndex);
-  const nodes =
-    record.nodes === undefined
-      ? undefined
-      : normalizeInlineNodes(record.nodes as unknown, `record-${index}`);
-  return { ...record, index, nodes };
-}
-
-function normalizeTracePayload(trace: TracePayload | null): TracePayload | null {
-  if (!trace?.records) return trace;
-  return {
-    ...trace,
-    records: trace.records.map((record, index) => normalizeRecord(record, index))
-  };
-}
-
-function mergeNodesIntoRecords(
-  records: TraceRecord[],
-  nodesByRecord: Map<number, TraceNode[]>
-) {
-  return records.map((record, position) => {
-    const recordIndex = normalizeRecordIndex(record.index, position);
-    const nodes = nodesByRecord.get(recordIndex);
-    if (!nodes || nodes.length === 0) {
-      return { ...record, index: recordIndex };
-    }
-    const existing = normalizeInlineNodes(record.nodes as unknown, `record-${recordIndex}`);
-    return {
-      ...record,
-      index: recordIndex,
-      nodes: [...existing, ...nodes]
-    };
-  });
 }
 
 async function loadRecordChunks(traceId: string, detail: TraceDetailRef): Promise<TraceRecord[]> {

--- a/crates/rulemorph_ui/ui/src/__tests__/trace_payload.test.ts
+++ b/crates/rulemorph_ui/ui/src/__tests__/trace_payload.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mergeNodesIntoRecords,
+  normalizeInlineNodeValue,
+  normalizeInlineNodes,
+  normalizeRecord,
+  normalizeRecordIndex,
+  normalizeTracePayload,
+  parseNumericIndex,
+  type TracePayload,
+  type TraceRecord
+} from "../trace_payload";
+
+describe("trace payload helpers", () => {
+  it("parses finite numeric record indexes", () => {
+    expect(parseNumericIndex(2)).toBe(2);
+    expect(parseNumericIndex("3")).toBe(3);
+    expect(parseNumericIndex(Number.NaN)).toBeNull();
+    expect(parseNumericIndex(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(parseNumericIndex("not-a-number")).toBeNull();
+    expect(normalizeRecordIndex("4", 9)).toBe(4);
+    expect(normalizeRecordIndex("missing", 9)).toBe(9);
+  });
+
+  it("normalizes inline node values with existing fallback behavior", () => {
+    expect(normalizeInlineNodeValue("label text", "fallback")).toMatchObject({
+      id: "fallback",
+      kind: "value",
+      label: "label text",
+      value: "label text"
+    });
+
+    expect(normalizeInlineNodeValue({ id: "", kind: "", label: "", value: 7 }, "fallback")).toMatchObject({
+      id: "fallback",
+      kind: "value",
+      label: "value",
+      value: 7
+    });
+
+    expect(normalizeInlineNodeValue({ id: "node", kind: "op", label: "trim" }, "fallback")).toMatchObject({
+      id: "node",
+      kind: "op",
+      label: "trim"
+    });
+  });
+
+  it("normalizes inline node collections", () => {
+    expect(normalizeInlineNodes(null, "record-0")).toEqual([]);
+    expect(normalizeInlineNodes(undefined, "record-0")).toEqual([]);
+    expect(normalizeInlineNodes("single", "record-0")).toEqual([
+      { id: "record-0-0", kind: "value", label: "single", value: "single" }
+    ]);
+    expect(normalizeInlineNodes([{ label: "A" }, { id: "b", kind: "step" }], "record-0")).toEqual([
+      { id: "record-0-0", kind: "value", label: "A" },
+      { id: "b", kind: "step", label: "step" }
+    ]);
+  });
+
+  it("normalizes record indexes and node prefixes", () => {
+    const record = normalizeRecord(
+      { index: "bad" as unknown as number, nodes: [{ label: "node" }] },
+      6
+    );
+    expect(record.index).toBe(6);
+    expect(record.nodes).toEqual([{ id: "record-6-0", kind: "value", label: "node" }]);
+  });
+
+  it("normalizes traces only when records are present", () => {
+    expect(normalizeTracePayload(null)).toBeNull();
+    const traceWithoutRecords: TracePayload = { trace_id: "trace-a" };
+    expect(normalizeTracePayload(traceWithoutRecords)).toBe(traceWithoutRecords);
+
+    const normalized = normalizeTracePayload({
+      trace_id: "trace-b",
+      records: [{ index: "1" as unknown as number, nodes: "inline" as unknown as TraceRecord["nodes"] }]
+    });
+    expect(normalized?.records?.[0]).toMatchObject({
+      index: 1,
+      nodes: [{ id: "record-1-0", kind: "value", label: "inline", value: "inline" }]
+    });
+  });
+
+  it("merges chunk nodes into normalized records", () => {
+    const chunkNodes = new Map([
+      [
+        2,
+        [
+          {
+            id: "chunk-node",
+            kind: "op",
+            label: "chunk"
+          }
+        ]
+      ]
+    ]);
+
+    const merged = mergeNodesIntoRecords(
+      [
+        { index: "2" as unknown as number, nodes: [{ label: "inline" }] },
+        { index: "bad" as unknown as number }
+      ],
+      chunkNodes
+    );
+
+    expect(merged[0]).toMatchObject({
+      index: 2,
+      nodes: [
+        { id: "record-2-0", kind: "value", label: "inline" },
+        { id: "chunk-node", kind: "op", label: "chunk" }
+      ]
+    });
+    expect(merged[1]).toEqual({ index: 1 });
+  });
+});

--- a/crates/rulemorph_ui/ui/src/trace_payload.ts
+++ b/crates/rulemorph_ui/ui/src/trace_payload.ts
@@ -1,0 +1,182 @@
+import type { TraceSummary } from "./trace_list_helpers";
+
+export type TraceNode = {
+  id: string;
+  kind: string;
+  label: string;
+  status?: string;
+  duration_us?: number;
+  duration_ms?: number;
+  input?: unknown;
+  output?: unknown;
+  pipe_value?: unknown;
+  args?: unknown[];
+  pipe_steps?: { index: number; label: string; input?: unknown; output?: unknown }[];
+  children?: TraceNode[];
+  child_trace?: TracePayload;
+  error?: { code?: string; message?: string; path?: string };
+  meta?: Record<string, unknown>;
+};
+
+export type TraceRecord = {
+  index: number;
+  status?: string;
+  duration_us?: number;
+  duration_ms?: number;
+  input?: unknown;
+  output?: unknown;
+  nodes?: TraceNode[];
+  error?: { code?: string; message?: string; path?: string };
+};
+
+export type EndpointSpec = {
+  method: string;
+  path: string;
+  steps: { rule: string }[];
+  reply?: { status?: number; body?: string };
+};
+
+export type EndpointRule = {
+  version: number;
+  type: "endpoint";
+  endpoints: EndpointSpec[];
+};
+
+export type TraceChunkRef = {
+  path: string;
+  format: string;
+  compression: string;
+  record_start?: number;
+  record_end?: number;
+  node_start?: number;
+  node_end?: number;
+  bytes?: number;
+};
+
+export type TraceDetailRef = {
+  layout: string;
+  status: string;
+  reason?: string[];
+  records?: TraceChunkRef[];
+  nodes?: TraceChunkRef[];
+  finalize?: TraceChunkRef;
+};
+
+export type TraceManifest = {
+  trace_schema_version: number;
+  trace_id: string;
+  timestamp?: string;
+  status?: string;
+  rule?: { name?: string; path?: string; type?: string; version?: number };
+  input_format?: string;
+  summary?: TraceSummary;
+  max_chunk_bytes_uncompressed?: number;
+  detail?: TraceDetailRef;
+  masking?: { enabled: boolean; rules?: string[] };
+  rule_source?: EndpointRule;
+};
+
+export type TraceNodeChunkEntry = {
+  record_index: number;
+  node: TraceNode;
+};
+
+export type TracePayload = {
+  trace_id?: string;
+  timestamp?: string;
+  status?: string;
+  rule?: { name?: string; path?: string; type?: string; version?: number };
+  rule_source?: EndpointRule;
+  detail?: TraceDetailRef;
+  records?: TraceRecord[];
+  finalize?: {
+    nodes?: TraceNode[];
+    input?: unknown;
+    output?: unknown;
+    status?: string;
+    duration_us?: number;
+    duration_ms?: number;
+  };
+  summary?: TraceSummary;
+  input_format?: string;
+};
+
+export function parseNumericIndex(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return null;
+}
+
+export function normalizeRecordIndex(value: unknown, fallback: number) {
+  const parsed = parseNumericIndex(value);
+  return parsed ?? fallback;
+}
+
+export function normalizeInlineNodeValue(value: unknown, fallbackId: string): TraceNode {
+  const node =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? { ...(value as Record<string, unknown>) }
+      : { value };
+  if (typeof node.id !== "string" || node.id.length === 0) {
+    node.id = fallbackId;
+  }
+  if (typeof node.kind !== "string" || node.kind.length === 0) {
+    node.kind = "value";
+  }
+  if (typeof node.label !== "string" || node.label.length === 0) {
+    node.label =
+      typeof node.value === "string" ? node.value : node.kind ?? "value";
+  }
+  return node as TraceNode;
+}
+
+export function normalizeInlineNodes(value: unknown, prefix: string): TraceNode[] {
+  if (Array.isArray(value)) {
+    return value.map((node, index) =>
+      normalizeInlineNodeValue(node, `${prefix}-${index}`)
+    );
+  }
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return [normalizeInlineNodeValue(value, `${prefix}-0`)];
+}
+
+export function normalizeRecord(record: TraceRecord, fallbackIndex: number): TraceRecord {
+  const index = normalizeRecordIndex(record.index, fallbackIndex);
+  const nodes =
+    record.nodes === undefined
+      ? undefined
+      : normalizeInlineNodes(record.nodes as unknown, `record-${index}`);
+  return { ...record, index, nodes };
+}
+
+export function normalizeTracePayload(trace: TracePayload | null): TracePayload | null {
+  if (!trace?.records) return trace;
+  return {
+    ...trace,
+    records: trace.records.map((record, index) => normalizeRecord(record, index))
+  };
+}
+
+export function mergeNodesIntoRecords(
+  records: TraceRecord[],
+  nodesByRecord: Map<number, TraceNode[]>
+) {
+  return records.map((record, position) => {
+    const recordIndex = normalizeRecordIndex(record.index, position);
+    const nodes = nodesByRecord.get(recordIndex);
+    if (!nodes || nodes.length === 0) {
+      return { ...record, index: recordIndex };
+    }
+    const existing = normalizeInlineNodes(record.nodes as unknown, `record-${recordIndex}`);
+    return {
+      ...record,
+      index: recordIndex,
+      nodes: [...existing, ...nodes]
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- move pure Trace Console payload types and normalization helpers from App.tsx into src/trace_payload.ts
- keep App.tsx type exports source-compatible for existing imports
- keep chunk loading, fetch/auth paths, React state, graph construction, import flow, rendering, and API contracts unchanged
- add focused unit coverage for trace payload normalization behavior

## Verification
- npm --prefix crates/rulemorph_ui/ui run test -- trace_payload
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- cargo build -p rulemorph_server
- npm --prefix crates/rulemorph_ui/ui run test:e2e (sandbox-external after server prebuild)
- browser smoke via Vite preview at 127.0.0.1:4176 desktop screenshot
- git diff --check
- git diff --cached --check