### PR TITLE
Refactor v2 trace map step

### DIFF
--- a/crates/rulemorph/src/transform/v2_trace/pipe.rs
+++ b/crates/rulemorph/src/transform/v2_trace/pipe.rs
@@ -1,6 +1,10 @@
 use super::*;
 use crate::v2_operator::{V2OperatorTrace, operator};
 
+mod map_step;
+
+use map_step::eval_v2_map_step_traced;
+
 pub(in crate::transform) fn eval_v2_pipe_traced<'a>(
     pipe: &V2Pipe,
     record: &'a JsonValue,
@@ -136,112 +140,9 @@ fn eval_v2_step_traced<'a>(
                 .finish_with_v2_eval_output(collector, &output, None);
             Ok((output, ctx.clone()))
         }
-        V2Step::Map(map) => {
-            collector
-                .start_span(TraceEventKind::OpStart, TracePhase::Start)
-                .rule_path(step_path)
-                .operator("map")
-                .input_v2_eval_value(&pipe_value, collector.options(), None)
-                .finish(collector);
-            let arr = match &pipe_value {
-                V2EvalValue::Missing => {
-                    collector
-                        .end_span(TraceEventKind::OpEnd, TracePhase::End)
-                        .rule_path(step_path)
-                        .operator("map")
-                        .finish_with_v2_eval_output(collector, &V2EvalValue::Missing, None);
-                    return Ok((V2EvalValue::Missing, ctx.clone()));
-                }
-                V2EvalValue::Value(JsonValue::Array(arr)) => arr,
-                V2EvalValue::Value(_) => {
-                    collector
-                        .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
-                        .rule_path(step_path)
-                        .operator("map")
-                        .finish(collector);
-                    return Err(TransformError::new(
-                        TransformErrorKind::ExprError,
-                        "map step requires array",
-                    )
-                    .with_path(step_path));
-                }
-            };
-            let mut results = Vec::with_capacity(arr.len());
-            for (index, item_value) in arr.iter().enumerate() {
-                let item_path = format!("{}[{}]", step_path, index);
-                let item_eval_value = V2EvalValue::Value(item_value.clone());
-                let item_ctx = ctx
-                    .clone()
-                    .with_pipe_value(item_eval_value.clone())
-                    .with_item(V2EvalItem {
-                        value: item_value,
-                        index,
-                    });
-                let mut current = item_eval_value;
-                let mut step_ctx = item_ctx.clone();
-
-                collector
-                    .start_span(TraceEventKind::CollectionItemStart, TracePhase::Start)
-                    .rule_path(&item_path)
-                    .input_path(canonical_item_path(""))
-                    .attr_index("item_index", index)
-                    .attr_enum("scope", "item")
-                    .input_value(item_value, collector.options(), Some("@item"))
-                    .finish(collector);
-
-                for (nested_index, nested_step) in map.steps.iter().enumerate() {
-                    let nested_ctx = step_ctx.clone().with_pipe_value(current.clone());
-                    let (next, next_ctx) = match eval_v2_step_traced(
-                        nested_step,
-                        current,
-                        record,
-                        context,
-                        out,
-                        &format!("{}.step[{}]", item_path, nested_index),
-                        &nested_ctx,
-                        collector,
-                    ) {
-                        Ok(result) => result,
-                        Err(error) => {
-                            collector
-                                .error_span(
-                                    TraceEventKind::Error,
-                                    "COLLECTION_ERROR",
-                                    "item failed",
-                                )
-                                .rule_path(&item_path)
-                                .finish(collector);
-                            collector
-                                .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
-                                .rule_path(step_path)
-                                .operator("map")
-                                .input_v2_eval_value(&pipe_value, collector.options(), None)
-                                .finish(collector);
-                            return Err(error);
-                        }
-                    };
-                    current = next;
-                    step_ctx = next_ctx;
-                }
-                collector
-                    .end_span(TraceEventKind::CollectionItemEnd, TracePhase::End)
-                    .rule_path(&item_path)
-                    .finish_with_v2_eval_output(collector, &current, Some("@item"));
-                if let V2EvalValue::Value(value) = current {
-                    results.push(value);
-                }
-            }
-            collector
-                .end_span(TraceEventKind::OpEnd, TracePhase::End)
-                .rule_path(step_path)
-                .operator("map")
-                .finish_with_v2_eval_output(
-                    collector,
-                    &V2EvalValue::Value(JsonValue::Array(results.clone())),
-                    None,
-                );
-            Ok((V2EvalValue::Value(JsonValue::Array(results)), ctx.clone()))
-        }
+        V2Step::Map(map) => eval_v2_map_step_traced(
+            map, pipe_value, record, context, out, step_path, ctx, collector,
+        ),
         V2Step::Let(let_step) => {
             let new_ctx = eval_v2_let_step(
                 let_step,

--- a/crates/rulemorph/src/transform/v2_trace/pipe/map_step.rs
+++ b/crates/rulemorph/src/transform/v2_trace/pipe/map_step.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn eval_v2_map_step_traced<'a>(
+    map: &crate::v2_model::V2MapStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    step_path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<(V2EvalValue, V2EvalContext<'a>), TransformError> {
+    collector
+        .start_span(TraceEventKind::OpStart, TracePhase::Start)
+        .rule_path(step_path)
+        .operator("map")
+        .input_v2_eval_value(&pipe_value, collector.options(), None)
+        .finish(collector);
+    let arr = match &pipe_value {
+        V2EvalValue::Missing => {
+            collector
+                .end_span(TraceEventKind::OpEnd, TracePhase::End)
+                .rule_path(step_path)
+                .operator("map")
+                .finish_with_v2_eval_output(collector, &V2EvalValue::Missing, None);
+            return Ok((V2EvalValue::Missing, ctx.clone()));
+        }
+        V2EvalValue::Value(JsonValue::Array(arr)) => arr,
+        V2EvalValue::Value(_) => {
+            collector
+                .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                .rule_path(step_path)
+                .operator("map")
+                .finish(collector);
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "map step requires array",
+            )
+            .with_path(step_path));
+        }
+    };
+    let mut results = Vec::with_capacity(arr.len());
+    for (index, item_value) in arr.iter().enumerate() {
+        let item_path = format!("{}[{}]", step_path, index);
+        let item_eval_value = V2EvalValue::Value(item_value.clone());
+        let item_ctx = ctx
+            .clone()
+            .with_pipe_value(item_eval_value.clone())
+            .with_item(V2EvalItem {
+                value: item_value,
+                index,
+            });
+        let mut current = item_eval_value;
+        let mut step_ctx = item_ctx.clone();
+
+        collector
+            .start_span(TraceEventKind::CollectionItemStart, TracePhase::Start)
+            .rule_path(&item_path)
+            .input_path(canonical_item_path(""))
+            .attr_index("item_index", index)
+            .attr_enum("scope", "item")
+            .input_value(item_value, collector.options(), Some("@item"))
+            .finish(collector);
+
+        for (nested_index, nested_step) in map.steps.iter().enumerate() {
+            let nested_ctx = step_ctx.clone().with_pipe_value(current.clone());
+            let (next, next_ctx) = match eval_v2_step_traced(
+                nested_step,
+                current,
+                record,
+                context,
+                out,
+                &format!("{}.step[{}]", item_path, nested_index),
+                &nested_ctx,
+                collector,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    collector
+                        .error_span(TraceEventKind::Error, "COLLECTION_ERROR", "item failed")
+                        .rule_path(&item_path)
+                        .finish(collector);
+                    collector
+                        .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                        .rule_path(step_path)
+                        .operator("map")
+                        .input_v2_eval_value(&pipe_value, collector.options(), None)
+                        .finish(collector);
+                    return Err(error);
+                }
+            };
+            current = next;
+            step_ctx = next_ctx;
+        }
+        collector
+            .end_span(TraceEventKind::CollectionItemEnd, TracePhase::End)
+            .rule_path(&item_path)
+            .finish_with_v2_eval_output(collector, &current, Some("@item"));
+        if let V2EvalValue::Value(value) = current {
+            results.push(value);
+        }
+    }
+    collector
+        .end_span(TraceEventKind::OpEnd, TracePhase::End)
+        .rule_path(step_path)
+        .operator("map")
+        .finish_with_v2_eval_output(
+            collector,
+            &V2EvalValue::Value(JsonValue::Array(results.clone())),
+            None,
+        );
+    Ok((V2EvalValue::Value(JsonValue::Array(results)), ctx.clone()))
+}


### PR DESCRIPTION
## Summary
- move traced v2 map step handling into v2_trace/pipe/map_step.rs
- keep nested item scope, let binding propagation, and map error trace behavior unchanged
- leave transform semantics, trace JSON schema, public API, docs/specs unchanged

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_v2_map_nested_error_closes_collection_and_map_spans -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_v2_let_binding_survives_nested_map_steps -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace -- --test-threads=1
- cargo fmt --check
- git diff --check