### PR TITLE
Refactor array operator dispatch

### DIFF
--- a/crates/rulemorph/src/transform/operators/dispatch.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch.rs
@@ -259,6 +259,100 @@ pub(crate) fn eval_op(
             base_path,
             locals,
         ),
+        "map" | "filter" | "flat_map" | "flatten" | "take" | "drop" | "slice" | "chunk" | "zip"
+        | "zip_with" | "unzip" | "group_by" | "key_by" | "partition" | "unique" | "distinct_by"
+        | "sort_by" | "find" | "find_index" | "index_of" | "contains" | "sum" | "avg" | "min"
+        | "max" | "reduce" | "fold" => {
+            eval_array_dispatch(expr_op, record, context, out, base_path, injected, locals)
+        }
+        "+" | "-" | "*" | "/" => {
+            eval_numeric_op(expr_op, injected, record, context, out, base_path, locals)
+        }
+        "round" => eval_round(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "to_base" => eval_to_base(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "date_format" => eval_date_format(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "to_unixtime" => eval_to_unixtime(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "and" => eval_bool_and_or(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            true,
+            locals,
+        ),
+        "or" => eval_bool_and_or(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            false,
+            locals,
+        ),
+        "not" => eval_bool_not(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "==" | "!=" | "<" | "<=" | ">" | ">=" | "~=" => {
+            eval_compare(expr_op, injected, record, context, out, base_path, locals)
+        }
+        _ => Err(
+            TransformError::new(TransformErrorKind::ExprError, "expr.op is not supported")
+                .with_path(format!("{}.op", base_path)),
+        ),
+    }
+}
+
+fn eval_array_dispatch(
+    expr_op: &ExprOp,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    injected: Option<&EvalValue>,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    match expr_op.op.as_str() {
         "map" => eval_array_map(
             &expr_op.args,
             injected,
@@ -502,80 +596,6 @@ pub(crate) fn eval_op(
             base_path,
             locals,
         ),
-        "+" | "-" | "*" | "/" => {
-            eval_numeric_op(expr_op, injected, record, context, out, base_path, locals)
-        }
-        "round" => eval_round(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "to_base" => eval_to_base(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "date_format" => eval_date_format(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "to_unixtime" => eval_to_unixtime(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "and" => eval_bool_and_or(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            true,
-            locals,
-        ),
-        "or" => eval_bool_and_or(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            false,
-            locals,
-        ),
-        "not" => eval_bool_not(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "==" | "!=" | "<" | "<=" | ">" | ">=" | "~=" => {
-            eval_compare(expr_op, injected, record, context, out, base_path, locals)
-        }
-        _ => Err(
-            TransformError::new(TransformErrorKind::ExprError, "expr.op is not supported")
-                .with_path(format!("{}.op", base_path)),
-        ),
+        _ => unreachable!("array dispatch called for non-array operator"),
     }
 }


### PR DESCRIPTION
## Summary
- Extract array operator dispatch arms from eval_op into a private eval_array_dispatch helper in dispatch.rs
- Keep operator names, dispatch coverage, argument propagation, unknown-op fallback, transform semantics, trace schema, and public APIs unchanged
- No new modules or public exports

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden t16_array_ops
- cargo test -p rulemorph --test transform_golden t26_chain_all_ops
- cargo test -p rulemorph --test transform_golden tv26_unknown_op_error
- cargo test -p rulemorph --test validation
- cargo test -p rulemorph --test v2_collection_ops
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_collection_operators_emit_item_level_events
- cargo test -p rulemorph --test transform_golden
- cargo test -p rulemorph --test transform_trace_semantics
- cargo fmt --check
- git diff --check

## Rebase verification after #248 merge
- cargo test -p rulemorph --test transform_golden t16_array_ops
- cargo test -p rulemorph --test transform_golden t26_chain_all_ops
- cargo test -p rulemorph --test v2_collection_ops
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD