### PR TITLE
Refactor transform preflight API helpers

### DIFF
--- a/crates/rulemorph/src/transform/api.rs
+++ b/crates/rulemorph/src/transform/api.rs
@@ -11,8 +11,16 @@ use super::stream::{
 };
 use super::{BranchContext, apply_finalize, apply_rule_to_record};
 
+mod preflight;
 mod trace;
 
+pub use preflight::{
+    preflight_validate, preflight_validate_input, preflight_validate_input_with_base_dir,
+    preflight_validate_input_with_warnings, preflight_validate_input_with_warnings_with_base_dir,
+    preflight_validate_input_with_warnings_with_base_dir_and_options,
+    preflight_validate_with_base_dir, preflight_validate_with_warnings,
+    preflight_validate_with_warnings_with_base_dir,
+};
 pub use trace::{
     transform_input_with_trace, transform_input_with_trace_with_base_dir_and_options,
     transform_record_with_trace,
@@ -81,40 +89,6 @@ pub fn transform_input_with_base_dir_and_options(
 ) -> Result<JsonValue, TransformError> {
     transform_input_with_warnings_with_base_dir_and_options(rule, input, context, base_dir, options)
         .map(|(output, _)| output)
-}
-
-pub fn preflight_validate(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-) -> Result<(), TransformError> {
-    preflight_validate_with_warnings(rule, input, context).map(|_| ())
-}
-
-pub fn preflight_validate_input(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-) -> Result<(), TransformError> {
-    preflight_validate_input_with_warnings(rule, input, context).map(|_| ())
-}
-
-pub fn preflight_validate_with_base_dir(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<(), TransformError> {
-    preflight_validate_with_warnings_with_base_dir(rule, input, context, base_dir).map(|_| ())
-}
-
-pub fn preflight_validate_input_with_base_dir(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<(), TransformError> {
-    preflight_validate_input_with_warnings_with_base_dir(rule, input, context, base_dir).map(|_| ())
 }
 
 pub fn transform_with_warnings(
@@ -325,110 +299,4 @@ pub(super) fn transform_record_with_warnings_inner(
         return Ok((Some(finalized), warnings));
     }
     Ok((output, warnings))
-}
-
-pub fn preflight_validate_with_warnings(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-) -> Result<Vec<TransformWarning>, TransformError> {
-    preflight_validate_input_with_warnings(rule, InputData::Text(input), context)
-}
-
-pub fn preflight_validate_input_with_warnings(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-) -> Result<Vec<TransformWarning>, TransformError> {
-    preflight_validate_input_with_warnings_inner(
-        rule,
-        input,
-        context,
-        None,
-        &NormalizationOptions::default(),
-    )
-}
-
-pub fn preflight_validate_with_warnings_with_base_dir(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<Vec<TransformWarning>, TransformError> {
-    preflight_validate_input_with_warnings_with_base_dir(
-        rule,
-        InputData::Text(input),
-        context,
-        base_dir,
-    )
-}
-
-pub fn preflight_validate_input_with_warnings_with_base_dir(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<Vec<TransformWarning>, TransformError> {
-    preflight_validate_input_with_warnings_with_base_dir_and_options(
-        rule,
-        input,
-        context,
-        base_dir,
-        &NormalizationOptions::default(),
-    )
-}
-
-pub fn preflight_validate_input_with_warnings_with_base_dir_and_options(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-    options: &NormalizationOptions,
-) -> Result<Vec<TransformWarning>, TransformError> {
-    preflight_validate_input_with_warnings_inner(rule, input, context, Some(base_dir), options)
-}
-
-fn preflight_validate_input_with_warnings_inner(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: Option<&Path>,
-    options: &NormalizationOptions,
-) -> Result<Vec<TransformWarning>, TransformError> {
-    let mut warnings = Vec::new();
-    if rule.finalize.is_some() {
-        let mut output_records = Vec::new();
-        let mut records = input_records_iter_with_options(rule, input, options)?;
-        while let Some(record) = records.next() {
-            let record = record?;
-            let mut record_warnings = Vec::new();
-            let mut branch_context = BranchContext::default();
-            if let Some(output) = apply_rule_to_record(
-                rule,
-                &record,
-                context,
-                &mut record_warnings,
-                base_dir,
-                &mut branch_context,
-            )? {
-                output_records.push(output);
-            }
-            warnings.extend(record_warnings);
-        }
-        if let Some(finalize) = &rule.finalize {
-            let _ = apply_finalize(finalize, JsonValue::Array(output_records), context)?;
-        }
-    } else {
-        let stream = match base_dir {
-            Some(base_dir) => transform_stream_input_with_base_dir_and_options(
-                rule, input, context, base_dir, options,
-            )?,
-            None => transform_stream_input_with_options(rule, input, context, options)?,
-        };
-        for item in stream {
-            let item = item?;
-            warnings.extend(item.warnings);
-        }
-    }
-    Ok(warnings)
 }

--- a/crates/rulemorph/src/transform/api/preflight.rs
+++ b/crates/rulemorph/src/transform/api/preflight.rs
@@ -1,0 +1,141 @@
+use super::*;
+
+pub fn preflight_validate(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+) -> Result<(), TransformError> {
+    preflight_validate_with_warnings(rule, input, context).map(|_| ())
+}
+
+pub fn preflight_validate_input(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+) -> Result<(), TransformError> {
+    preflight_validate_input_with_warnings(rule, input, context).map(|_| ())
+}
+
+pub fn preflight_validate_with_base_dir(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<(), TransformError> {
+    preflight_validate_with_warnings_with_base_dir(rule, input, context, base_dir).map(|_| ())
+}
+
+pub fn preflight_validate_input_with_base_dir(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<(), TransformError> {
+    preflight_validate_input_with_warnings_with_base_dir(rule, input, context, base_dir).map(|_| ())
+}
+
+pub fn preflight_validate_with_warnings(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+) -> Result<Vec<TransformWarning>, TransformError> {
+    preflight_validate_input_with_warnings(rule, InputData::Text(input), context)
+}
+
+pub fn preflight_validate_input_with_warnings(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+) -> Result<Vec<TransformWarning>, TransformError> {
+    preflight_validate_input_with_warnings_inner(
+        rule,
+        input,
+        context,
+        None,
+        &NormalizationOptions::default(),
+    )
+}
+
+pub fn preflight_validate_with_warnings_with_base_dir(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<Vec<TransformWarning>, TransformError> {
+    preflight_validate_input_with_warnings_with_base_dir(
+        rule,
+        InputData::Text(input),
+        context,
+        base_dir,
+    )
+}
+
+pub fn preflight_validate_input_with_warnings_with_base_dir(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<Vec<TransformWarning>, TransformError> {
+    preflight_validate_input_with_warnings_with_base_dir_and_options(
+        rule,
+        input,
+        context,
+        base_dir,
+        &NormalizationOptions::default(),
+    )
+}
+
+pub fn preflight_validate_input_with_warnings_with_base_dir_and_options(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+    options: &NormalizationOptions,
+) -> Result<Vec<TransformWarning>, TransformError> {
+    preflight_validate_input_with_warnings_inner(rule, input, context, Some(base_dir), options)
+}
+
+fn preflight_validate_input_with_warnings_inner(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: Option<&Path>,
+    options: &NormalizationOptions,
+) -> Result<Vec<TransformWarning>, TransformError> {
+    let mut warnings = Vec::new();
+    if rule.finalize.is_some() {
+        let mut output_records = Vec::new();
+        let mut records = input_records_iter_with_options(rule, input, options)?;
+        while let Some(record) = records.next() {
+            let record = record?;
+            let mut record_warnings = Vec::new();
+            let mut branch_context = BranchContext::default();
+            if let Some(output) = apply_rule_to_record(
+                rule,
+                &record,
+                context,
+                &mut record_warnings,
+                base_dir,
+                &mut branch_context,
+            )? {
+                output_records.push(output);
+            }
+            warnings.extend(record_warnings);
+        }
+        if let Some(finalize) = &rule.finalize {
+            let _ = apply_finalize(finalize, JsonValue::Array(output_records), context)?;
+        }
+    } else {
+        let stream = match base_dir {
+            Some(base_dir) => transform_stream_input_with_base_dir_and_options(
+                rule, input, context, base_dir, options,
+            )?,
+            None => transform_stream_input_with_options(rule, input, context, options)?,
+        };
+        for item in stream {
+            let item = item?;
+            warnings.extend(item.warnings);
+        }
+    }
+    Ok(warnings)
+}


### PR DESCRIPTION
## Summary
- Move transform preflight API wrappers into `transform/api/preflight.rs`
- Keep `transform/api.rs` as the public facade with unchanged exports
- Preserve transform behavior, trace schema, and public API names/signatures

## Verification
- `cargo fmt`
- `cargo test -p rulemorph --test preflight`
- `cargo test -p rulemorph --test transform_record`
- `cargo test -p rulemorph --test transform_stream`
- `cargo test -p rulemorph --test transform_trace`
- `cargo fmt --check`
- `git diff --check origin/v0.3.1...HEAD`