### PR TITLE
Refactor serde guard JSON parser

### DIFF
--- a/crates/rulemorph/src/serde_guard.rs
+++ b/crates/rulemorph/src/serde_guard.rs
@@ -4,8 +4,11 @@ use std::fmt;
 
 use serde::Deserializer;
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
-use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
 use serde_yaml::{Mapping as YamlMapping, Number as YamlNumber, Value as YamlValue};
+
+mod json;
+
+pub use self::json::parse_json_value_strict;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StrictYamlError {
@@ -44,15 +47,6 @@ impl fmt::Display for StrictYamlError {
 }
 
 impl std::error::Error for StrictYamlError {}
-
-pub fn parse_json_value_strict(source: &str) -> Result<JsonValue, String> {
-    let mut deserializer = serde_json::Deserializer::from_str(source);
-    let value = JsonValueSeed
-        .deserialize(&mut deserializer)
-        .map_err(|err| err.to_string())?;
-    deserializer.end().map_err(|err| err.to_string())?;
-    Ok(value)
-}
 
 pub fn parse_yaml_value_strict(source: &str) -> Result<YamlValue, StrictYamlError> {
     let mut documents = serde_yaml::Deserializer::from_str(source);
@@ -99,99 +93,6 @@ where
         ));
     }
     Ok(())
-}
-
-struct JsonValueSeed;
-
-impl<'de> DeserializeSeed<'de> for JsonValueSeed {
-    type Value = JsonValue;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(JsonValueVisitor)
-    }
-}
-
-struct JsonValueVisitor;
-
-impl<'de> Visitor<'de> for JsonValueVisitor {
-    type Value = JsonValue;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a JSON value")
-    }
-
-    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(JsonValue::Bool(value))
-    }
-
-    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
-        Ok(JsonValue::Number(value.into()))
-    }
-
-    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
-        Ok(JsonValue::Number(value.into()))
-    }
-
-    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        JsonNumber::from_f64(value)
-            .map(JsonValue::Number)
-            .ok_or_else(|| E::custom("non-finite JSON number is not allowed"))
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(JsonValue::String(value.to_string()))
-    }
-
-    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(JsonValue::String(value))
-    }
-
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(JsonValue::Null)
-    }
-
-    fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(JsonValue::Null)
-    }
-
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut values = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-        while let Some(value) = seq.next_element_seed(JsonValueSeed)? {
-            values.push(value);
-        }
-        Ok(JsonValue::Array(values))
-    }
-
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut values = JsonMap::new();
-        let mut keys = HashSet::new();
-        while let Some(key) = map.next_key::<String>()? {
-            if !keys.insert(key.clone()) {
-                return Err(de::Error::custom(format!("duplicate key `{}`", key)));
-            }
-            let value = map.next_value_seed(JsonValueSeed)?;
-            values.insert(key, value);
-        }
-        Ok(JsonValue::Object(values))
-    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rulemorph/src/serde_guard/json.rs
+++ b/crates/rulemorph/src/serde_guard/json.rs
@@ -1,0 +1,108 @@
+use std::collections::HashSet;
+use std::fmt;
+
+use serde::Deserializer;
+use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
+
+pub fn parse_json_value_strict(source: &str) -> Result<JsonValue, String> {
+    let mut deserializer = serde_json::Deserializer::from_str(source);
+    let value = JsonValueSeed
+        .deserialize(&mut deserializer)
+        .map_err(|err| err.to_string())?;
+    deserializer.end().map_err(|err| err.to_string())?;
+    Ok(value)
+}
+
+struct JsonValueSeed;
+
+impl<'de> DeserializeSeed<'de> for JsonValueSeed {
+    type Value = JsonValue;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(JsonValueVisitor)
+    }
+}
+
+struct JsonValueVisitor;
+
+impl<'de> Visitor<'de> for JsonValueVisitor {
+    type Value = JsonValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(JsonValue::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(JsonValue::Number(value.into()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(JsonValue::Number(value.into()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        JsonNumber::from_f64(value)
+            .map(JsonValue::Number)
+            .ok_or_else(|| E::custom("non-finite JSON number is not allowed"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(JsonValue::String(value.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(JsonValue::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(JsonValue::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(JsonValue::Null)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        while let Some(value) = seq.next_element_seed(JsonValueSeed)? {
+            values.push(value);
+        }
+        Ok(JsonValue::Array(values))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = JsonMap::new();
+        let mut keys = HashSet::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if !keys.insert(key.clone()) {
+                return Err(de::Error::custom(format!("duplicate key `{}`", key)));
+            }
+            let value = map.next_value_seed(JsonValueSeed)?;
+            values.insert(key, value);
+        }
+        Ok(JsonValue::Object(values))
+    }
+}


### PR DESCRIPTION
## Summary
- Move strict JSON value parsing into a private serde_guard child module
- Keep the public serde_guard::parse_json_value_strict path re-exported

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test validation json_rule -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_golden json_input_duplicate_key_is_invalid -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_golden r01_float_non_finite -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --lib -- --test-threads=1
- cargo fmt --check
- git diff --check