### PR TITLE
Refactor trace writer manifest payload write

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer/bundle.rs
+++ b/crates/rulemorph_trace/src/trace_writer/bundle.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 
-use super::atomic::write_atomic;
 use super::chunk_write::{
     max_ndjson_line_bytes, total_chunk_bytes, write_finalize_chunk, write_node_chunks,
     write_record_chunks,
@@ -21,9 +20,12 @@ use super::trace_dir::{
 };
 use super::trace_identity::resolve_trace_id;
 use crate::trace_schema::{
-    TRACE_CHUNK_COUNT_HARD_MAX, TRACE_JSON_MAX_BYTES, TRACE_NODE_COUNT_HARD_MAX,
-    TRACE_RECORD_COUNT_HARD_MAX, TraceDetailRef, TraceManifest, TraceMasking,
+    TRACE_CHUNK_COUNT_HARD_MAX, TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX,
+    TraceDetailRef, TraceManifest, TraceMasking,
 };
+
+mod manifest_payload;
+use self::manifest_payload::write_manifest_payload;
 
 const TRACE_SCHEMA_VERSION: u8 = 1;
 
@@ -336,29 +338,7 @@ pub(crate) fn write_trace_bundle_sync(
     }
 
     let manifest_path = trace_dir.join("trace.json");
-    let mut manifest_payload = serde_json::to_string_pretty(&manifest)?;
-    if manifest_payload.len() as u64 > TRACE_JSON_MAX_BYTES {
-        if manifest.rule_source.is_some() {
-            manifest.rule_source = None;
-            if !detail
-                .reason
-                .iter()
-                .any(|reason| reason == "rule_source_dropped")
-            {
-                detail.reason.push("rule_source_dropped".to_string());
-            }
-            manifest.detail = Some(detail.clone());
-            manifest_payload = serde_json::to_string_pretty(&manifest)?;
-        }
-        if manifest_payload.len() as u64 > TRACE_JSON_MAX_BYTES {
-            return Err(anyhow::anyhow!(
-                "trace json exceeds max bytes: {} > {}",
-                manifest_payload.len(),
-                TRACE_JSON_MAX_BYTES
-            ));
-        }
-    }
-    write_atomic(&manifest_path, manifest_payload.as_bytes())?;
+    write_manifest_payload(&manifest_path, &mut manifest, &mut detail)?;
     trace_dir_guard.commit();
 
     Ok(manifest_path)

--- a/crates/rulemorph_trace/src/trace_writer/bundle/manifest_payload.rs
+++ b/crates/rulemorph_trace/src/trace_writer/bundle/manifest_payload.rs
@@ -1,0 +1,36 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::super::atomic::write_atomic;
+use crate::trace_schema::{TRACE_JSON_MAX_BYTES, TraceDetailRef, TraceManifest};
+
+pub(super) fn write_manifest_payload(
+    manifest_path: &Path,
+    manifest: &mut TraceManifest,
+    detail: &mut TraceDetailRef,
+) -> Result<()> {
+    let mut manifest_payload = serde_json::to_string_pretty(manifest)?;
+    if manifest_payload.len() as u64 > TRACE_JSON_MAX_BYTES {
+        if manifest.rule_source.is_some() {
+            manifest.rule_source = None;
+            if !detail
+                .reason
+                .iter()
+                .any(|reason| reason == "rule_source_dropped")
+            {
+                detail.reason.push("rule_source_dropped".to_string());
+            }
+            manifest.detail = Some(detail.clone());
+            manifest_payload = serde_json::to_string_pretty(manifest)?;
+        }
+        if manifest_payload.len() as u64 > TRACE_JSON_MAX_BYTES {
+            return Err(anyhow::anyhow!(
+                "trace json exceeds max bytes: {} > {}",
+                manifest_payload.len(),
+                TRACE_JSON_MAX_BYTES
+            ));
+        }
+    }
+    write_atomic(manifest_path, manifest_payload.as_bytes())
+}


### PR DESCRIPTION
## Summary
- move manifest serialization and TRACE_JSON_MAX_BYTES fallback into trace_writer/bundle/manifest_payload.rs
- keep trace writing orchestration and TraceManifest field assembly in bundle.rs
- no behavior, schema, public API, CLI/MCP/HTTP, transform semantics, or docs/spec changes

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_drops_rule_source_when_manifest_too_large -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_drops_oversized_rule_source -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD