### PR TITLE
Refactor trace writer externalized node traversal

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer/externalize.rs
+++ b/crates/rulemorph_trace/src/trace_writer/externalize.rs
@@ -7,8 +7,10 @@ use serde_json::{Value as JsonValue, json};
 use super::TraceWriteOptions;
 
 mod blob;
+mod node;
 
 use blob::{WriteBlobResult, build_payload_preview, write_blob};
+use node::externalize_node_payloads;
 
 pub(super) fn externalize_trace_payloads(
     trace: &mut JsonValue,
@@ -138,124 +140,6 @@ fn externalize_record_payloads(
                 }
             }
             _ => {}
-        }
-    }
-    if let Some(child_trace) = obj.get_mut("child_trace") {
-        if externalize_trace_payloads_inner(
-            child_trace,
-            trace_dir,
-            options,
-            seen,
-            budget_remaining,
-            blob_files,
-        )? {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-fn externalize_node_payloads(
-    node: &mut JsonValue,
-    trace_dir: &Path,
-    options: &TraceWriteOptions,
-    seen: &mut HashSet<String>,
-    budget_remaining: &mut u64,
-    blob_files: &mut Vec<PathBuf>,
-) -> Result<bool> {
-    let Some(obj) = node.as_object_mut() else {
-        return Ok(false);
-    };
-    if let Some(input) = obj.get_mut("input") {
-        if maybe_externalize_payload(
-            input,
-            trace_dir,
-            options,
-            seen,
-            budget_remaining,
-            blob_files,
-        )? {
-            return Ok(true);
-        }
-    }
-    if let Some(output) = obj.get_mut("output") {
-        if maybe_externalize_payload(
-            output,
-            trace_dir,
-            options,
-            seen,
-            budget_remaining,
-            blob_files,
-        )? {
-            return Ok(true);
-        }
-    }
-    if let Some(args) = obj.get_mut("args") {
-        if maybe_externalize_payload(args, trace_dir, options, seen, budget_remaining, blob_files)?
-        {
-            return Ok(true);
-        }
-    }
-    if let Some(pipe_value) = obj.get_mut("pipe_value") {
-        if maybe_externalize_payload(
-            pipe_value,
-            trace_dir,
-            options,
-            seen,
-            budget_remaining,
-            blob_files,
-        )? {
-            return Ok(true);
-        }
-    }
-    if let Some(pipe_steps) = obj
-        .get_mut("pipe_steps")
-        .and_then(|value| value.as_array_mut())
-    {
-        for step in pipe_steps {
-            if let Some(step_obj) = step.as_object_mut() {
-                if let Some(input) = step_obj.get_mut("input") {
-                    if maybe_externalize_payload(
-                        input,
-                        trace_dir,
-                        options,
-                        seen,
-                        budget_remaining,
-                        blob_files,
-                    )? {
-                        return Ok(true);
-                    }
-                }
-                if let Some(output) = step_obj.get_mut("output") {
-                    if maybe_externalize_payload(
-                        output,
-                        trace_dir,
-                        options,
-                        seen,
-                        budget_remaining,
-                        blob_files,
-                    )? {
-                        return Ok(true);
-                    }
-                }
-            }
-        }
-    }
-    if let Some(children) = obj
-        .get_mut("children")
-        .and_then(|value| value.as_array_mut())
-    {
-        for child in children {
-            if externalize_node_payloads(
-                child,
-                trace_dir,
-                options,
-                seen,
-                budget_remaining,
-                blob_files,
-            )? {
-                return Ok(true);
-            }
         }
     }
     if let Some(child_trace) = obj.get_mut("child_trace") {

--- a/crates/rulemorph_trace/src/trace_writer/externalize/node.rs
+++ b/crates/rulemorph_trace/src/trace_writer/externalize/node.rs
@@ -1,0 +1,126 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde_json::Value as JsonValue;
+
+use super::{externalize_trace_payloads_inner, maybe_externalize_payload};
+use crate::trace_writer::TraceWriteOptions;
+
+pub(super) fn externalize_node_payloads(
+    node: &mut JsonValue,
+    trace_dir: &Path,
+    options: &TraceWriteOptions,
+    seen: &mut HashSet<String>,
+    budget_remaining: &mut u64,
+    blob_files: &mut Vec<PathBuf>,
+) -> Result<bool> {
+    let Some(obj) = node.as_object_mut() else {
+        return Ok(false);
+    };
+    if let Some(input) = obj.get_mut("input") {
+        if maybe_externalize_payload(
+            input,
+            trace_dir,
+            options,
+            seen,
+            budget_remaining,
+            blob_files,
+        )? {
+            return Ok(true);
+        }
+    }
+    if let Some(output) = obj.get_mut("output") {
+        if maybe_externalize_payload(
+            output,
+            trace_dir,
+            options,
+            seen,
+            budget_remaining,
+            blob_files,
+        )? {
+            return Ok(true);
+        }
+    }
+    if let Some(args) = obj.get_mut("args") {
+        if maybe_externalize_payload(args, trace_dir, options, seen, budget_remaining, blob_files)?
+        {
+            return Ok(true);
+        }
+    }
+    if let Some(pipe_value) = obj.get_mut("pipe_value") {
+        if maybe_externalize_payload(
+            pipe_value,
+            trace_dir,
+            options,
+            seen,
+            budget_remaining,
+            blob_files,
+        )? {
+            return Ok(true);
+        }
+    }
+    if let Some(pipe_steps) = obj
+        .get_mut("pipe_steps")
+        .and_then(|value| value.as_array_mut())
+    {
+        for step in pipe_steps {
+            if let Some(step_obj) = step.as_object_mut() {
+                if let Some(input) = step_obj.get_mut("input") {
+                    if maybe_externalize_payload(
+                        input,
+                        trace_dir,
+                        options,
+                        seen,
+                        budget_remaining,
+                        blob_files,
+                    )? {
+                        return Ok(true);
+                    }
+                }
+                if let Some(output) = step_obj.get_mut("output") {
+                    if maybe_externalize_payload(
+                        output,
+                        trace_dir,
+                        options,
+                        seen,
+                        budget_remaining,
+                        blob_files,
+                    )? {
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+    }
+    if let Some(children) = obj
+        .get_mut("children")
+        .and_then(|value| value.as_array_mut())
+    {
+        for child in children {
+            if externalize_node_payloads(
+                child,
+                trace_dir,
+                options,
+                seen,
+                budget_remaining,
+                blob_files,
+            )? {
+                return Ok(true);
+            }
+        }
+    }
+    if let Some(child_trace) = obj.get_mut("child_trace") {
+        if externalize_trace_payloads_inner(
+            child_trace,
+            trace_dir,
+            options,
+            seen,
+            budget_remaining,
+            blob_files,
+        )? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}


### PR DESCRIPTION
## Summary
- move externalized node payload traversal into trace_writer/externalize/node.rs
- keep record/finalize traversal and payload replacement in externalize.rs
- no behavior, schema, public API, CLI/MCP/HTTP, transform semantics, or docs/spec changes

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer externalized -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_counts_blob_bytes_in_budget -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_masks_preview_for_externalized_payloads -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD