### PR TITLE
Refactor trace store chunk read node helpers

### DIFF
--- a/crates/rulemorph_trace/src/trace_store/chunk_read.rs
+++ b/crates/rulemorph_trace/src/trace_store/chunk_read.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use serde_json::{Value, json};
+use serde_json::Value;
 use tracing::warn;
 
 use crate::trace_schema::{
@@ -9,85 +9,14 @@ use crate::trace_schema::{
 };
 
 mod io;
+mod nodes;
 
 #[cfg(test)]
 pub(super) use io::resolve_chunk_path;
 use io::{ChunkSizeExceeded, read_chunk_bytes};
-
-pub(super) struct NodeChunkEntry {
-    pub(super) record_index: Option<u64>,
-    pub(super) record_index_present: bool,
-    pub(super) node: Value,
-}
-
-pub(super) fn parse_node_chunk_entry(value: Value) -> NodeChunkEntry {
-    let record_index_value = value.get("record_index");
-    let record_index_present = record_index_value.is_some();
-    let record_index = record_index_value.and_then(parse_record_index);
-    let mut node = match value {
-        Value::Object(mut obj) => {
-            let has_node = obj.contains_key("node");
-            let has_core_fields =
-                obj.contains_key("id") || obj.contains_key("kind") || obj.contains_key("status");
-            let legacy_wrapper_shape = has_node
-                && !has_core_fields
-                && obj
-                    .keys()
-                    .all(|key| matches!(key.as_str(), "node" | "record_index"));
-            if legacy_wrapper_shape {
-                obj.remove("node").unwrap_or(Value::Null)
-            } else {
-                obj.remove("record_index");
-                Value::Object(obj)
-            }
-        }
-        other => other,
-    };
-    if !node.is_object() {
-        node = json!({ "value": node });
-    }
-    NodeChunkEntry {
-        record_index,
-        record_index_present,
-        node,
-    }
-}
-
-pub(super) fn normalize_inline_nodes_value(nodes_value: &Value) -> Vec<Value> {
-    match nodes_value {
-        Value::Array(nodes) => nodes.iter().map(normalize_inline_node).collect(),
-        Value::Object(_) => vec![normalize_inline_node(nodes_value)],
-        other => vec![json!({ "value": other })],
-    }
-}
-
-fn normalize_inline_node(value: &Value) -> Value {
-    match value {
-        Value::Object(map) => Value::Object(map.clone()),
-        other => json!({ "value": other }),
-    }
-}
-
-pub(super) fn count_inline_nodes(records: &[Value], max_nodes: usize) -> usize {
-    let mut total = 0usize;
-    for record in records {
-        if let Some(nodes) = record.get("nodes").and_then(|value| value.as_array()) {
-            total = total.saturating_add(nodes.len());
-            if total > max_nodes {
-                break;
-            }
-        }
-    }
-    total
-}
-
-pub(super) fn parse_record_index(value: &Value) -> Option<u64> {
-    match value {
-        Value::Number(number) => number.as_u64(),
-        Value::String(text) => text.parse().ok(),
-        _ => None,
-    }
-}
+pub(super) use nodes::{
+    count_inline_nodes, normalize_inline_nodes_value, parse_node_chunk_entry, parse_record_index,
+};
 
 pub(super) struct ChunkReadResult<T> {
     pub(super) value: T,

--- a/crates/rulemorph_trace/src/trace_store/chunk_read/nodes.rs
+++ b/crates/rulemorph_trace/src/trace_store/chunk_read/nodes.rs
@@ -1,0 +1,76 @@
+use serde_json::{Value, json};
+
+pub(in crate::trace_store) struct NodeChunkEntry {
+    pub(in crate::trace_store) record_index: Option<u64>,
+    pub(in crate::trace_store) record_index_present: bool,
+    pub(in crate::trace_store) node: Value,
+}
+
+pub(in crate::trace_store) fn parse_node_chunk_entry(value: Value) -> NodeChunkEntry {
+    let record_index_value = value.get("record_index");
+    let record_index_present = record_index_value.is_some();
+    let record_index = record_index_value.and_then(parse_record_index);
+    let mut node = match value {
+        Value::Object(mut obj) => {
+            let has_node = obj.contains_key("node");
+            let has_core_fields =
+                obj.contains_key("id") || obj.contains_key("kind") || obj.contains_key("status");
+            let legacy_wrapper_shape = has_node
+                && !has_core_fields
+                && obj
+                    .keys()
+                    .all(|key| matches!(key.as_str(), "node" | "record_index"));
+            if legacy_wrapper_shape {
+                obj.remove("node").unwrap_or(Value::Null)
+            } else {
+                obj.remove("record_index");
+                Value::Object(obj)
+            }
+        }
+        other => other,
+    };
+    if !node.is_object() {
+        node = json!({ "value": node });
+    }
+    NodeChunkEntry {
+        record_index,
+        record_index_present,
+        node,
+    }
+}
+
+pub(in crate::trace_store) fn normalize_inline_nodes_value(nodes_value: &Value) -> Vec<Value> {
+    match nodes_value {
+        Value::Array(nodes) => nodes.iter().map(normalize_inline_node).collect(),
+        Value::Object(_) => vec![normalize_inline_node(nodes_value)],
+        other => vec![json!({ "value": other })],
+    }
+}
+
+fn normalize_inline_node(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(map.clone()),
+        other => json!({ "value": other }),
+    }
+}
+
+pub(in crate::trace_store) fn count_inline_nodes(records: &[Value], max_nodes: usize) -> usize {
+    let mut total = 0usize;
+    for record in records {
+        if let Some(nodes) = record.get("nodes").and_then(|value| value.as_array()) {
+            total = total.saturating_add(nodes.len());
+            if total > max_nodes {
+                break;
+            }
+        }
+    }
+    total
+}
+
+pub(in crate::trace_store) fn parse_record_index(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => number.as_u64(),
+        Value::String(text) => text.parse().ok(),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Summary
- Move trace store chunk-read node helper parsing/normalization into trace_store/chunk_read/nodes.rs.
- Keep chunk budget, NDJSON/JSON chunk read/decode, format/compression checks, and IO helpers in the parent chunk_read module.
- Preserve node wrapper handling, record_index parsing, inline node normalization, count budget behavior, public API, and trace JSON schema.

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_parses_string_record_index_in_nodes -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_wraps_inline_scalar_nodes_value -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_store trace_store_downgrades_on_node_count_limit -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_store -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace -- --test-threads=1
- cargo fmt --check
- git diff --check
- After merging PR #377 into this branch: env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_parses_string_record_index_in_nodes -- --test-threads=1
- After merging PR #377 into this branch: env CARGO_INCREMENTAL=0 cargo test -p rulemorph_trace --test trace_store trace_store_ignores_oversized_trace_json -- --test-threads=1
- After merging PR #377 into this branch: cargo fmt --check
- After merging PR #377 into this branch: git diff --check origin/v0.3.1...HEAD

## Notes
- No transform semantics, trace JSON schema, public API/export, CLI/MCP/HTTP contract, or docs/specs changes.