### PR TITLE
Refactor endpoint validation network rules

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
@@ -1,21 +1,18 @@
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
-use axum::http::Method;
-use rulemorph::v2_parser::parse_v2_expr;
 use rulemorph::{RuleFormat, parse_rule_file_with_format, validate_rule_file_with_source};
 
-use super::{
-    CompiledEndpointRule, EndpointRuleFile, NetworkRuleFile, compile_retry, parse_duration,
-    resolve_rule_path,
-};
+use super::{CompiledEndpointRule, EndpointRuleFile, resolve_rule_path};
 
 mod diagnostics;
+mod network;
 mod source;
 mod state;
 
 pub use self::diagnostics::{RulesDirError, RulesDirErrors};
 use self::diagnostics::{push_error, push_parse_error, push_rule_error};
+use self::network::validate_network_rule;
 use self::source::{parse_rule_type, parse_yaml, read_rule_source};
 use self::state::{RuleRefUsage, ValidationState};
 
@@ -210,185 +207,6 @@ fn validate_normal_rule(
                     }
                 }
             }
-        }
-    }
-}
-
-fn validate_network_rule(
-    source: &str,
-    path: &Path,
-    state: &mut ValidationState,
-    errors: &mut Vec<RulesDirError>,
-) {
-    let raw: NetworkRuleFile = match parse_yaml(path, source, errors) {
-        Some(raw) => raw,
-        None => return,
-    };
-
-    if raw.version != 2 {
-        push_error(
-            errors,
-            "InvalidVersion",
-            path,
-            "network rule version must be 2",
-            Some("version".to_string()),
-            None,
-        );
-    }
-    if raw.rule_type != "network" {
-        push_error(
-            errors,
-            "InvalidRuleType",
-            path,
-            "network rule type must be network",
-            Some("type".to_string()),
-            None,
-        );
-    }
-    if raw.body.is_some() && raw.body_map.is_some() {
-        push_error(
-            errors,
-            "NetworkInvalidConfig",
-            path,
-            "body and body_map are mutually exclusive",
-            Some("body".to_string()),
-            None,
-        );
-    }
-    if raw.body.is_some() && raw.body_rule.is_some() {
-        push_error(
-            errors,
-            "NetworkInvalidConfig",
-            path,
-            "body and body_rule are mutually exclusive",
-            Some("body".to_string()),
-            None,
-        );
-    }
-    if raw.body_map.is_some() && raw.body_rule.is_some() {
-        push_error(
-            errors,
-            "NetworkInvalidConfig",
-            path,
-            "body_map and body_rule are mutually exclusive",
-            Some("body_map".to_string()),
-            None,
-        );
-    }
-
-    let method = match Method::from_bytes(raw.request.method.as_bytes()) {
-        Ok(method) => Some(method),
-        Err(_) => {
-            push_error(
-                errors,
-                "InvalidMethod",
-                path,
-                "invalid method",
-                Some("request.method".to_string()),
-                None,
-            );
-            None
-        }
-    };
-
-    if let Some(method) = method {
-        if method == Method::GET
-            && (raw.body.is_some() || raw.body_map.is_some() || raw.body_rule.is_some())
-        {
-            push_error(
-                errors,
-                "NetworkInvalidConfig",
-                path,
-                "GET with body is not allowed",
-                Some("request.method".to_string()),
-                None,
-            );
-        }
-    }
-
-    if let Err(err) = parse_v2_expr(&raw.request.url) {
-        push_error(
-            errors,
-            "InvalidExpr",
-            path,
-            format!("request.url: {}", err),
-            Some("request.url".to_string()),
-            None,
-        );
-    }
-    if let Some(body) = &raw.body {
-        if let Err(err) = parse_v2_expr(body) {
-            push_error(
-                errors,
-                "InvalidExpr",
-                path,
-                format!("body: {}", err),
-                Some("body".to_string()),
-                None,
-            );
-        }
-    }
-    if let Some(headers) = &raw.request.headers {
-        for (key, value) in headers {
-            if let Err(err) = parse_v2_expr(value) {
-                let field = format!("request.headers.{}", key);
-                push_error(
-                    errors,
-                    "InvalidExpr",
-                    path,
-                    format!("{}: {}", field, err),
-                    Some(field),
-                    None,
-                );
-            }
-        }
-    }
-
-    match parse_duration(&raw.timeout) {
-        Ok(timeout) => {
-            if timeout.is_zero() {
-                push_error(
-                    errors,
-                    "InvalidTimeout",
-                    path,
-                    "timeout must be > 0",
-                    Some("timeout".to_string()),
-                    None,
-                );
-            }
-        }
-        Err(err) => {
-            push_error(
-                errors,
-                "InvalidTimeout",
-                path,
-                err.to_string(),
-                Some("timeout".to_string()),
-                None,
-            );
-        }
-    }
-
-    if let Err(err) = compile_retry(raw.retry.as_ref()) {
-        push_error(
-            errors,
-            "InvalidRetry",
-            path,
-            err.to_string(),
-            Some("retry".to_string()),
-            None,
-        );
-    }
-
-    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    if let Some(body_rule) = raw.body_rule.as_deref() {
-        let resolved = resolve_rule_path(base_dir, body_rule);
-        validate_rule_path(&resolved, RuleRefUsage::body_rule(), state, errors);
-    }
-    if let Some(catch) = &raw.catch {
-        for target in catch.values() {
-            let resolved = resolve_rule_path(base_dir, target);
-            validate_rule_path(&resolved, RuleRefUsage::catch_rule(), state, errors);
         }
     }
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation/network.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation/network.rs
@@ -1,0 +1,189 @@
+use std::path::Path;
+
+use axum::http::Method;
+use rulemorph::v2_parser::parse_v2_expr;
+
+use super::diagnostics::{RulesDirError, push_error};
+use super::source::parse_yaml;
+use super::state::{RuleRefUsage, ValidationState};
+use super::validate_rule_path;
+use crate::endpoint_engine::{NetworkRuleFile, compile_retry, parse_duration, resolve_rule_path};
+
+pub(super) fn validate_network_rule(
+    source: &str,
+    path: &Path,
+    state: &mut ValidationState,
+    errors: &mut Vec<RulesDirError>,
+) {
+    let raw: NetworkRuleFile = match parse_yaml(path, source, errors) {
+        Some(raw) => raw,
+        None => return,
+    };
+
+    if raw.version != 2 {
+        push_error(
+            errors,
+            "InvalidVersion",
+            path,
+            "network rule version must be 2",
+            Some("version".to_string()),
+            None,
+        );
+    }
+    if raw.rule_type != "network" {
+        push_error(
+            errors,
+            "InvalidRuleType",
+            path,
+            "network rule type must be network",
+            Some("type".to_string()),
+            None,
+        );
+    }
+    if raw.body.is_some() && raw.body_map.is_some() {
+        push_error(
+            errors,
+            "NetworkInvalidConfig",
+            path,
+            "body and body_map are mutually exclusive",
+            Some("body".to_string()),
+            None,
+        );
+    }
+    if raw.body.is_some() && raw.body_rule.is_some() {
+        push_error(
+            errors,
+            "NetworkInvalidConfig",
+            path,
+            "body and body_rule are mutually exclusive",
+            Some("body".to_string()),
+            None,
+        );
+    }
+    if raw.body_map.is_some() && raw.body_rule.is_some() {
+        push_error(
+            errors,
+            "NetworkInvalidConfig",
+            path,
+            "body_map and body_rule are mutually exclusive",
+            Some("body_map".to_string()),
+            None,
+        );
+    }
+
+    let method = match Method::from_bytes(raw.request.method.as_bytes()) {
+        Ok(method) => Some(method),
+        Err(_) => {
+            push_error(
+                errors,
+                "InvalidMethod",
+                path,
+                "invalid method",
+                Some("request.method".to_string()),
+                None,
+            );
+            None
+        }
+    };
+
+    if let Some(method) = method {
+        if method == Method::GET
+            && (raw.body.is_some() || raw.body_map.is_some() || raw.body_rule.is_some())
+        {
+            push_error(
+                errors,
+                "NetworkInvalidConfig",
+                path,
+                "GET with body is not allowed",
+                Some("request.method".to_string()),
+                None,
+            );
+        }
+    }
+
+    if let Err(err) = parse_v2_expr(&raw.request.url) {
+        push_error(
+            errors,
+            "InvalidExpr",
+            path,
+            format!("request.url: {}", err),
+            Some("request.url".to_string()),
+            None,
+        );
+    }
+    if let Some(body) = &raw.body {
+        if let Err(err) = parse_v2_expr(body) {
+            push_error(
+                errors,
+                "InvalidExpr",
+                path,
+                format!("body: {}", err),
+                Some("body".to_string()),
+                None,
+            );
+        }
+    }
+    if let Some(headers) = &raw.request.headers {
+        for (key, value) in headers {
+            if let Err(err) = parse_v2_expr(value) {
+                let field = format!("request.headers.{}", key);
+                push_error(
+                    errors,
+                    "InvalidExpr",
+                    path,
+                    format!("{}: {}", field, err),
+                    Some(field),
+                    None,
+                );
+            }
+        }
+    }
+
+    match parse_duration(&raw.timeout) {
+        Ok(timeout) => {
+            if timeout.is_zero() {
+                push_error(
+                    errors,
+                    "InvalidTimeout",
+                    path,
+                    "timeout must be > 0",
+                    Some("timeout".to_string()),
+                    None,
+                );
+            }
+        }
+        Err(err) => {
+            push_error(
+                errors,
+                "InvalidTimeout",
+                path,
+                err.to_string(),
+                Some("timeout".to_string()),
+                None,
+            );
+        }
+    }
+
+    if let Err(err) = compile_retry(raw.retry.as_ref()) {
+        push_error(
+            errors,
+            "InvalidRetry",
+            path,
+            err.to_string(),
+            Some("retry".to_string()),
+            None,
+        );
+    }
+
+    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    if let Some(body_rule) = raw.body_rule.as_deref() {
+        let resolved = resolve_rule_path(base_dir, body_rule);
+        validate_rule_path(&resolved, RuleRefUsage::body_rule(), state, errors);
+    }
+    if let Some(catch) = &raw.catch {
+        for target in catch.values() {
+            let resolved = resolve_rule_path(base_dir, target);
+            validate_rule_path(&resolved, RuleRefUsage::catch_rule(), state, errors);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move endpoint network-rule validation into endpoint_engine/validation/network.rs
- keep validation entrypoint, normal rule validation, endpoint validation, branch/catch/body traversal, and diagnostics behavior unchanged
- reduce validation.rs from 394 to 212 lines

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint --test rules_dir_validation -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint -- --test-threads=1
  - sandbox run failed only on localhost bind PermissionDenied for network tests
  - sandbox-outside rerun passed: unit 60 passed / 1 ignored, rules_dir_validation 7 passed, doctest 0 passed
- cargo fmt --check
- git diff --check
- post-commit: env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint --test rules_dir_validation -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD

## Review
- Subagent review: PASS; moved function body unchanged aside from module/import path and visibility, no diagnostics/API/runtime/schema changes found, and no circular dependency risk found.