### PR TITLE
Refactor endpoint network body helpers

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
@@ -1,22 +1,21 @@
-use std::path::Path;
 use std::time::Instant;
 
 use anyhow::Result;
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
-use rulemorph::v2_eval::EvalValue;
-use rulemorph::{get_path, parse_path, transform_record_with_base_dir};
-use serde_json::{Map as JsonMap, Value as JsonValue, json};
+use rulemorph::{get_path, parse_path};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
 
+mod body;
+
 use super::config::RequestContext;
 use super::error::{EndpointError, EndpointErrorKind};
-use super::expr::{apply_mappings_via_rule, build_headers, eval_expr_string, eval_expr_value};
+use super::expr::{build_headers, eval_expr_string};
 use super::host::internal_hosts_match;
 use super::network_rule::CompiledNetworkRule;
 use super::ssrf_audit::build_ssrf_audit_log;
-use super::trace_graph::{build_rule_nodes_from_rule, build_rule_trace};
 use super::{EndpointEngine, NetworkExecution, empty_object};
 
 impl EndpointEngine {
@@ -155,78 +154,6 @@ impl EndpointEngine {
                 }
             }
         }
-    }
-
-    pub(super) fn build_network_body(
-        &self,
-        rule: &CompiledNetworkRule,
-        input: &JsonValue,
-        context: Option<&JsonValue>,
-    ) -> Result<Option<JsonValue>, EndpointError> {
-        if let Some(body_expr) = &rule.body {
-            let value = eval_expr_value(body_expr, input, context)
-                .map_err(|err| EndpointError::invalid(err.to_string()))?;
-            return Ok(match value {
-                EvalValue::Missing => None,
-                EvalValue::Value(val) => Some(val),
-            });
-        }
-        if let Some(mappings) = &rule.body_map {
-            let output = apply_mappings_via_rule(mappings, input, context)
-                .map_err(EndpointError::from_transform)?
-                .unwrap_or_else(empty_object);
-            return Ok(Some(output));
-        }
-        if let Some(body_rule) = &rule.body_rule {
-            let output = transform_record_with_base_dir(
-                &body_rule.rule,
-                input,
-                context,
-                &body_rule.base_dir,
-            )
-            .map_err(EndpointError::from_transform)?;
-            return Ok(output);
-        }
-        Ok(None)
-    }
-
-    fn build_body_rule_trace(
-        rule: &CompiledNetworkRule,
-        input: &JsonValue,
-        context: Option<&JsonValue>,
-        output: Option<&JsonValue>,
-    ) -> Option<JsonValue> {
-        let body_rule = rule.body_rule.as_ref()?;
-        let rule_ref = rule
-            .body_rule_ref
-            .clone()
-            .unwrap_or_else(|| "body_rule".to_string());
-        let name = Path::new(&rule_ref)
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or("body_rule")
-            .to_string();
-        let rule_trace =
-            build_rule_nodes_from_rule(&body_rule.rule, input, context, &body_rule.base_dir);
-        let duration_us = rule_trace.duration_us;
-        let output_value = rule_trace
-            .pre_finalize_output
-            .clone()
-            .or_else(|| output.cloned())
-            .unwrap_or(JsonValue::Null);
-        Some(build_rule_trace(
-            "normal",
-            name,
-            rule_ref,
-            body_rule.rule.version,
-            json!({}),
-            input.clone(),
-            output_value,
-            rule_trace.nodes,
-            rule_trace.finalize,
-            duration_us,
-            "ok",
-        ))
     }
 
     fn build_resolved_client(&self, target: &ResolvedSsrfTarget) -> Result<Client, EndpointError> {

--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/body.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/body.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+
+use rulemorph::transform_record_with_base_dir;
+use rulemorph::v2_eval::EvalValue;
+use serde_json::{Value as JsonValue, json};
+
+use super::*;
+use crate::endpoint_engine::expr::{apply_mappings_via_rule, eval_expr_value};
+use crate::endpoint_engine::trace_graph::{build_rule_nodes_from_rule, build_rule_trace};
+
+impl EndpointEngine {
+    pub(in crate::endpoint_engine) fn build_network_body(
+        &self,
+        rule: &CompiledNetworkRule,
+        input: &JsonValue,
+        context: Option<&JsonValue>,
+    ) -> Result<Option<JsonValue>, EndpointError> {
+        if let Some(body_expr) = &rule.body {
+            let value = eval_expr_value(body_expr, input, context)
+                .map_err(|err| EndpointError::invalid(err.to_string()))?;
+            return Ok(match value {
+                EvalValue::Missing => None,
+                EvalValue::Value(val) => Some(val),
+            });
+        }
+        if let Some(mappings) = &rule.body_map {
+            let output = apply_mappings_via_rule(mappings, input, context)
+                .map_err(EndpointError::from_transform)?
+                .unwrap_or_else(empty_object);
+            return Ok(Some(output));
+        }
+        if let Some(body_rule) = &rule.body_rule {
+            let output = transform_record_with_base_dir(
+                &body_rule.rule,
+                input,
+                context,
+                &body_rule.base_dir,
+            )
+            .map_err(EndpointError::from_transform)?;
+            return Ok(output);
+        }
+        Ok(None)
+    }
+
+    pub(super) fn build_body_rule_trace(
+        rule: &CompiledNetworkRule,
+        input: &JsonValue,
+        context: Option<&JsonValue>,
+        output: Option<&JsonValue>,
+    ) -> Option<JsonValue> {
+        let body_rule = rule.body_rule.as_ref()?;
+        let rule_ref = rule
+            .body_rule_ref
+            .clone()
+            .unwrap_or_else(|| "body_rule".to_string());
+        let name = Path::new(&rule_ref)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("body_rule")
+            .to_string();
+        let rule_trace =
+            build_rule_nodes_from_rule(&body_rule.rule, input, context, &body_rule.base_dir);
+        let duration_us = rule_trace.duration_us;
+        let output_value = rule_trace
+            .pre_finalize_output
+            .clone()
+            .or_else(|| output.cloned())
+            .unwrap_or(JsonValue::Null);
+        Some(build_rule_trace(
+            "normal",
+            name,
+            rule_ref,
+            body_rule.rule.version,
+            json!({}),
+            input.clone(),
+            output_value,
+            rule_trace.nodes,
+            rule_trace.finalize,
+            duration_us,
+            "ok",
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
- Move endpoint network body construction into network_exec/body.rs
- Move body_rule trace construction alongside body helper code
- Leave network send, SSRF, internal auth, retry, select/catch, and payload limit paths unchanged

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint --lib endpoint_engine::tests::build_network_body_body_rule_none_omits_body -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint --lib endpoint_engine::tests::network_nodes_include_request_duration_us -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint --lib endpoint_engine::tests::network_body_build_error_runs_catch -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint --lib endpoint_engine::tests::network_response_too_large_returns_error -- --test-threads=1 (sandbox bind failed; same command passed outside sandbox)
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint -- --test-threads=1 (sandbox bind failed; same command passed outside sandbox)
- cargo fmt --check
- git diff --check
- git diff --cached --check
- git diff --check origin/v0.3.1...HEAD