### PR TITLE
Refactor record trace branch step

### DIFF
--- a/crates/rulemorph/src/transform/record_trace.rs
+++ b/crates/rulemorph/src/transform/record_trace.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+mod branch_step;
 mod mapping;
 
+use branch_step::apply_branch_step_traced;
 use mapping::{apply_mappings_into_traced, apply_mappings_traced};
 
 pub(super) fn apply_rule_to_record_traced(
@@ -217,101 +219,18 @@ fn apply_steps_traced(
             }
 
             if let Some(branch) = &step.branch {
-                let branch_path = format!("{}.branch", base_path);
-                let take = eval_when_expr(
-                    &branch.when,
+                return apply_branch_step_traced(
+                    branch,
                     record,
                     context,
-                    &out,
-                    &format!("{}.when", branch_path),
+                    warnings,
+                    &mut out,
                     rule_version,
-                )?;
-                collector
-                    .emit(TraceEventKind::BranchEval, TracePhase::Instant)
-                    .rule_path(format!("{}.when", branch_path))
-                    .finish_with_output(collector, &JsonValue::Bool(take), None);
-                let (target, target_field) = if take {
-                    (Some(branch.then.as_str()), "then")
-                } else {
-                    (branch.r#else.as_deref(), "else")
-                };
-                if let Some(target) = target {
-                    collector
-                        .start_span(TraceEventKind::BranchTaken, TracePhase::Start)
-                        .rule_path(&branch_path)
-                        .attr_enum("selected_branch", target_field)
-                        .finish(collector);
-                    let branch_path_guard = match branch_context.enter(base_dir, target) {
-                        Ok(guard) => guard,
-                        Err(err) => {
-                            collector
-                                .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
-                                .rule_path(&branch_path)
-                                .finish(collector);
-                            return Err(err.with_path(format!("{}.{}", branch_path, target_field)));
-                        }
-                    };
-                    let branch_result = (|| {
-                        let (branch_rule, branch_base_dir) =
-                            load_rule_from_path(base_dir, target, branch_context.allowed_root())
-                                .map_err(|err| {
-                                    err.with_path(format!("{}.{}", branch_path, target_field))
-                                })?;
-                        let branch_input = out.clone();
-                        transform_record_with_warnings_inner_traced(
-                            &branch_rule,
-                            &branch_input,
-                            context,
-                            Some(&branch_base_dir),
-                            branch_context,
-                            collector,
-                        )
-                    })();
-                    branch_context.exit(branch_path_guard);
-                    let (branch_output, branch_warnings) = match branch_result {
-                        Ok(output) => output,
-                        Err(error) => {
-                            collector
-                                .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
-                                .rule_path(&branch_path)
-                                .finish(collector);
-                            return Err(error);
-                        }
-                    };
-                    warnings.extend(branch_warnings);
-                    let Some(branch_output) = branch_output else {
-                        collector
-                            .end_span(TraceEventKind::BranchTaken, TracePhase::End)
-                            .rule_path(&branch_path)
-                            .finish(collector);
-                        return Ok(TracedStepOutcome::DropRecord);
-                    };
-
-                    if branch.return_ {
-                        collector
-                            .end_span(TraceEventKind::BranchTaken, TracePhase::End)
-                            .rule_path(&branch_path)
-                            .finish_with_output(collector, &branch_output, None);
-                        return Ok(TracedStepOutcome::Return(branch_output));
-                    }
-                    if let Err(error) = merge_branch_output(&mut out, &branch_output, &branch_path)
-                    {
-                        collector
-                            .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
-                            .rule_path(&branch_path)
-                            .finish(collector);
-                        return Err(error);
-                    }
-                    collector
-                        .emit(TraceEventKind::BranchMerge, TracePhase::Instant)
-                        .rule_path(&branch_path)
-                        .finish_with_output(collector, &out, None);
-                    collector
-                        .end_span(TraceEventKind::BranchTaken, TracePhase::End)
-                        .rule_path(&branch_path)
-                        .finish(collector);
-                }
-                return Ok(TracedStepOutcome::Continue);
+                    base_dir,
+                    branch_context,
+                    collector,
+                    &base_path,
+                );
             }
 
             Ok(TracedStepOutcome::Continue)

--- a/crates/rulemorph/src/transform/record_trace/branch_step.rs
+++ b/crates/rulemorph/src/transform/record_trace/branch_step.rs
@@ -1,0 +1,109 @@
+use super::*;
+use crate::model::V2Branch;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn apply_branch_step_traced(
+    branch: &V2Branch,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    warnings: &mut Vec<TransformWarning>,
+    out: &mut JsonValue,
+    rule_version: u8,
+    base_dir: Option<&Path>,
+    branch_context: &mut BranchContext,
+    collector: &mut TraceCollector,
+    base_path: &str,
+) -> Result<TracedStepOutcome, TransformError> {
+    let branch_path = format!("{}.branch", base_path);
+    let take = eval_when_expr(
+        &branch.when,
+        record,
+        context,
+        out,
+        &format!("{}.when", branch_path),
+        rule_version,
+    )?;
+    collector
+        .emit(TraceEventKind::BranchEval, TracePhase::Instant)
+        .rule_path(format!("{}.when", branch_path))
+        .finish_with_output(collector, &JsonValue::Bool(take), None);
+    let (target, target_field) = if take {
+        (Some(branch.then.as_str()), "then")
+    } else {
+        (branch.r#else.as_deref(), "else")
+    };
+    if let Some(target) = target {
+        collector
+            .start_span(TraceEventKind::BranchTaken, TracePhase::Start)
+            .rule_path(&branch_path)
+            .attr_enum("selected_branch", target_field)
+            .finish(collector);
+        let branch_path_guard = match branch_context.enter(base_dir, target) {
+            Ok(guard) => guard,
+            Err(err) => {
+                collector
+                    .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
+                    .rule_path(&branch_path)
+                    .finish(collector);
+                return Err(err.with_path(format!("{}.{}", branch_path, target_field)));
+            }
+        };
+        let branch_result = (|| {
+            let (branch_rule, branch_base_dir) =
+                load_rule_from_path(base_dir, target, branch_context.allowed_root())
+                    .map_err(|err| err.with_path(format!("{}.{}", branch_path, target_field)))?;
+            let branch_input = out.clone();
+            transform_record_with_warnings_inner_traced(
+                &branch_rule,
+                &branch_input,
+                context,
+                Some(&branch_base_dir),
+                branch_context,
+                collector,
+            )
+        })();
+        branch_context.exit(branch_path_guard);
+        let (branch_output, branch_warnings) = match branch_result {
+            Ok(output) => output,
+            Err(error) => {
+                collector
+                    .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
+                    .rule_path(&branch_path)
+                    .finish(collector);
+                return Err(error);
+            }
+        };
+        warnings.extend(branch_warnings);
+        let Some(branch_output) = branch_output else {
+            collector
+                .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+                .rule_path(&branch_path)
+                .finish(collector);
+            return Ok(TracedStepOutcome::DropRecord);
+        };
+
+        if branch.return_ {
+            collector
+                .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+                .rule_path(&branch_path)
+                .finish_with_output(collector, &branch_output, None);
+            return Ok(TracedStepOutcome::Return(branch_output));
+        }
+        if let Err(error) = merge_branch_output(out, &branch_output, &branch_path) {
+            collector
+                .error_span(TraceEventKind::Error, "BRANCH_ERROR", "branch failed")
+                .rule_path(&branch_path)
+                .finish(collector);
+            return Err(error);
+        }
+        collector
+            .emit(TraceEventKind::BranchMerge, TracePhase::Instant)
+            .rule_path(&branch_path)
+            .finish_with_output(collector, out, None);
+        collector
+            .end_span(TraceEventKind::BranchTaken, TracePhase::End)
+            .rule_path(&branch_path)
+            .finish(collector);
+    }
+    Ok(TracedStepOutcome::Continue)
+}


### PR DESCRIPTION
## Summary
- move traced step branch handling into a dedicated record_trace branch_step module
- keep record_trace.rs as the step dispatch coordinator
- preserve branch trace events, span closure, branch return/merge/drop behavior, and error paths

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_branch -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace trace_branch_child_rule_stays_in_same_record_trace -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD