### PR TITLE
Refactor v2 eval op number tests

### DIFF
--- a/crates/rulemorph/src/v2_eval/tests/op_step.rs
+++ b/crates/rulemorph/src/v2_eval/tests/op_step.rs
@@ -9,47 +9,7 @@ fn lit(value: JsonValue) -> V2Expr {
 }
 
 include!("op_step/string.rs");
-
-#[test]
-fn test_eval_op_round_and_to_base() {
-    let round = V2OpStep {
-        op: "round".to_string(),
-        args: vec![lit(json!(2))],
-    };
-    let to_base = V2OpStep {
-        op: "to_base".to_string(),
-        args: vec![lit(json!(2))],
-    };
-    let ctx = V2EvalContext::new();
-
-    let rounded = eval_v2_op_step(
-        &round,
-        EvalValue::Value(json!(1.2345)),
-        &json!({}),
-        None,
-        &json!({}),
-        "test",
-        &ctx,
-    )
-    .unwrap();
-    if let EvalValue::Value(v) = rounded {
-        let value = v.as_f64().unwrap();
-        assert!((value - 1.23).abs() < 1e-9);
-    } else {
-        panic!("expected rounded value");
-    }
-
-    let base = eval_v2_op_step(
-        &to_base,
-        EvalValue::Value(json!(10)),
-        &json!({}),
-        None,
-        &json!({}),
-        "test",
-        &ctx,
-    );
-    assert!(matches!(base, Ok(EvalValue::Value(v)) if v == json!("1010")));
-}
+include!("op_step/number.rs");
 
 #[test]
 fn test_eval_op_json_merge() {
@@ -280,50 +240,6 @@ fn test_eval_op_and_or_short_circuit() {
     assert!(matches!(and_result, Ok(EvalValue::Value(v)) if v == json!(false)));
 }
 
-#[test]
-fn test_eval_op_add() {
-    let op = V2OpStep {
-        op: "add".to_string(),
-        args: vec![V2Expr::Pipe(V2Pipe {
-            start: V2Start::Literal(json!(10)),
-            steps: vec![],
-        })],
-    };
-    let ctx = V2EvalContext::new();
-    let result = eval_v2_op_step(
-        &op,
-        EvalValue::Value(json!(5)),
-        &json!({}),
-        None,
-        &json!({}),
-        "test",
-        &ctx,
-    );
-    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(15.0)));
-}
-
-#[test]
-fn test_eval_op_subtract() {
-    let op = V2OpStep {
-        op: "subtract".to_string(),
-        args: vec![V2Expr::Pipe(V2Pipe {
-            start: V2Start::Literal(json!(3)),
-            steps: vec![],
-        })],
-    };
-    let ctx = V2EvalContext::new();
-    let result = eval_v2_op_step(
-        &op,
-        EvalValue::Value(json!(10)),
-        &json!({}),
-        None,
-        &json!({}),
-        "test",
-        &ctx,
-    );
-    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(7.0)));
-}
-
 include!("op_step/comparison.rs");
 
 #[test]
@@ -390,72 +306,6 @@ fn test_eval_op_pick_paths_array_arg() {
         result,
         Ok(EvalValue::Value(v)) if v == json!({"name": "apple", "price": 100})
     ));
-}
-
-#[test]
-fn test_eval_op_multiply() {
-    let op = V2OpStep {
-        op: "multiply".to_string(),
-        args: vec![V2Expr::Pipe(V2Pipe {
-            start: V2Start::Literal(json!(0.9)),
-            steps: vec![],
-        })],
-    };
-    let ctx = V2EvalContext::new();
-    let result = eval_v2_op_step(
-        &op,
-        EvalValue::Value(json!(100)),
-        &json!({}),
-        None,
-        &json!({}),
-        "test",
-        &ctx,
-    );
-    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(90.0)));
-}
-
-#[test]
-fn test_eval_op_divide() {
-    let op = V2OpStep {
-        op: "divide".to_string(),
-        args: vec![V2Expr::Pipe(V2Pipe {
-            start: V2Start::Literal(json!(2)),
-            steps: vec![],
-        })],
-    };
-    let ctx = V2EvalContext::new();
-    let result = eval_v2_op_step(
-        &op,
-        EvalValue::Value(json!(10)),
-        &json!({}),
-        None,
-        &json!({}),
-        "test",
-        &ctx,
-    );
-    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(5.0)));
-}
-
-#[test]
-fn test_eval_op_divide_by_zero() {
-    let op = V2OpStep {
-        op: "divide".to_string(),
-        args: vec![V2Expr::Pipe(V2Pipe {
-            start: V2Start::Literal(json!(0)),
-            steps: vec![],
-        })],
-    };
-    let ctx = V2EvalContext::new();
-    let result = eval_v2_op_step(
-        &op,
-        EvalValue::Value(json!(10)),
-        &json!({}),
-        None,
-        &json!({}),
-        "test",
-        &ctx,
-    );
-    assert!(result.is_err());
 }
 
 #[test]

--- a/crates/rulemorph/src/v2_eval/tests/op_step/number.rs
+++ b/crates/rulemorph/src/v2_eval/tests/op_step/number.rs
@@ -1,0 +1,150 @@
+#[test]
+fn test_eval_op_round_and_to_base() {
+    let round = V2OpStep {
+        op: "round".to_string(),
+        args: vec![lit(json!(2))],
+    };
+    let to_base = V2OpStep {
+        op: "to_base".to_string(),
+        args: vec![lit(json!(2))],
+    };
+    let ctx = V2EvalContext::new();
+
+    let rounded = eval_v2_op_step(
+        &round,
+        EvalValue::Value(json!(1.2345)),
+        &json!({}),
+        None,
+        &json!({}),
+        "test",
+        &ctx,
+    )
+    .unwrap();
+    if let EvalValue::Value(v) = rounded {
+        let value = v.as_f64().unwrap();
+        assert!((value - 1.23).abs() < 1e-9);
+    } else {
+        panic!("expected rounded value");
+    }
+
+    let base = eval_v2_op_step(
+        &to_base,
+        EvalValue::Value(json!(10)),
+        &json!({}),
+        None,
+        &json!({}),
+        "test",
+        &ctx,
+    );
+    assert!(matches!(base, Ok(EvalValue::Value(v)) if v == json!("1010")));
+}
+
+#[test]
+fn test_eval_op_add() {
+    let op = V2OpStep {
+        op: "add".to_string(),
+        args: vec![V2Expr::Pipe(V2Pipe {
+            start: V2Start::Literal(json!(10)),
+            steps: vec![],
+        })],
+    };
+    let ctx = V2EvalContext::new();
+    let result = eval_v2_op_step(
+        &op,
+        EvalValue::Value(json!(5)),
+        &json!({}),
+        None,
+        &json!({}),
+        "test",
+        &ctx,
+    );
+    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(15.0)));
+}
+
+#[test]
+fn test_eval_op_subtract() {
+    let op = V2OpStep {
+        op: "subtract".to_string(),
+        args: vec![V2Expr::Pipe(V2Pipe {
+            start: V2Start::Literal(json!(3)),
+            steps: vec![],
+        })],
+    };
+    let ctx = V2EvalContext::new();
+    let result = eval_v2_op_step(
+        &op,
+        EvalValue::Value(json!(10)),
+        &json!({}),
+        None,
+        &json!({}),
+        "test",
+        &ctx,
+    );
+    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(7.0)));
+}
+
+#[test]
+fn test_eval_op_multiply() {
+    let op = V2OpStep {
+        op: "multiply".to_string(),
+        args: vec![V2Expr::Pipe(V2Pipe {
+            start: V2Start::Literal(json!(0.9)),
+            steps: vec![],
+        })],
+    };
+    let ctx = V2EvalContext::new();
+    let result = eval_v2_op_step(
+        &op,
+        EvalValue::Value(json!(100)),
+        &json!({}),
+        None,
+        &json!({}),
+        "test",
+        &ctx,
+    );
+    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(90.0)));
+}
+
+#[test]
+fn test_eval_op_divide() {
+    let op = V2OpStep {
+        op: "divide".to_string(),
+        args: vec![V2Expr::Pipe(V2Pipe {
+            start: V2Start::Literal(json!(2)),
+            steps: vec![],
+        })],
+    };
+    let ctx = V2EvalContext::new();
+    let result = eval_v2_op_step(
+        &op,
+        EvalValue::Value(json!(10)),
+        &json!({}),
+        None,
+        &json!({}),
+        "test",
+        &ctx,
+    );
+    assert!(matches!(result, Ok(EvalValue::Value(v)) if v == json!(5.0)));
+}
+
+#[test]
+fn test_eval_op_divide_by_zero() {
+    let op = V2OpStep {
+        op: "divide".to_string(),
+        args: vec![V2Expr::Pipe(V2Pipe {
+            start: V2Start::Literal(json!(0)),
+            steps: vec![],
+        })],
+    };
+    let ctx = V2EvalContext::new();
+    let result = eval_v2_op_step(
+        &op,
+        EvalValue::Value(json!(10)),
+        &json!({}),
+        None,
+        &json!({}),
+        "test",
+        &ctx,
+    );
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- move v2 numeric operator eval tests into op_step/number.rs
- keep existing test names through the parent include! layout

## Verification
- cargo fmt
- cargo test -p rulemorph --lib v2_eval::tests::v2_op_step_eval_tests::test_eval_op_ -- --test-threads=1
- cargo test -p rulemorph --lib v2_eval -- --list
- cargo test -p rulemorph --lib v2_eval -- --test-threads=1
- cargo test -p rulemorph --test v2_transform
- cargo test -p rulemorph --test transform_trace_semantics
- cargo fmt --check
- git diff --check