### PR TITLE
Refactor endpoint rule branch trace

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes.rs
@@ -4,15 +4,13 @@ use std::time::Instant;
 use rulemorph::{RuleFile, TransformError, TransformErrorKind, transform_record_with_base_dir};
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
+use self::branch_trace::apply_branch_trace_meta;
 use super::condition::eval_trace_condition;
 use super::duration::sum_rule_trace_duration_us;
-use super::envelope::build_rule_trace;
 use super::finalize::build_finalize_trace;
 use super::mapping_ops::build_mapping_ops_with_values;
-use crate::endpoint_engine::rule_loader::{RuleKind, load_rule_kind, yaml_source_to_json};
-use crate::endpoint_engine::{
-    empty_object, resolve_rule_path, rule_display_name, rule_ref_from_path, rule_ref_from_rule,
-};
+
+mod branch_trace;
 
 pub(in crate::endpoint_engine) struct RuleTraceNodes {
     pub(in crate::endpoint_engine) nodes: Vec<JsonValue>,
@@ -174,20 +172,6 @@ pub(in crate::endpoint_engine) fn build_rule_nodes_from_rule(
 
             if step_active && status != "error" {
                 if let Some(branch) = step.branch.as_ref() {
-                    let mut refs = Vec::new();
-                    let mut labels = Vec::new();
-                    let then_ref = rule_ref_from_rule(base_dir, &branch.then);
-                    refs.push(then_ref.clone());
-                    labels.push("branch: then".to_string());
-                    let else_ref = branch
-                        .r#else
-                        .as_ref()
-                        .map(|other| rule_ref_from_rule(base_dir, other));
-                    if let Some(other_ref) = else_ref.as_ref() {
-                        refs.push(other_ref.clone());
-                        labels.push("branch: else".to_string());
-                    }
-
                     let branch_taken = match eval_trace_condition(
                         &branch.when,
                         record,
@@ -211,77 +195,18 @@ pub(in crate::endpoint_engine) fn build_rule_nodes_from_rule(
                             "none"
                         }
                     };
-                    meta.insert(
-                        "branch_taken".to_string(),
-                        JsonValue::String(branch_taken.to_string()),
-                    );
-                    meta.insert(
-                        "rule_refs".to_string(),
-                        JsonValue::Array(refs.iter().cloned().map(JsonValue::String).collect()),
-                    );
-                    meta.insert(
-                        "rule_ref_labels".to_string(),
-                        JsonValue::Array(labels.iter().cloned().map(JsonValue::String).collect()),
-                    );
                     if branch.return_ && branch_taken != "none" {
                         halted = true;
                     }
-
-                    let taken_ref = match branch_taken {
-                        "then" => Some((branch.then.as_str(), then_ref)),
-                        "else" => branch
-                            .r#else
-                            .as_deref()
-                            .and_then(|path| else_ref.map(|label| (path, label))),
-                        _ => None,
-                    };
-                    if let Some((target_path, ref_label)) = taken_ref {
-                        meta.insert("rule_ref".to_string(), JsonValue::String(ref_label.clone()));
-                        meta.insert(
-                            "rule_ref_label".to_string(),
-                            JsonValue::String(format!("branch: {}", branch_taken)),
-                        );
-                        let resolved = resolve_rule_path(base_dir, target_path);
-                        if let Ok(RuleKind::Normal(loaded)) = load_rule_kind(&resolved) {
-                            let rule_source = std::fs::read_to_string(&resolved)
-                                .ok()
-                                .and_then(|source| yaml_source_to_json(&source))
-                                .unwrap_or_else(|| json!({}));
-                            let child_rule_trace = build_rule_nodes_from_rule(
-                                &loaded.rule,
-                                &step_input,
-                                context,
-                                &loaded.base_dir,
-                            );
-                            let child_duration_us = child_rule_trace.duration_us;
-                            let child_output = transform_record_with_base_dir(
-                                &loaded.rule,
-                                &step_input,
-                                context,
-                                &loaded.base_dir,
-                            )
-                            .ok()
-                            .and_then(|value| value)
-                            .unwrap_or_else(empty_object);
-                            let trace_output = child_rule_trace
-                                .pre_finalize_output
-                                .clone()
-                                .unwrap_or_else(|| child_output.clone());
-                            child_trace = Some(build_rule_trace(
-                                "normal",
-                                rule_display_name(&resolved),
-                                rule_ref_from_path(base_dir, &resolved),
-                                loaded.rule.version,
-                                rule_source,
-                                step_input.clone(),
-                                trace_output,
-                                child_rule_trace.nodes,
-                                child_rule_trace.finalize,
-                                child_duration_us,
-                                "ok",
-                            ));
-                        }
-                    }
+                    child_trace = apply_branch_trace_meta(
+                        &branch.then,
+                        branch.r#else.as_deref(),
+                        branch_taken,
+                        base_dir,
+                        &step_input,
+                        context,
+                        &mut meta,
+                    );
                 }
             }
 

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/branch_trace.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/branch_trace.rs
@@ -1,0 +1,91 @@
+use std::path::Path;
+
+use rulemorph::transform_record_with_base_dir;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+
+use super::build_rule_nodes_from_rule;
+use crate::endpoint_engine::rule_loader::{RuleKind, load_rule_kind, yaml_source_to_json};
+use crate::endpoint_engine::trace_graph::build_rule_trace;
+use crate::endpoint_engine::{
+    empty_object, resolve_rule_path, rule_display_name, rule_ref_from_path, rule_ref_from_rule,
+};
+
+pub(super) fn apply_branch_trace_meta(
+    then_path: &str,
+    else_path: Option<&str>,
+    branch_taken: &str,
+    base_dir: &Path,
+    step_input: &JsonValue,
+    context: Option<&JsonValue>,
+    meta: &mut JsonMap<String, JsonValue>,
+) -> Option<JsonValue> {
+    let mut refs = Vec::new();
+    let mut labels = Vec::new();
+    let then_ref = rule_ref_from_rule(base_dir, then_path);
+    refs.push(then_ref.clone());
+    labels.push("branch: then".to_string());
+    let else_ref = else_path.map(|other| rule_ref_from_rule(base_dir, other));
+    if let Some(other_ref) = else_ref.as_ref() {
+        refs.push(other_ref.clone());
+        labels.push("branch: else".to_string());
+    }
+
+    meta.insert(
+        "branch_taken".to_string(),
+        JsonValue::String(branch_taken.to_string()),
+    );
+    meta.insert(
+        "rule_refs".to_string(),
+        JsonValue::Array(refs.iter().cloned().map(JsonValue::String).collect()),
+    );
+    meta.insert(
+        "rule_ref_labels".to_string(),
+        JsonValue::Array(labels.iter().cloned().map(JsonValue::String).collect()),
+    );
+
+    let taken_ref = match branch_taken {
+        "then" => Some((then_path, then_ref)),
+        "else" => else_path.and_then(|path| else_ref.map(|label| (path, label))),
+        _ => None,
+    };
+    if let Some((target_path, ref_label)) = taken_ref {
+        meta.insert("rule_ref".to_string(), JsonValue::String(ref_label.clone()));
+        meta.insert(
+            "rule_ref_label".to_string(),
+            JsonValue::String(format!("branch: {}", branch_taken)),
+        );
+        let resolved = resolve_rule_path(base_dir, target_path);
+        if let Ok(RuleKind::Normal(loaded)) = load_rule_kind(&resolved) {
+            let rule_source = std::fs::read_to_string(&resolved)
+                .ok()
+                .and_then(|source| yaml_source_to_json(&source))
+                .unwrap_or_else(|| json!({}));
+            let child_rule_trace =
+                build_rule_nodes_from_rule(&loaded.rule, step_input, context, &loaded.base_dir);
+            let child_duration_us = child_rule_trace.duration_us;
+            let child_output =
+                transform_record_with_base_dir(&loaded.rule, step_input, context, &loaded.base_dir)
+                    .ok()
+                    .and_then(|value| value)
+                    .unwrap_or_else(empty_object);
+            let trace_output = child_rule_trace
+                .pre_finalize_output
+                .clone()
+                .unwrap_or_else(|| child_output.clone());
+            return Some(build_rule_trace(
+                "normal",
+                rule_display_name(&resolved),
+                rule_ref_from_path(base_dir, &resolved),
+                loaded.rule.version,
+                rule_source,
+                step_input.clone(),
+                trace_output,
+                child_rule_trace.nodes,
+                child_rule_trace.finalize,
+                child_duration_us,
+                "ok",
+            ));
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Summary
- Move endpoint rule branch trace metadata and child-trace construction into a private helper module
- Keep branch condition evaluation, return halt behavior, and error status handling in the parent step loop
- Avoid widening rulemorph public exports by passing then/else path primitives into the helper

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint endpoint_trace_branch_step_includes_rule_refs_and_child_trace -- --test-threads=1
- env CARGO_INCREMENTAL=0 cargo test -p rulemorph_endpoint rule_nodes_include_step_duration_us -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

No behavior, public API, transform semantics, trace graph JSON shape, trace schema, CLI/MCP/HTTP contract, or docs/spec changes.