### PR TITLE
Refactor validation test helpers

### DIFF
--- a/crates/rulemorph/tests/common/mod.rs
+++ b/crates/rulemorph/tests/common/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod golden;
 pub(crate) mod trace;
+pub(crate) mod validation;

--- a/crates/rulemorph/tests/common/validation.rs
+++ b/crates/rulemorph/tests/common/validation.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rulemorph::{RuleError, parse_rule_file};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct ExpectedError {
+    code: String,
+    path: Option<String>,
+}
+
+pub fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+pub fn load_rule(case: &str) -> rulemorph::RuleFile {
+    let rules_path = fixtures_dir().join(case).join("rules.yaml");
+    let yaml = fs::read_to_string(&rules_path)
+        .unwrap_or_else(|_| panic!("failed to read {}", rules_path.display()));
+    parse_rule_file(&yaml)
+        .unwrap_or_else(|err| panic!("failed to parse YAML {}: {}", rules_path.display(), err))
+}
+
+pub fn load_expected_errors(case: &str) -> Vec<ExpectedError> {
+    let errors_path = fixtures_dir().join(case).join("expected_errors.json");
+    let json = fs::read_to_string(&errors_path)
+        .unwrap_or_else(|_| panic!("failed to read {}", errors_path.display()));
+    serde_json::from_str(&json).unwrap_or_else(|err| {
+        panic!(
+            "failed to parse expected errors {}: {}",
+            errors_path.display(),
+            err
+        )
+    })
+}
+
+pub fn normalize_errors(errors: Vec<RuleError>) -> Vec<(String, Option<String>)> {
+    let mut normalized: Vec<(String, Option<String>)> = errors
+        .into_iter()
+        .map(|err| (err.code.as_str().to_string(), err.path))
+        .collect();
+    normalized.sort();
+    normalized
+}
+
+pub fn normalize_expected(errors: Vec<ExpectedError>) -> Vec<(String, Option<String>)> {
+    let mut normalized: Vec<(String, Option<String>)> =
+        errors.into_iter().map(|err| (err.code, err.path)).collect();
+    normalized.sort();
+    normalized
+}

--- a/crates/rulemorph/tests/common/validation.rs
+++ b/crates/rulemorph/tests/common/validation.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -5,18 +7,18 @@ use rulemorph::{RuleError, parse_rule_file};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-pub struct ExpectedError {
+struct ExpectedError {
     code: String,
     path: Option<String>,
 }
 
-pub fn fixtures_dir() -> PathBuf {
+pub(crate) fn fixtures_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures")
 }
 
-pub fn load_rule(case: &str) -> rulemorph::RuleFile {
+pub(crate) fn load_rule(case: &str) -> rulemorph::RuleFile {
     let rules_path = fixtures_dir().join(case).join("rules.yaml");
     let yaml = fs::read_to_string(&rules_path)
         .unwrap_or_else(|_| panic!("failed to read {}", rules_path.display()));
@@ -24,20 +26,21 @@ pub fn load_rule(case: &str) -> rulemorph::RuleFile {
         .unwrap_or_else(|err| panic!("failed to parse YAML {}: {}", rules_path.display(), err))
 }
 
-pub fn load_expected_errors(case: &str) -> Vec<ExpectedError> {
+pub(crate) fn load_expected_errors(case: &str) -> Vec<(String, Option<String>)> {
     let errors_path = fixtures_dir().join(case).join("expected_errors.json");
     let json = fs::read_to_string(&errors_path)
         .unwrap_or_else(|_| panic!("failed to read {}", errors_path.display()));
-    serde_json::from_str(&json).unwrap_or_else(|err| {
+    let errors: Vec<ExpectedError> = serde_json::from_str(&json).unwrap_or_else(|err| {
         panic!(
             "failed to parse expected errors {}: {}",
             errors_path.display(),
             err
         )
-    })
+    });
+    normalize_expected(errors)
 }
 
-pub fn normalize_errors(errors: Vec<RuleError>) -> Vec<(String, Option<String>)> {
+pub(crate) fn normalize_errors(errors: Vec<RuleError>) -> Vec<(String, Option<String>)> {
     let mut normalized: Vec<(String, Option<String>)> = errors
         .into_iter()
         .map(|err| (err.code.as_str().to_string(), err.path))
@@ -46,7 +49,7 @@ pub fn normalize_errors(errors: Vec<RuleError>) -> Vec<(String, Option<String>)>
     normalized
 }
 
-pub fn normalize_expected(errors: Vec<ExpectedError>) -> Vec<(String, Option<String>)> {
+fn normalize_expected(errors: Vec<ExpectedError>) -> Vec<(String, Option<String>)> {
     let mut normalized: Vec<(String, Option<String>)> =
         errors.into_iter().map(|err| (err.code, err.path)).collect();
     normalized.sort();

--- a/crates/rulemorph/tests/validation.rs
+++ b/crates/rulemorph/tests/validation.rs
@@ -1,60 +1,16 @@
 use std::fs;
-use std::path::{Path, PathBuf};
 
 use rulemorph::{
-    ErrorCode, RuleError, RuleFormat, parse_rule_file, parse_rule_file_with_format,
-    validate_rule_file, validate_rule_file_with_source,
+    ErrorCode, RuleFormat, parse_rule_file, parse_rule_file_with_format, validate_rule_file,
+    validate_rule_file_with_source,
 };
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
-struct ExpectedError {
-    code: String,
-    path: Option<String>,
-}
+#[path = "common/validation.rs"]
+mod validation_common;
 
-fn fixtures_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-}
-
-fn load_rule(case: &str) -> rulemorph::RuleFile {
-    let rules_path = fixtures_dir().join(case).join("rules.yaml");
-    let yaml = fs::read_to_string(&rules_path)
-        .unwrap_or_else(|_| panic!("failed to read {}", rules_path.display()));
-    parse_rule_file(&yaml)
-        .unwrap_or_else(|err| panic!("failed to parse YAML {}: {}", rules_path.display(), err))
-}
-
-fn load_expected_errors(case: &str) -> Vec<ExpectedError> {
-    let errors_path = fixtures_dir().join(case).join("expected_errors.json");
-    let json = fs::read_to_string(&errors_path)
-        .unwrap_or_else(|_| panic!("failed to read {}", errors_path.display()));
-    serde_json::from_str(&json).unwrap_or_else(|err| {
-        panic!(
-            "failed to parse expected errors {}: {}",
-            errors_path.display(),
-            err
-        )
-    })
-}
-
-fn normalize_errors(errors: Vec<RuleError>) -> Vec<(String, Option<String>)> {
-    let mut normalized: Vec<(String, Option<String>)> = errors
-        .into_iter()
-        .map(|err| (err.code.as_str().to_string(), err.path))
-        .collect();
-    normalized.sort();
-    normalized
-}
-
-fn normalize_expected(errors: Vec<ExpectedError>) -> Vec<(String, Option<String>)> {
-    let mut normalized: Vec<(String, Option<String>)> =
-        errors.into_iter().map(|err| (err.code, err.path)).collect();
-    normalized.sort();
-    normalized
-}
+use validation_common::{
+    fixtures_dir, load_expected_errors, load_rule, normalize_errors, normalize_expected,
+};
 
 #[test]
 fn valid_rules_should_pass_validation() {

--- a/crates/rulemorph/tests/validation.rs
+++ b/crates/rulemorph/tests/validation.rs
@@ -5,12 +5,9 @@ use rulemorph::{
     validate_rule_file_with_source,
 };
 
-#[path = "common/validation.rs"]
-mod validation_common;
+mod common;
 
-use validation_common::{
-    fixtures_dir, load_expected_errors, load_rule, normalize_errors, normalize_expected,
-};
+use common::validation::{fixtures_dir, load_expected_errors, load_rule, normalize_errors};
 
 #[test]
 fn valid_rules_should_pass_validation() {
@@ -77,7 +74,7 @@ fn invalid_rules_should_match_expected_errors() {
 
     for case in cases {
         let rule = load_rule(case);
-        let expected = normalize_expected(load_expected_errors(case));
+        let expected = load_expected_errors(case);
         let errors = validate_rule_file(&rule).unwrap_err();
         let actual = normalize_errors(errors);
         assert_eq!(actual, expected, "error mismatch for fixture {}", case);
@@ -445,7 +442,7 @@ fn v2_invalid_rules_should_fail_validation() {
 
     for case in cases {
         let rule = load_rule(case);
-        let expected = normalize_expected(load_expected_errors(case));
+        let expected = load_expected_errors(case);
         let errors = validate_rule_file(&rule).unwrap_err();
         let actual = normalize_errors(errors);
         assert_eq!(actual, expected, "error mismatch for {}", case);
@@ -456,7 +453,7 @@ fn v2_invalid_rules_should_fail_validation() {
 fn v2_forward_out_ref_should_fail_validation() {
     // tv26_v02_forward_out_ref should fail with ForwardOutReference error
     let rule = load_rule("tv26_v02_forward_out_ref");
-    let expected = normalize_expected(load_expected_errors("tv26_v02_forward_out_ref"));
+    let expected = load_expected_errors("tv26_v02_forward_out_ref");
     let errors = validate_rule_file(&rule).unwrap_err();
     let actual = normalize_errors(errors);
     assert_eq!(


### PR DESCRIPTION
## Summary
- Extract validation integration test fixture and expected-error helpers
- Keep all 27 validation tests and semantic cases represented
- Preserve validation entrypoints, error code/path/source-location assertions, and v1/v2 coverage

## Verification
- cargo fmt
- cargo test -p rulemorph --test validation -- --list
- cargo test -p rulemorph --test validation
- cargo test -p rulemorph --test transform_golden
- cargo fmt --check
- git diff --check
- git diff --cached --check

No production code, public API, transform semantics, trace JSON schema, CLI/MCP/HTTP contract, or docs/specs changes.