### PR TITLE
Refactor trace store read value helper

### DIFF
--- a/crates/rulemorph_trace/src/trace_store/file_backend.rs
+++ b/crates/rulemorph_trace/src/trace_store/file_backend.rs
@@ -21,7 +21,7 @@ use super::index::build_trace_index;
 use super::legacy::{apply_legacy_limits, looks_like_legacy_trace};
 use super::manifest_budget::{apply_manifest_budget, apply_record_total_budget_for_get};
 use super::manifest_trace::build_trace_from_manifest_async;
-use super::meta::{is_manifest, read_trace_json_with_limit_async};
+use super::meta::{is_manifest, read_trace_value_with_limit_async};
 use super::purge::purge_trace_metas;
 use super::{ImportResult, PurgeReport, TraceMeta, TraceNodeChunkEntry, rules_dir, traces_dir};
 
@@ -70,15 +70,7 @@ impl FileTraceBackend {
             None => return Ok(None),
         };
         let path = PathBuf::from(&meta.path);
-        let raw = read_trace_json_with_limit_async(&path).await?;
-        let parse_result = tokio::task::spawn_blocking({
-            let raw = raw.clone();
-            move || serde_json::from_str::<Value>(&raw)
-        })
-        .await
-        .map_err(|err| anyhow::anyhow!("trace json parse task failed: {}", err))?;
-        let value: Value =
-            parse_result.with_context(|| format!("invalid trace json: {}", path.display()))?;
+        let value = read_trace_value_with_limit_async(&path).await?;
         if is_manifest(&value) {
             let mut manifest: TraceManifest = serde_json::from_value(value)
                 .with_context(|| format!("invalid trace manifest: {}", path.display()))?;
@@ -155,15 +147,7 @@ impl FileTraceBackend {
             None => return Ok(None),
         };
         let path = PathBuf::from(&meta.path);
-        let raw = read_trace_json_with_limit_async(&path).await?;
-        let parse_result = tokio::task::spawn_blocking({
-            let raw = raw.clone();
-            move || serde_json::from_str::<Value>(&raw)
-        })
-        .await
-        .map_err(|err| anyhow::anyhow!("trace json parse task failed: {}", err))?;
-        let value: Value =
-            parse_result.with_context(|| format!("invalid trace json: {}", path.display()))?;
+        let value = read_trace_value_with_limit_async(&path).await?;
         if !is_manifest(&value) {
             return Ok(None);
         }

--- a/crates/rulemorph_trace/src/trace_store/meta.rs
+++ b/crates/rulemorph_trace/src/trace_store/meta.rs
@@ -26,6 +26,17 @@ pub(super) async fn read_trace_json_with_limit_async(path: &Path) -> Result<Stri
         .with_context(|| format!("failed to read trace: {}", path.display()))
 }
 
+pub(super) async fn read_trace_value_with_limit_async(path: &Path) -> Result<Value> {
+    let raw = read_trace_json_with_limit_async(path).await?;
+    let parse_result = tokio::task::spawn_blocking({
+        let raw = raw.clone();
+        move || serde_json::from_str::<Value>(&raw)
+    })
+    .await
+    .map_err(|err| anyhow::anyhow!("trace json parse task failed: {}", err))?;
+    parse_result.with_context(|| format!("invalid trace json: {}", path.display()))
+}
+
 fn read_trace_json_with_limit(path: &Path) -> Result<String> {
     let metadata = std::fs::metadata(path)
         .with_context(|| format!("failed to read trace metadata: {}", path.display()))?;


### PR DESCRIPTION
## Summary
- move duplicated trace JSON read + parse logic into trace_store/meta.rs
- keep manifest/legacy handling and budget application in file_backend.rs
- no behavior, schema, public API, CLI/MCP/HTTP, transform semantics, or docs/spec changes

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_store trace_store_ignores_oversized_trace_json -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_sanitizes_manifest_trace_id_on_list_get -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_store -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD