### PR TITLE
Refactor legacy trace id resolution tests

### DIFF
--- a/crates/rulemorph_trace/tests/trace_writer/trace_ids/store_resolution.rs
+++ b/crates/rulemorph_trace/tests/trace_writer/trace_ids/store_resolution.rs
@@ -1,94 +1,4 @@
 #[tokio::test]
-async fn write_trace_bundle_sanitizes_legacy_trace_id() -> anyhow::Result<()> {
-    let temp_dir = unique_temp_dir();
-    let traces_dir = temp_dir.join("traces");
-    fs::create_dir_all(&traces_dir)?;
-
-    let legacy_path = traces_dir.join("legacy.json");
-    fs::write(
-        &legacy_path,
-        serde_json::to_string(&json!({
-            "trace_id": "legacy id/非",
-            "status": "ok"
-        }))?,
-    )?;
-
-    let store = TraceStore::new(temp_dir.clone()).await?;
-    let items = store.list().await?;
-    assert_eq!(items.len(), 1);
-    assert_eq!(items[0].trace_id, "legacy_id__");
-    let loaded = store
-        .get(&items[0].trace_id)
-        .await?
-        .expect("trace should load");
-    assert_eq!(
-        loaded.get("trace_id").and_then(|value| value.as_str()),
-        Some("legacy_id__")
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn write_trace_bundle_legacy_missing_trace_id_trace_filename_falls_back_to_hash()
--> anyhow::Result<()> {
-    let temp_dir = unique_temp_dir();
-    let traces_dir = temp_dir.join("traces");
-    fs::create_dir_all(&traces_dir)?;
-
-    let legacy_path = traces_dir.join("trace.json");
-    fs::write(
-        &legacy_path,
-        serde_json::to_string(&json!({
-            "records": [],
-            "status": "ok"
-        }))?,
-    )?;
-
-    let store = TraceStore::new(temp_dir.clone()).await?;
-    let items = store.list().await?;
-    assert_eq!(items.len(), 1);
-    assert!(items[0].trace_id.starts_with("trace-"));
-    assert_ne!(items[0].trace_id, "trace");
-
-    let loaded = store
-        .get(&items[0].trace_id)
-        .await?
-        .expect("trace should load");
-    assert_eq!(
-        loaded.get("trace_id").and_then(|value| value.as_str()),
-        Some(items[0].trace_id.as_str())
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn write_trace_bundle_legacy_trace_id_trace_falls_back_to_hash() -> anyhow::Result<()> {
-    let temp_dir = unique_temp_dir();
-    let traces_dir = temp_dir.join("traces");
-    fs::create_dir_all(&traces_dir)?;
-
-    let legacy_path = traces_dir.join("legacy-trace.json");
-    fs::write(
-        &legacy_path,
-        serde_json::to_string(&json!({
-            "trace_id": "trace",
-            "records": [],
-            "status": "ok"
-        }))?,
-    )?;
-
-    let store = TraceStore::new(temp_dir.clone()).await?;
-    let items = store.list().await?;
-    assert_eq!(items.len(), 1);
-    assert!(items[0].trace_id.starts_with("trace-"));
-    assert_ne!(items[0].trace_id, "trace");
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn write_trace_bundle_disambiguates_legacy_trace_id_collisions() -> anyhow::Result<()> {
     let temp_dir = unique_temp_dir();
     let traces_dir = temp_dir.join("traces");
@@ -199,56 +109,6 @@ async fn write_trace_bundle_manifest_empty_trace_id_uses_file_stem() -> anyhow::
 }
 
 #[tokio::test]
-async fn write_trace_bundle_legacy_empty_trace_id_uses_file_stem() -> anyhow::Result<()> {
-    let temp_dir = unique_temp_dir();
-    let traces_dir = temp_dir.join("traces");
-    fs::create_dir_all(&traces_dir)?;
-
-    let legacy_path = traces_dir.join("legacy-custom.json");
-    fs::write(
-        &legacy_path,
-        serde_json::to_string(&json!({
-            "trace_id": "",
-            "status": "ok"
-        }))?,
-    )?;
-
-    let store = TraceStore::new(temp_dir.clone()).await?;
-    let items = store.list().await?;
-    assert_eq!(items.len(), 1);
-    assert_eq!(items[0].trace_id, "legacy-custom");
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn write_trace_bundle_legacy_dot_trace_id_uses_file_stem() -> anyhow::Result<()> {
-    let temp_dir = unique_temp_dir();
-    let traces_dir = temp_dir.join("traces");
-    fs::create_dir_all(&traces_dir)?;
-
-    for raw in [".", ".."] {
-        let legacy_path = traces_dir.join(format!("legacy-dot-{raw}.json"));
-        fs::write(
-            &legacy_path,
-            serde_json::to_string(&json!({
-                "trace_id": raw,
-                "status": "ok"
-            }))?,
-        )?;
-    }
-
-    let store = TraceStore::new(temp_dir.clone()).await?;
-    let items = store.list().await?;
-    let trace_ids: std::collections::HashSet<_> =
-        items.iter().map(|item| item.trace_id.as_str()).collect();
-    assert!(trace_ids.contains("legacy-dot-."));
-    assert!(trace_ids.contains("legacy-dot-.."));
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn write_trace_bundle_manifest_trace_id_trace_falls_back_to_hash() -> anyhow::Result<()> {
     let temp_dir = unique_temp_dir();
     let traces_dir = temp_dir.join("traces");
@@ -298,5 +158,7 @@ async fn write_trace_bundle_manifest_dot_trace_id_uses_file_stem() -> anyhow::Re
 
     Ok(())
 }
+
+include!("store_resolution/legacy.rs");
 
 include!("store_resolution/collisions.rs");

--- a/crates/rulemorph_trace/tests/trace_writer/trace_ids/store_resolution/legacy.rs
+++ b/crates/rulemorph_trace/tests/trace_writer/trace_ids/store_resolution/legacy.rs
@@ -1,0 +1,139 @@
+#[tokio::test]
+async fn write_trace_bundle_sanitizes_legacy_trace_id() -> anyhow::Result<()> {
+    let temp_dir = unique_temp_dir();
+    let traces_dir = temp_dir.join("traces");
+    fs::create_dir_all(&traces_dir)?;
+
+    let legacy_path = traces_dir.join("legacy.json");
+    fs::write(
+        &legacy_path,
+        serde_json::to_string(&json!({
+            "trace_id": "legacy id/非",
+            "status": "ok"
+        }))?,
+    )?;
+
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let items = store.list().await?;
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].trace_id, "legacy_id__");
+    let loaded = store
+        .get(&items[0].trace_id)
+        .await?
+        .expect("trace should load");
+    assert_eq!(
+        loaded.get("trace_id").and_then(|value| value.as_str()),
+        Some("legacy_id__")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_trace_bundle_legacy_missing_trace_id_trace_filename_falls_back_to_hash()
+-> anyhow::Result<()> {
+    let temp_dir = unique_temp_dir();
+    let traces_dir = temp_dir.join("traces");
+    fs::create_dir_all(&traces_dir)?;
+
+    let legacy_path = traces_dir.join("trace.json");
+    fs::write(
+        &legacy_path,
+        serde_json::to_string(&json!({
+            "records": [],
+            "status": "ok"
+        }))?,
+    )?;
+
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let items = store.list().await?;
+    assert_eq!(items.len(), 1);
+    assert!(items[0].trace_id.starts_with("trace-"));
+    assert_ne!(items[0].trace_id, "trace");
+
+    let loaded = store
+        .get(&items[0].trace_id)
+        .await?
+        .expect("trace should load");
+    assert_eq!(
+        loaded.get("trace_id").and_then(|value| value.as_str()),
+        Some(items[0].trace_id.as_str())
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_trace_bundle_legacy_trace_id_trace_falls_back_to_hash() -> anyhow::Result<()> {
+    let temp_dir = unique_temp_dir();
+    let traces_dir = temp_dir.join("traces");
+    fs::create_dir_all(&traces_dir)?;
+
+    let legacy_path = traces_dir.join("legacy-trace.json");
+    fs::write(
+        &legacy_path,
+        serde_json::to_string(&json!({
+            "trace_id": "trace",
+            "records": [],
+            "status": "ok"
+        }))?,
+    )?;
+
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let items = store.list().await?;
+    assert_eq!(items.len(), 1);
+    assert!(items[0].trace_id.starts_with("trace-"));
+    assert_ne!(items[0].trace_id, "trace");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_trace_bundle_legacy_empty_trace_id_uses_file_stem() -> anyhow::Result<()> {
+    let temp_dir = unique_temp_dir();
+    let traces_dir = temp_dir.join("traces");
+    fs::create_dir_all(&traces_dir)?;
+
+    let legacy_path = traces_dir.join("legacy-custom.json");
+    fs::write(
+        &legacy_path,
+        serde_json::to_string(&json!({
+            "trace_id": "",
+            "status": "ok"
+        }))?,
+    )?;
+
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let items = store.list().await?;
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].trace_id, "legacy-custom");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_trace_bundle_legacy_dot_trace_id_uses_file_stem() -> anyhow::Result<()> {
+    let temp_dir = unique_temp_dir();
+    let traces_dir = temp_dir.join("traces");
+    fs::create_dir_all(&traces_dir)?;
+
+    for raw in [".", ".."] {
+        let legacy_path = traces_dir.join(format!("legacy-dot-{raw}.json"));
+        fs::write(
+            &legacy_path,
+            serde_json::to_string(&json!({
+                "trace_id": raw,
+                "status": "ok"
+            }))?,
+        )?;
+    }
+
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let items = store.list().await?;
+    let trace_ids: std::collections::HashSet<_> =
+        items.iter().map(|item| item.trace_id.as_str()).collect();
+    assert!(trace_ids.contains("legacy-dot-."));
+    assert!(trace_ids.contains("legacy-dot-.."));
+
+    Ok(())
+}


### PR DESCRIPTION
Summary:
- Move legacy trace-id resolution trace writer tests into an included test file.
- Keep manifest trace-id tests and collision tests represented in the same integration test crate.
- Keep test names, top-level integration discovery, assertions, and coverage unchanged.
- No TraceStore/TraceWriter behavior, public API, trace schema, CLI/MCP/HTTP contract, docs, or specs changes.

Verification:
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer legacy_trace_id -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer legacy_ -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer manifest_trace_id -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer trace_id -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- post-commit/base-update: env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer trace_id -- --test-threads=1
- post-commit/base-update: cargo fmt --check
- post-commit/base-update: git diff --check origin/v0.3.1...HEAD