### PR TITLE
Refactor v2 operator inventory definitions

### DIFF
--- a/crates/rulemorph/src/v2_operator/inventory.rs
+++ b/crates/rulemorph/src/v2_operator/inventory.rs
@@ -1,29 +1,9 @@
-use super::types::{
-    V2OperatorArgRange, V2OperatorArgScope, V2OperatorArgScopeRule, V2OperatorArgSelector,
-    V2OperatorMetadata, V2OperatorTrace,
+mod definitions;
+
+use self::definitions::{
+    ITEM_ACC_ARG_0, ITEM_ACC_ARG_1, ITEM_ARG_0, ITEM_LAST_ARG, NO_SCOPE, range,
 };
-
-const fn range(min: usize, max: Option<usize>) -> V2OperatorArgRange {
-    V2OperatorArgRange { min, max }
-}
-
-const NO_SCOPE: &[V2OperatorArgScopeRule] = &[];
-const ITEM_ARG_0: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
-    selector: V2OperatorArgSelector::Exact(0),
-    scope: V2OperatorArgScope::Item,
-}];
-const ITEM_ACC_ARG_0: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
-    selector: V2OperatorArgSelector::Exact(0),
-    scope: V2OperatorArgScope::ItemAndAcc,
-}];
-const ITEM_ACC_ARG_1: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
-    selector: V2OperatorArgSelector::Exact(1),
-    scope: V2OperatorArgScope::ItemAndAcc,
-}];
-const ITEM_LAST_ARG: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
-    selector: V2OperatorArgSelector::Last,
-    scope: V2OperatorArgScope::Item,
-}];
+use super::types::{V2OperatorMetadata, V2OperatorTrace};
 
 macro_rules! op {
     ($name:literal, $range:expr, $trace:ident, $skip_missing_pipe:expr, $stop_after_missing_arg:expr, $scopes:ident) => {

--- a/crates/rulemorph/src/v2_operator/inventory/definitions.rs
+++ b/crates/rulemorph/src/v2_operator/inventory/definitions.rs
@@ -1,0 +1,25 @@
+use super::super::types::{
+    V2OperatorArgRange, V2OperatorArgScope, V2OperatorArgScopeRule, V2OperatorArgSelector,
+};
+
+pub(super) const fn range(min: usize, max: Option<usize>) -> V2OperatorArgRange {
+    V2OperatorArgRange { min, max }
+}
+
+pub(super) const NO_SCOPE: &[V2OperatorArgScopeRule] = &[];
+pub(super) const ITEM_ARG_0: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
+    selector: V2OperatorArgSelector::Exact(0),
+    scope: V2OperatorArgScope::Item,
+}];
+pub(super) const ITEM_ACC_ARG_0: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
+    selector: V2OperatorArgSelector::Exact(0),
+    scope: V2OperatorArgScope::ItemAndAcc,
+}];
+pub(super) const ITEM_ACC_ARG_1: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
+    selector: V2OperatorArgSelector::Exact(1),
+    scope: V2OperatorArgScope::ItemAndAcc,
+}];
+pub(super) const ITEM_LAST_ARG: &[V2OperatorArgScopeRule] = &[V2OperatorArgScopeRule {
+    selector: V2OperatorArgSelector::Last,
+    scope: V2OperatorArgScope::Item,
+}];


### PR DESCRIPTION
## Summary
- move v2 operator inventory arg range/scope definitions into an internal definitions module
- keep the V2_OPERATORS table entries, order, names, validation metadata, trace classifications, missing short-circuit flags, and scope assignments unchanged
- reduce inventory.rs from 412 to 392 lines without changing public exports or behavior

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph v2_operator_metadata -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --lib test_op_arg_range -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --lib -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit: env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD

## Review
- Subagent review: PASS; no behavior/API/schema changes found, and no circular dependency risk found.