### PR TITLE
Refactor endpoint network response handling

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
@@ -9,6 +9,7 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
 
 mod body;
+mod response;
 
 use super::config::RequestContext;
 use super::error::{EndpointError, EndpointErrorKind};
@@ -305,43 +306,12 @@ impl EndpointEngine {
                 req = req.json(body);
             }
 
-            let mut response = req
+            let response = req
                 .send()
                 .await
                 .map_err(|err| EndpointError::network(err.to_string()))?;
 
-            let status = response.status();
-            let status_u16 = status.as_u16();
-            if status.is_client_error() || status.is_server_error() {
-                return Err(EndpointError::http_status(status_u16));
-            }
-
-            let max_response_bytes = self.config.max_response_bytes;
-            if let Some(length) = response.content_length() {
-                if length > max_response_bytes as u64 {
-                    return Err(EndpointError::payload_too_large(max_response_bytes));
-                }
-            }
-            let mut bytes: Vec<u8> = Vec::new();
-            let mut total = 0usize;
-            while let Some(chunk) = response
-                .chunk()
-                .await
-                .map_err(|err| EndpointError::network(err.to_string()))?
-            {
-                total = total.saturating_add(chunk.len());
-                if total > max_response_bytes {
-                    return Err(EndpointError::payload_too_large(max_response_bytes));
-                }
-                bytes.extend_from_slice(&chunk);
-            }
-            let value = if bytes.is_empty() {
-                JsonValue::Null
-            } else {
-                serde_json::from_slice::<JsonValue>(&bytes)
-                    .map_err(|err| EndpointError::network(err.to_string()))?
-            };
-            Ok(value)
+            response::read_network_response(response, self.config.max_response_bytes).await
         })
         .await
         .map_err(|_| EndpointError::timeout())??;

--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/response.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/response.rs
@@ -1,0 +1,41 @@
+use reqwest::Response;
+use serde_json::Value as JsonValue;
+
+use crate::endpoint_engine::error::EndpointError;
+
+pub(super) async fn read_network_response(
+    mut response: Response,
+    max_response_bytes: usize,
+) -> Result<JsonValue, EndpointError> {
+    let status = response.status();
+    let status_u16 = status.as_u16();
+    if status.is_client_error() || status.is_server_error() {
+        return Err(EndpointError::http_status(status_u16));
+    }
+
+    if let Some(length) = response.content_length() {
+        if length > max_response_bytes as u64 {
+            return Err(EndpointError::payload_too_large(max_response_bytes));
+        }
+    }
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut total = 0usize;
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|err| EndpointError::network(err.to_string()))?
+    {
+        total = total.saturating_add(chunk.len());
+        if total > max_response_bytes {
+            return Err(EndpointError::payload_too_large(max_response_bytes));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    let value = if bytes.is_empty() {
+        JsonValue::Null
+    } else {
+        serde_json::from_slice::<JsonValue>(&bytes)
+            .map_err(|err| EndpointError::network(err.to_string()))?
+    };
+    Ok(value)
+}


### PR DESCRIPTION
## Summary
- move endpoint network response status, size limit, body read, and JSON parse handling into a private helper module
- keep request construction, SSRF/internal auth checks, retry/catch/select behavior, trace schema, and public API unchanged

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage372 cargo test -p rulemorph_endpoint network_response_too_large_returns_error -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage372 cargo test -p rulemorph_endpoint network_chunked_response_too_large_returns_error -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage372 cargo test -p rulemorph_endpoint internal_auth_rejected_when_disabled -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage372 cargo test -p rulemorph_endpoint -- --test-threads=1
- cargo fmt --check
- git diff --check