### PR TITLE
Refactor string record index tests

### DIFF
--- a/crates/rulemorph_trace/tests/trace_writer/node_record_indexes/record_index.rs
+++ b/crates/rulemorph_trace/tests/trace_writer/node_record_indexes/record_index.rs
@@ -70,67 +70,7 @@ async fn write_trace_bundle_inherits_record_index_for_legacy_wrapper() -> anyhow
 
     Ok(())
 }
-#[tokio::test]
-async fn write_trace_bundle_parses_string_record_index() -> anyhow::Result<()> {
-    let temp_dir = create_temp_dir()?;
-
-    let trace = json!({
-        "trace_id": "trace-nodes-string-index",
-        "records": [
-            {
-                "index": 0,
-                "status": "ok",
-                "nodes": [
-                    { "id": "n1", "kind": "mappings", "status": "ok" }
-                ]
-            }
-        ]
-    });
-
-    let options = TraceWriteOptions {
-        compression: TraceCompression::None,
-        split_nodes: true,
-        ..Default::default()
-    };
-
-    let manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
-    let manifest = read_manifest(&manifest_path)?;
-    let detail = manifest.detail.expect("detail should exist");
-    let trace_dir = trace_dir(&manifest_path);
-    let record_chunk = &detail.records[0];
-    let record_chunk_path = trace_dir.join(&record_chunk.path);
-
-    let mut lines = read_ndjson_lines(&record_chunk_path)?;
-    let mut record: serde_json::Value = serde_json::from_str(&lines[0])?;
-    if let Some(obj) = record.as_object_mut() {
-        obj.insert(
-            "index".to_string(),
-            serde_json::Value::String("0".to_string()),
-        );
-    }
-    lines[0] = serde_json::to_string(&record)?;
-    write_ndjson_lines(&record_chunk_path, &lines)?;
-
-    let store = TraceStore::new(temp_dir.clone()).await?;
-    let loaded = store
-        .get("trace-nodes-string-index")
-        .await?
-        .expect("trace should load");
-    let records = loaded
-        .get("records")
-        .and_then(|value| value.as_array())
-        .expect("records should exist");
-    let nodes_first = records[0]
-        .get("nodes")
-        .and_then(|value| value.as_array())
-        .expect("first nodes should be array");
-    assert_eq!(
-        nodes_first[0].get("id").and_then(|value| value.as_str()),
-        Some("n1")
-    );
-
-    Ok(())
-}
+include!("record_index/string.rs");
 
 include!("record_index/invalid_missing.rs");
 
@@ -180,57 +120,6 @@ async fn write_trace_bundle_dedupes_duplicate_record_index() -> anyhow::Result<(
         .collect();
     node_indices.sort_unstable();
     assert_eq!(node_indices, vec![1, 2]);
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn write_trace_bundle_accepts_string_record_index() -> anyhow::Result<()> {
-    let temp_dir = create_temp_dir()?;
-
-    let trace = json!({
-        "trace_id": "trace-string-index-input",
-        "records": [
-            {
-                "index": "2",
-                "status": "ok",
-                "nodes": [
-                    { "id": "n1", "kind": "mappings", "status": "ok" }
-                ]
-            }
-        ]
-    });
-
-    let options = TraceWriteOptions {
-        compression: TraceCompression::None,
-        split_nodes: true,
-        ..Default::default()
-    };
-
-    let manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
-    let manifest = read_manifest(&manifest_path)?;
-    let detail = manifest.detail.expect("detail should exist");
-    let trace_dir = trace_dir(&manifest_path);
-
-    let record_chunk = &detail.records[0];
-    let record = read_ndjson_values(trace_dir.join(&record_chunk.path))?
-        .into_iter()
-        .next()
-        .expect("record line should exist");
-    assert_eq!(
-        record.get("index").and_then(|value| value.as_u64()),
-        Some(2)
-    );
-
-    let node_chunk = &detail.nodes[0];
-    let node = read_ndjson_values(trace_dir.join(&node_chunk.path))?
-        .into_iter()
-        .next()
-        .expect("node line should exist");
-    assert_eq!(
-        node.get("record_index").and_then(|value| value.as_u64()),
-        Some(2)
-    );
 
     Ok(())
 }
@@ -304,68 +193,6 @@ async fn write_trace_bundle_first_wins_duplicate_record_index() -> anyhow::Resul
     let nodes_second = records[1].get("nodes");
     assert_eq!(nodes_first.len(), 2);
     assert!(nodes_second.is_none());
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn write_trace_bundle_parses_string_record_index_in_nodes() -> anyhow::Result<()> {
-    let temp_dir = create_temp_dir()?;
-
-    let trace = json!({
-        "trace_id": "trace-nodes-string-index-line",
-        "records": [
-            {
-                "status": "ok",
-                "nodes": [
-                    { "id": "n1", "kind": "mappings", "status": "ok" }
-                ]
-            }
-        ]
-    });
-
-    let options = TraceWriteOptions {
-        compression: TraceCompression::None,
-        split_nodes: true,
-        ..Default::default()
-    };
-
-    let manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
-    let manifest = read_manifest(&manifest_path)?;
-    let detail = manifest.detail.expect("detail should exist");
-    let trace_dir = trace_dir(&manifest_path);
-    let node_chunk = &detail.nodes[0];
-    let node_chunk_path = trace_dir.join(&node_chunk.path);
-
-    let mut lines = read_ndjson_lines(&node_chunk_path)?;
-    let mut node: serde_json::Value = serde_json::from_str(&lines[0])?;
-    if let Some(obj) = node.as_object_mut() {
-        obj.insert(
-            "record_index".to_string(),
-            serde_json::Value::String("0".to_string()),
-        );
-    }
-    lines[0] = serde_json::to_string(&node)?;
-    write_ndjson_lines(&node_chunk_path, &lines)?;
-
-    let store = TraceStore::new(temp_dir.clone()).await?;
-    let loaded = store
-        .get("trace-nodes-string-index-line")
-        .await?
-        .expect("trace should load");
-    let records = loaded
-        .get("records")
-        .and_then(|value| value.as_array())
-        .expect("records should exist");
-    let nodes_first = records[0]
-        .get("nodes")
-        .and_then(|value| value.as_array())
-        .expect("nodes should be array");
-    assert_eq!(nodes_first.len(), 1);
-    assert_eq!(
-        nodes_first[0].get("id").and_then(|value| value.as_str()),
-        Some("n1")
-    );
 
     Ok(())
 }

--- a/crates/rulemorph_trace/tests/trace_writer/node_record_indexes/record_index/string.rs
+++ b/crates/rulemorph_trace/tests/trace_writer/node_record_indexes/record_index/string.rs
@@ -1,0 +1,174 @@
+#[tokio::test]
+async fn write_trace_bundle_parses_string_record_index() -> anyhow::Result<()> {
+    let temp_dir = create_temp_dir()?;
+
+    let trace = json!({
+        "trace_id": "trace-nodes-string-index",
+        "records": [
+            {
+                "index": 0,
+                "status": "ok",
+                "nodes": [
+                    { "id": "n1", "kind": "mappings", "status": "ok" }
+                ]
+            }
+        ]
+    });
+
+    let options = TraceWriteOptions {
+        compression: TraceCompression::None,
+        split_nodes: true,
+        ..Default::default()
+    };
+
+    let manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
+    let manifest = read_manifest(&manifest_path)?;
+    let detail = manifest.detail.expect("detail should exist");
+    let trace_dir = trace_dir(&manifest_path);
+    let record_chunk = &detail.records[0];
+    let record_chunk_path = trace_dir.join(&record_chunk.path);
+
+    let mut lines = read_ndjson_lines(&record_chunk_path)?;
+    let mut record: serde_json::Value = serde_json::from_str(&lines[0])?;
+    if let Some(obj) = record.as_object_mut() {
+        obj.insert(
+            "index".to_string(),
+            serde_json::Value::String("0".to_string()),
+        );
+    }
+    lines[0] = serde_json::to_string(&record)?;
+    write_ndjson_lines(&record_chunk_path, &lines)?;
+
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let loaded = store
+        .get("trace-nodes-string-index")
+        .await?
+        .expect("trace should load");
+    let records = loaded
+        .get("records")
+        .and_then(|value| value.as_array())
+        .expect("records should exist");
+    let nodes_first = records[0]
+        .get("nodes")
+        .and_then(|value| value.as_array())
+        .expect("first nodes should be array");
+    assert_eq!(
+        nodes_first[0].get("id").and_then(|value| value.as_str()),
+        Some("n1")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_trace_bundle_accepts_string_record_index() -> anyhow::Result<()> {
+    let temp_dir = create_temp_dir()?;
+
+    let trace = json!({
+        "trace_id": "trace-string-index-input",
+        "records": [
+            {
+                "index": "2",
+                "status": "ok",
+                "nodes": [
+                    { "id": "n1", "kind": "mappings", "status": "ok" }
+                ]
+            }
+        ]
+    });
+
+    let options = TraceWriteOptions {
+        compression: TraceCompression::None,
+        split_nodes: true,
+        ..Default::default()
+    };
+
+    let manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
+    let manifest = read_manifest(&manifest_path)?;
+    let detail = manifest.detail.expect("detail should exist");
+    let trace_dir = trace_dir(&manifest_path);
+
+    let record_chunk = &detail.records[0];
+    let record = read_ndjson_values(trace_dir.join(&record_chunk.path))?
+        .into_iter()
+        .next()
+        .expect("record line should exist");
+    assert_eq!(
+        record.get("index").and_then(|value| value.as_u64()),
+        Some(2)
+    );
+
+    let node_chunk = &detail.nodes[0];
+    let node = read_ndjson_values(trace_dir.join(&node_chunk.path))?
+        .into_iter()
+        .next()
+        .expect("node line should exist");
+    assert_eq!(
+        node.get("record_index").and_then(|value| value.as_u64()),
+        Some(2)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_trace_bundle_parses_string_record_index_in_nodes() -> anyhow::Result<()> {
+    let temp_dir = create_temp_dir()?;
+
+    let trace = json!({
+        "trace_id": "trace-nodes-string-index-line",
+        "records": [
+            {
+                "status": "ok",
+                "nodes": [
+                    { "id": "n1", "kind": "mappings", "status": "ok" }
+                ]
+            }
+        ]
+    });
+
+    let options = TraceWriteOptions {
+        compression: TraceCompression::None,
+        split_nodes: true,
+        ..Default::default()
+    };
+
+    let manifest_path = write_trace_bundle(&temp_dir, &trace, Some(options)).await?;
+    let manifest = read_manifest(&manifest_path)?;
+    let detail = manifest.detail.expect("detail should exist");
+    let trace_dir = trace_dir(&manifest_path);
+    let node_chunk = &detail.nodes[0];
+    let node_chunk_path = trace_dir.join(&node_chunk.path);
+
+    let mut lines = read_ndjson_lines(&node_chunk_path)?;
+    let mut node: serde_json::Value = serde_json::from_str(&lines[0])?;
+    if let Some(obj) = node.as_object_mut() {
+        obj.insert(
+            "record_index".to_string(),
+            serde_json::Value::String("0".to_string()),
+        );
+    }
+    lines[0] = serde_json::to_string(&node)?;
+    write_ndjson_lines(&node_chunk_path, &lines)?;
+
+    let store = TraceStore::new(temp_dir.clone()).await?;
+    let loaded = store
+        .get("trace-nodes-string-index-line")
+        .await?
+        .expect("trace should load");
+    let records = loaded
+        .get("records")
+        .and_then(|value| value.as_array())
+        .expect("records should exist");
+    let nodes_first = records[0]
+        .get("nodes")
+        .and_then(|value| value.as_array())
+        .expect("nodes should be array");
+    assert_eq!(nodes_first.len(), 1);
+    assert_eq!(
+        nodes_first[0].get("id").and_then(|value| value.as_str()),
+        Some("n1")
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Summary:
- Move string record_index trace writer tests into an included test file.
- Keep legacy wrapper, invalid/missing, and duplicate/first-wins record_index tests represented.
- Keep test names, top-level integration discovery, assertions, and coverage unchanged.
- No TraceStore/TraceWriter behavior, public API, trace schema, CLI/MCP/HTTP contract, docs, or specs changes.

Verification:
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer string_record_index -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer record_index -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- post-commit: env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer record_index -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD