### PR TITLE
Refactor finalize helpers

### DIFF
--- a/crates/rulemorph/src/transform/finalize.rs
+++ b/crates/rulemorph/src/transform/finalize.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+mod sort;
+mod wrap;
+
+pub(super) use sort::sort_key_from_value;
+use wrap::eval_wrap_value;
+
 pub(super) fn apply_finalize(
     finalize: &FinalizeSpec,
     output: JsonValue,
@@ -273,61 +279,4 @@ pub(super) fn apply_finalize_traced(
     }
 
     Ok(output)
-}
-
-fn eval_wrap_value(
-    value: &JsonValue,
-    out: &JsonValue,
-    context: Option<&JsonValue>,
-    path: &str,
-) -> Result<JsonValue, TransformError> {
-    match value {
-        JsonValue::Object(map) => {
-            let mut out_map = serde_json::Map::new();
-            for (key, value) in map {
-                let child_path = format!("{}.{}", path, key);
-                out_map.insert(
-                    key.clone(),
-                    eval_wrap_value(value, out, context, &child_path)?,
-                );
-            }
-            Ok(JsonValue::Object(out_map))
-        }
-        _ => {
-            let expr = parse_v2_expr(value).map_err(|err| {
-                TransformError::new(
-                    TransformErrorKind::ExprError,
-                    format!("invalid v2 expr: {}", err),
-                )
-                .with_path(path)
-            })?;
-            let ctx = V2EvalContext::new();
-            match eval_v2_expr(&expr, out, context, out, path, &ctx)? {
-                V2EvalValue::Missing => Ok(JsonValue::Null),
-                V2EvalValue::Value(value) => Ok(value),
-            }
-        }
-    }
-}
-
-pub(super) fn sort_key_from_value(
-    value: &JsonValue,
-    path: &str,
-) -> Result<SortKey, TransformError> {
-    match value {
-        JsonValue::Number(number) => number.as_f64().map(SortKey::Number).ok_or_else(|| {
-            TransformError::new(
-                TransformErrorKind::ExprError,
-                "sort key must be a finite number",
-            )
-            .with_path(path)
-        }),
-        JsonValue::String(value) => Ok(SortKey::String(value.clone())),
-        JsonValue::Bool(value) => Ok(SortKey::Bool(*value)),
-        _ => Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "sort key must be string/number/bool",
-        )
-        .with_path(path)),
-    }
 }

--- a/crates/rulemorph/src/transform/finalize/sort.rs
+++ b/crates/rulemorph/src/transform/finalize/sort.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+pub(in crate::transform) fn sort_key_from_value(
+    value: &JsonValue,
+    path: &str,
+) -> Result<SortKey, TransformError> {
+    match value {
+        JsonValue::Number(number) => number.as_f64().map(SortKey::Number).ok_or_else(|| {
+            TransformError::new(
+                TransformErrorKind::ExprError,
+                "sort key must be a finite number",
+            )
+            .with_path(path)
+        }),
+        JsonValue::String(value) => Ok(SortKey::String(value.clone())),
+        JsonValue::Bool(value) => Ok(SortKey::Bool(*value)),
+        _ => Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "sort key must be string/number/bool",
+        )
+        .with_path(path)),
+    }
+}

--- a/crates/rulemorph/src/transform/finalize/wrap.rs
+++ b/crates/rulemorph/src/transform/finalize/wrap.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+pub(super) fn eval_wrap_value(
+    value: &JsonValue,
+    out: &JsonValue,
+    context: Option<&JsonValue>,
+    path: &str,
+) -> Result<JsonValue, TransformError> {
+    match value {
+        JsonValue::Object(map) => {
+            let mut out_map = serde_json::Map::new();
+            for (key, value) in map {
+                let child_path = format!("{}.{}", path, key);
+                out_map.insert(
+                    key.clone(),
+                    eval_wrap_value(value, out, context, &child_path)?,
+                );
+            }
+            Ok(JsonValue::Object(out_map))
+        }
+        _ => {
+            let expr = parse_v2_expr(value).map_err(|err| {
+                TransformError::new(
+                    TransformErrorKind::ExprError,
+                    format!("invalid v2 expr: {}", err),
+                )
+                .with_path(path)
+            })?;
+            let ctx = V2EvalContext::new();
+            match eval_v2_expr(&expr, out, context, out, path, &ctx)? {
+                V2EvalValue::Missing => Ok(JsonValue::Null),
+                V2EvalValue::Value(value) => Ok(value),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move finalize wrap expression evaluation into finalize/wrap.rs
- move finalize sort key conversion into finalize/sort.rs
- keep finalize orchestration, trace events, and transform-internal sort helper availability unchanged

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_golden tv35_finalize_wrap -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_golden tv38_finalize_filter_offset -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_finalize_filter_and_sort_emit_item_level_decisions -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_trace_semantics trace_record_api_matches_normal_finalize_behavior -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit: env CARGO_INCREMENTAL=0 cargo test -p rulemorph --test transform_golden tv35_finalize_wrap -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD

No public API, transform semantics, trace JSON schema, CLI/MCP/HTTP contract, docs/specs, or fixtures changed.