### PR TITLE
Refactor array scoped predicate operators

### DIFF
--- a/crates/rulemorph/src/transform/operators/array.rs
+++ b/crates/rulemorph/src/transform/operators/array.rs
@@ -7,10 +7,12 @@ mod sequence;
 
 pub(super) use self::aggregate::{eval_array_avg, eval_array_max, eval_array_min, eval_array_sum};
 pub(super) use self::equality::{eval_array_contains, eval_array_index_of, eval_array_unique};
+pub(super) use self::scoped::predicate::{
+    eval_array_filter, eval_array_find, eval_array_find_index, eval_array_partition,
+};
 pub(super) use self::scoped::{
-    eval_array_distinct_by, eval_array_filter, eval_array_find, eval_array_find_index,
-    eval_array_flat_map, eval_array_fold, eval_array_group_by, eval_array_key_by, eval_array_map,
-    eval_array_partition, eval_array_reduce, eval_array_sort_by,
+    eval_array_distinct_by, eval_array_flat_map, eval_array_fold, eval_array_group_by,
+    eval_array_key_by, eval_array_map, eval_array_reduce, eval_array_sort_by,
 };
 pub(super) use self::sequence::{
     eval_array_chunk, eval_array_drop, eval_array_flatten, eval_array_slice, eval_array_take,

--- a/crates/rulemorph/src/transform/operators/array/scoped.rs
+++ b/crates/rulemorph/src/transform/operators/array/scoped.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+pub(super) mod predicate;
+
 pub(in crate::transform::operators) fn eval_array_map(
     args: &[Expr],
     injected: Option<&EvalValue>,
@@ -34,46 +36,6 @@ pub(in crate::transform::operators) fn eval_array_map(
         let item_locals = locals_with_item(locals, EvalItem { value: item, index });
         let value = eval_expr_or_null(expr, record, context, out, &expr_path, Some(&item_locals))?;
         results.push(value);
-    }
-
-    Ok(EvalValue::Value(JsonValue::Array(results)))
-}
-
-pub(in crate::transform::operators) fn eval_array_filter(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len != 2 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain exactly two items",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
-    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args index is out of bounds",
-        )
-        .with_path(format!("{}.args[1]", base_path))
-    })?;
-    let expr_index = if injected.is_some() { 0 } else { 1 };
-    let expr_path = format!("{}.args[{}]", base_path, expr_index);
-
-    let mut results = Vec::new();
-    for (index, item) in array.iter().enumerate() {
-        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
-        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
-            results.push(item.clone());
-        }
     }
 
     Ok(EvalValue::Value(JsonValue::Array(results)))
@@ -202,52 +164,6 @@ pub(in crate::transform::operators) fn eval_array_key_by(
     }
 
     Ok(EvalValue::Value(JsonValue::Object(results)))
-}
-
-pub(in crate::transform::operators) fn eval_array_partition(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len != 2 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain exactly two items",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
-    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args index is out of bounds",
-        )
-        .with_path(format!("{}.args[1]", base_path))
-    })?;
-    let expr_index = if injected.is_some() { 0 } else { 1 };
-    let expr_path = format!("{}.args[{}]", base_path, expr_index);
-
-    let mut matched = Vec::new();
-    let mut unmatched = Vec::new();
-    for (index, item) in array.iter().enumerate() {
-        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
-        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
-            matched.push(item.clone());
-        } else {
-            unmatched.push(item.clone());
-        }
-    }
-
-    Ok(EvalValue::Value(JsonValue::Array(vec![
-        JsonValue::Array(matched),
-        JsonValue::Array(unmatched),
-    ])))
 }
 
 pub(in crate::transform::operators) fn eval_array_distinct_by(
@@ -387,84 +303,6 @@ pub(in crate::transform::operators) fn eval_array_sort_by(
 
     let results = items.into_iter().map(|item| item.value).collect::<Vec<_>>();
     Ok(EvalValue::Value(JsonValue::Array(results)))
-}
-
-pub(in crate::transform::operators) fn eval_array_find(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len != 2 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain exactly two items",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
-    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args index is out of bounds",
-        )
-        .with_path(format!("{}.args[1]", base_path))
-    })?;
-    let expr_index = if injected.is_some() { 0 } else { 1 };
-    let expr_path = format!("{}.args[{}]", base_path, expr_index);
-
-    for (index, item) in array.iter().enumerate() {
-        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
-        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
-            return Ok(EvalValue::Value(item.clone()));
-        }
-    }
-
-    Ok(EvalValue::Value(JsonValue::Null))
-}
-
-pub(in crate::transform::operators) fn eval_array_find_index(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len != 2 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain exactly two items",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
-    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args index is out of bounds",
-        )
-        .with_path(format!("{}.args[1]", base_path))
-    })?;
-    let expr_index = if injected.is_some() { 0 } else { 1 };
-    let expr_path = format!("{}.args[{}]", base_path, expr_index);
-
-    for (index, item) in array.iter().enumerate() {
-        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
-        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
-            return Ok(EvalValue::Value(JsonValue::Number((index as i64).into())));
-        }
-    }
-
-    Ok(EvalValue::Value(JsonValue::Number((-1).into())))
 }
 
 pub(in crate::transform::operators) fn eval_array_reduce(

--- a/crates/rulemorph/src/transform/operators/array/scoped/predicate.rs
+++ b/crates/rulemorph/src/transform/operators/array/scoped/predicate.rs
@@ -1,0 +1,165 @@
+use super::super::*;
+
+pub(in crate::transform::operators) fn eval_array_filter(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
+    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[1]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 0 } else { 1 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    let mut results = Vec::new();
+    for (index, item) in array.iter().enumerate() {
+        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
+        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
+            results.push(item.clone());
+        }
+    }
+
+    Ok(EvalValue::Value(JsonValue::Array(results)))
+}
+
+pub(in crate::transform::operators) fn eval_array_partition(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
+    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[1]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 0 } else { 1 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    let mut matched = Vec::new();
+    let mut unmatched = Vec::new();
+    for (index, item) in array.iter().enumerate() {
+        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
+        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
+            matched.push(item.clone());
+        } else {
+            unmatched.push(item.clone());
+        }
+    }
+
+    Ok(EvalValue::Value(JsonValue::Array(vec![
+        JsonValue::Array(matched),
+        JsonValue::Array(unmatched),
+    ])))
+}
+
+pub(in crate::transform::operators) fn eval_array_find(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
+    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[1]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 0 } else { 1 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    for (index, item) in array.iter().enumerate() {
+        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
+        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
+            return Ok(EvalValue::Value(item.clone()));
+        }
+    }
+
+    Ok(EvalValue::Value(JsonValue::Null))
+}
+
+pub(in crate::transform::operators) fn eval_array_find_index(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
+    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[1]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 0 } else { 1 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    for (index, item) in array.iter().enumerate() {
+        let item_locals = locals_with_item(locals, EvalItem { value: item, index });
+        if eval_predicate_expr(expr, record, context, out, &expr_path, Some(&item_locals))? {
+            return Ok(EvalValue::Value(JsonValue::Number((index as i64).into())));
+        }
+    }
+
+    Ok(EvalValue::Value(JsonValue::Number((-1).into())))
+}


### PR DESCRIPTION
## Summary
- move scoped array predicate/search operators into array/scoped/predicate.rs
- keep array dispatch re-export surface intact
- leave transform semantics, trace schema, and public APIs unchanged

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo check -p rulemorph
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_golden t16_array_ops -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics collection -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph
- cargo fmt --check
- git diff --check

Note: workspace cargo test was attempted with and without CARGO_BUILD_JOBS=1, but endpoint/server compile stalled for a long period and was stopped. The changed crate and focused semantics tests passed.