### PR TITLE
Refactor array scoped accumulator ops

### DIFF
--- a/crates/rulemorph/src/transform/operators/array/scoped.rs
+++ b/crates/rulemorph/src/transform/operators/array/scoped.rs
@@ -1,6 +1,9 @@
 use super::*;
 
+mod accumulator;
 pub(super) mod predicate;
+
+pub(in crate::transform::operators) use self::accumulator::{eval_array_fold, eval_array_reduce};
 
 pub(in crate::transform::operators) fn eval_array_map(
     args: &[Expr],
@@ -303,104 +306,4 @@ pub(in crate::transform::operators) fn eval_array_sort_by(
 
     let results = items.into_iter().map(|item| item.value).collect::<Vec<_>>();
     Ok(EvalValue::Value(JsonValue::Array(results)))
-}
-
-pub(in crate::transform::operators) fn eval_array_reduce(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len != 2 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain exactly two items",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
-    if array.is_empty() {
-        return Ok(EvalValue::Value(JsonValue::Null));
-    }
-
-    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args index is out of bounds",
-        )
-        .with_path(format!("{}.args[1]", base_path))
-    })?;
-    let expr_index = if injected.is_some() { 0 } else { 1 };
-    let expr_path = format!("{}.args[{}]", base_path, expr_index);
-
-    let mut acc = array[0].clone();
-    for (index, item) in array.iter().enumerate().skip(1) {
-        let item_locals = EvalLocals {
-            item: Some(EvalItem { value: item, index }),
-            acc: Some(&acc),
-            pipe: locals.and_then(|locals| locals.pipe),
-            locals: locals.and_then(|locals| locals.locals),
-            precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
-        };
-        let value = eval_expr_or_null(expr, record, context, out, &expr_path, Some(&item_locals))?;
-        acc = value;
-    }
-
-    Ok(EvalValue::Value(acc))
-}
-
-pub(in crate::transform::operators) fn eval_array_fold(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len != 3 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain exactly three items",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
-    let initial =
-        match eval_expr_at_index(1, args, injected, record, context, out, base_path, locals)? {
-            EvalValue::Missing => return Ok(EvalValue::Missing),
-            EvalValue::Value(value) => value,
-        };
-
-    let expr = arg_expr_at(2, args, injected).ok_or_else(|| {
-        TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args index is out of bounds",
-        )
-        .with_path(format!("{}.args[2]", base_path))
-    })?;
-    let expr_index = if injected.is_some() { 1 } else { 2 };
-    let expr_path = format!("{}.args[{}]", base_path, expr_index);
-
-    let mut acc = initial;
-    for (index, item) in array.iter().enumerate() {
-        let item_locals = EvalLocals {
-            item: Some(EvalItem { value: item, index }),
-            acc: Some(&acc),
-            pipe: locals.and_then(|locals| locals.pipe),
-            locals: locals.and_then(|locals| locals.locals),
-            precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
-        };
-        let value = eval_expr_or_null(expr, record, context, out, &expr_path, Some(&item_locals))?;
-        acc = value;
-    }
-
-    Ok(EvalValue::Value(acc))
 }

--- a/crates/rulemorph/src/transform/operators/array/scoped/accumulator.rs
+++ b/crates/rulemorph/src/transform/operators/array/scoped/accumulator.rs
@@ -1,0 +1,101 @@
+use super::super::*;
+
+pub(in crate::transform::operators) fn eval_array_reduce(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
+    if array.is_empty() {
+        return Ok(EvalValue::Value(JsonValue::Null));
+    }
+
+    let expr = arg_expr_at(1, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[1]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 0 } else { 1 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    let mut acc = array[0].clone();
+    for (index, item) in array.iter().enumerate().skip(1) {
+        let item_locals = EvalLocals {
+            item: Some(EvalItem { value: item, index }),
+            acc: Some(&acc),
+            pipe: locals.and_then(|locals| locals.pipe),
+            locals: locals.and_then(|locals| locals.locals),
+            precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
+        };
+        let value = eval_expr_or_null(expr, record, context, out, &expr_path, Some(&item_locals))?;
+        acc = value;
+    }
+
+    Ok(EvalValue::Value(acc))
+}
+
+pub(in crate::transform::operators) fn eval_array_fold(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 3 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly three items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let array = eval_array_arg(0, args, injected, record, context, out, base_path, locals)?;
+    let initial =
+        match eval_expr_at_index(1, args, injected, record, context, out, base_path, locals)? {
+            EvalValue::Missing => return Ok(EvalValue::Missing),
+            EvalValue::Value(value) => value,
+        };
+
+    let expr = arg_expr_at(2, args, injected).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args index is out of bounds",
+        )
+        .with_path(format!("{}.args[2]", base_path))
+    })?;
+    let expr_index = if injected.is_some() { 1 } else { 2 };
+    let expr_path = format!("{}.args[{}]", base_path, expr_index);
+
+    let mut acc = initial;
+    for (index, item) in array.iter().enumerate() {
+        let item_locals = EvalLocals {
+            item: Some(EvalItem { value: item, index }),
+            acc: Some(&acc),
+            pipe: locals.and_then(|locals| locals.pipe),
+            locals: locals.and_then(|locals| locals.locals),
+            precomputed_op_args: locals.and_then(|locals| locals.precomputed_op_args),
+        };
+        let value = eval_expr_or_null(expr, record, context, out, &expr_path, Some(&item_locals))?;
+        acc = value;
+    }
+
+    Ok(EvalValue::Value(acc))
+}


### PR DESCRIPTION
## Summary
- move array scoped reduce/fold accumulator operators into transform/operators/array/scoped/accumulator.rs
- keep the existing array.rs facade and dispatch users unchanged through a scoped.rs re-export
- reduce scoped.rs from 406 to 309 lines without changing operator semantics or trace contracts

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test v2_collection_ops v2_reduce_and_fold_preserve_acc_and_item_scope -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test v2_collection_ops v2_collection_missing_pipe_semantics_are_characterized -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_v1_reduce_ref_read_preserves_acc_namespace -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_v2_fold_preserves_acc_and_item_scope -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --lib -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit: env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test v2_collection_ops v2_reduce_and_fold_preserve_acc_and_item_scope -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD

## Review
- Subagent review: PASS; moved reduce/fold bodies unchanged aside from module import/re-export, no behavior/API/trace/schema changes found, and no circular dependency risk found.