### PR TITLE
Refactor traced v2 collection predicates

### DIFF
--- a/crates/rulemorph/src/transform/v2_trace/collection.rs
+++ b/crates/rulemorph/src/transform/v2_trace/collection.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+mod predicate;
 mod sort;
 
+use predicate::eval_v2_predicate_collection_traced;
 use sort::eval_v2_sort_by_traced;
 pub(in crate::transform) use sort::sort_key_to_json;
 
@@ -181,75 +183,9 @@ pub(in crate::transform) fn eval_v2_collection_op_traced<'a>(
             }
             Ok(V2EvalValue::Value(JsonValue::Array(results)))
         }
-        "filter" | "partition" | "find" | "find_index" => {
-            if op_step.args.len() != 1 {
-                return Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    format!("{operator} requires exactly one argument"),
-                )
-                .with_path(path));
-            }
-            let array = v2_eval_array_from_value(pipe_value, path)?;
-            let arg_path = format!("{}.args[0]", path);
-            let mut kept = Vec::new();
-            let mut rejected = Vec::new();
-            for (index, item) in array.iter().enumerate() {
-                let item_path = format!("{}[{}]", path, index);
-                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
-                let item_ctx = step_ctx
-                    .clone()
-                    .with_pipe_value(V2EvalValue::Value(item.clone()))
-                    .with_item(V2EvalItem { value: item, index });
-                let matches = eval_v2_predicate_expr_traced(
-                    &op_step.args[0],
-                    record,
-                    context,
-                    out,
-                    &arg_path,
-                    &item_ctx,
-                    collector,
-                )?;
-                let match_value = V2EvalValue::Value(JsonValue::Bool(matches));
-                emit_v2_arg_eval(collector, &arg_path, 0, operator, &match_value);
-                finish_v2_collection_item(
-                    collector,
-                    &item_path,
-                    operator,
-                    index,
-                    &match_value,
-                    Some(("matched", matches)),
-                );
-                match operator {
-                    "filter" => {
-                        if matches {
-                            kept.push(item.clone());
-                        }
-                    }
-                    "partition" => {
-                        if matches {
-                            kept.push(item.clone());
-                        } else {
-                            rejected.push(item.clone());
-                        }
-                    }
-                    "find" if matches => return Ok(V2EvalValue::Value(item.clone())),
-                    "find_index" if matches => {
-                        return Ok(V2EvalValue::Value(JsonValue::Number((index as i64).into())));
-                    }
-                    _ => {}
-                }
-            }
-            match operator {
-                "filter" => Ok(V2EvalValue::Value(JsonValue::Array(kept))),
-                "partition" => Ok(V2EvalValue::Value(JsonValue::Array(vec![
-                    JsonValue::Array(kept),
-                    JsonValue::Array(rejected),
-                ]))),
-                "find" => Ok(V2EvalValue::Value(JsonValue::Null)),
-                "find_index" => Ok(V2EvalValue::Value(JsonValue::Number((-1).into()))),
-                _ => unreachable!(),
-            }
-        }
+        "filter" | "partition" | "find" | "find_index" => eval_v2_predicate_collection_traced(
+            op_step, pipe_value, record, context, out, path, &step_ctx, collector,
+        ),
         "flat_map" => {
             if op_step.args.len() != 1 {
                 return Err(TransformError::new(

--- a/crates/rulemorph/src/transform/v2_trace/collection/predicate.rs
+++ b/crates/rulemorph/src/transform/v2_trace/collection/predicate.rs
@@ -1,0 +1,82 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn eval_v2_predicate_collection_traced<'a>(
+    op_step: &crate::v2_model::V2OpStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    step_ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    let operator = op_step.op.as_str();
+    if op_step.args.len() != 1 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            format!("{operator} requires exactly one argument"),
+        )
+        .with_path(path));
+    }
+    let array = v2_eval_array_from_value(pipe_value, path)?;
+    let arg_path = format!("{}.args[0]", path);
+    let mut kept = Vec::new();
+    let mut rejected = Vec::new();
+    for (index, item) in array.iter().enumerate() {
+        let item_path = format!("{}[{}]", path, index);
+        emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+        let item_ctx = step_ctx
+            .clone()
+            .with_pipe_value(V2EvalValue::Value(item.clone()))
+            .with_item(V2EvalItem { value: item, index });
+        let matches = eval_v2_predicate_expr_traced(
+            &op_step.args[0],
+            record,
+            context,
+            out,
+            &arg_path,
+            &item_ctx,
+            collector,
+        )?;
+        let match_value = V2EvalValue::Value(JsonValue::Bool(matches));
+        emit_v2_arg_eval(collector, &arg_path, 0, operator, &match_value);
+        finish_v2_collection_item(
+            collector,
+            &item_path,
+            operator,
+            index,
+            &match_value,
+            Some(("matched", matches)),
+        );
+        match operator {
+            "filter" => {
+                if matches {
+                    kept.push(item.clone());
+                }
+            }
+            "partition" => {
+                if matches {
+                    kept.push(item.clone());
+                } else {
+                    rejected.push(item.clone());
+                }
+            }
+            "find" if matches => return Ok(V2EvalValue::Value(item.clone())),
+            "find_index" if matches => {
+                return Ok(V2EvalValue::Value(JsonValue::Number((index as i64).into())));
+            }
+            _ => {}
+        }
+    }
+    match operator {
+        "filter" => Ok(V2EvalValue::Value(JsonValue::Array(kept))),
+        "partition" => Ok(V2EvalValue::Value(JsonValue::Array(vec![
+            JsonValue::Array(kept),
+            JsonValue::Array(rejected),
+        ]))),
+        "find" => Ok(V2EvalValue::Value(JsonValue::Null)),
+        "find_index" => Ok(V2EvalValue::Value(JsonValue::Number((-1).into()))),
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
## Summary
- Extract traced v2 filter, partition, find, and find_index collection handling into a private helper module
- Keep collection item tracing lifecycle, matched attributes, and return behavior unchanged

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics collection -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace trace_v2_filter_preserves_item_scope -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace trace_v2_pipe_operator_lifecycle_and_collection_items -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test v2_collection_ops -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph -- --test-threads=1
- cargo fmt --check
- git diff --check