### PR TITLE
Refactor network internal auth helpers

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
@@ -4,17 +4,17 @@ use anyhow::Result;
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
 use rulemorph::{get_path, parse_path};
-use serde_json::{Map as JsonMap, Value as JsonValue};
+use serde_json::Value as JsonValue;
 
 use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
 
 mod body;
+mod internal_auth;
 mod response;
 
 use super::config::RequestContext;
 use super::error::{EndpointError, EndpointErrorKind};
 use super::expr::{build_headers, eval_expr_string};
-use super::host::internal_hosts_match;
 use super::network_rule::CompiledNetworkRule;
 use super::ssrf_audit::build_ssrf_audit_log;
 use super::{EndpointEngine, NetworkExecution, empty_object};
@@ -166,77 +166,6 @@ impl EndpointEngine {
             .map_err(|err| EndpointError::network(err.to_string()))
     }
 
-    pub(super) fn is_internal_target(&self, url: &str) -> bool {
-        let Ok(target) = url::Url::parse(url) else {
-            return false;
-        };
-        let Ok(base) = url::Url::parse(&self.config.internal_base) else {
-            return false;
-        };
-        target.scheme() == base.scheme()
-            && internal_hosts_match(target.host_str(), base.host_str())
-            && target.port_or_known_default() == base.port_or_known_default()
-    }
-
-    pub(super) fn resolve_internal_api_key(
-        &self,
-        request_context: Option<&RequestContext>,
-    ) -> Option<String> {
-        if let Some(context) = request_context {
-            if let Some(key) = context.internal_api_key.as_ref() {
-                return Some(key.clone());
-            }
-        }
-        self.config.internal_api_key.clone()
-    }
-
-    pub(super) fn context_with_internal_api_key(
-        &self,
-        base_context: &JsonValue,
-        internal_api_key: &str,
-    ) -> JsonValue {
-        let mut value = base_context.clone();
-        if let JsonValue::Object(ref mut map) = value {
-            let config = map
-                .entry("config".to_string())
-                .or_insert_with(|| JsonValue::Object(JsonMap::new()));
-            if let JsonValue::Object(config) = config {
-                config.insert(
-                    "internal_api_key".to_string(),
-                    JsonValue::String(internal_api_key.to_string()),
-                );
-            }
-        }
-        value
-    }
-
-    fn ensure_internal_auth_path_allowed(&self, url: &str) -> Result<(), EndpointError> {
-        if self.config.internal_auth_path_allowlist.is_empty() {
-            return Err(EndpointError::invalid(
-                "internal_auth path allowlist not configured",
-            ));
-        }
-        let parsed =
-            url::Url::parse(url).map_err(|_| EndpointError::invalid("invalid internal url"))?;
-        let path = parsed.path();
-        let allowed = self
-            .config
-            .internal_auth_path_allowlist
-            .iter()
-            .any(|entry| {
-                if entry.ends_with('/') {
-                    path.starts_with(entry)
-                } else {
-                    path == entry
-                }
-            });
-        if allowed {
-            Ok(())
-        } else {
-            Err(EndpointError::invalid("internal_auth path not allowed"))
-        }
-    }
-
     pub(super) async fn send_network_request(
         &self,
         rule: &CompiledNetworkRule,
@@ -282,18 +211,7 @@ impl EndpointEngine {
             let mut req = client.request(rule.request.method.clone(), url);
             let mut headers = headers.clone();
             if is_internal {
-                if let Some(internal_api_key) = self.resolve_internal_api_key(request_context) {
-                    if !headers.contains_key("x-api-key") {
-                        let value = HeaderValue::from_str(&internal_api_key)
-                            .map_err(|_| EndpointError::invalid("invalid internal api key"))?;
-                        headers.insert(HeaderName::from_static("x-api-key"), value);
-                    }
-                }
-                if let Some(tenant_id) = request_context.and_then(|ctx| ctx.tenant_id.as_ref()) {
-                    let value = HeaderValue::from_str(tenant_id)
-                        .map_err(|_| EndpointError::invalid("invalid tenant id"))?;
-                    headers.insert(HeaderName::from_static("x-tenant-id"), value);
-                }
+                self.apply_internal_auth_headers(&mut headers, request_context)?;
             }
             if body.is_some() && !headers.contains_key("content-type") {
                 headers.insert(

--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/internal_auth.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/internal_auth.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use super::*;
+use crate::endpoint_engine::config::RequestContext;
+use crate::endpoint_engine::error::EndpointError;
+use crate::endpoint_engine::host::internal_hosts_match;
+
+impl EndpointEngine {
+    pub(in crate::endpoint_engine) fn is_internal_target(&self, url: &str) -> bool {
+        let Ok(target) = url::Url::parse(url) else {
+            return false;
+        };
+        let Ok(base) = url::Url::parse(&self.config.internal_base) else {
+            return false;
+        };
+        target.scheme() == base.scheme()
+            && internal_hosts_match(target.host_str(), base.host_str())
+            && target.port_or_known_default() == base.port_or_known_default()
+    }
+
+    pub(in crate::endpoint_engine) fn resolve_internal_api_key(
+        &self,
+        request_context: Option<&RequestContext>,
+    ) -> Option<String> {
+        if let Some(context) = request_context {
+            if let Some(key) = context.internal_api_key.as_ref() {
+                return Some(key.clone());
+            }
+        }
+        self.config.internal_api_key.clone()
+    }
+
+    pub(in crate::endpoint_engine) fn context_with_internal_api_key(
+        &self,
+        base_context: &JsonValue,
+        internal_api_key: &str,
+    ) -> JsonValue {
+        let mut value = base_context.clone();
+        if let JsonValue::Object(ref mut map) = value {
+            let config = map
+                .entry("config".to_string())
+                .or_insert_with(|| JsonValue::Object(JsonMap::new()));
+            if let JsonValue::Object(config) = config {
+                config.insert(
+                    "internal_api_key".to_string(),
+                    JsonValue::String(internal_api_key.to_string()),
+                );
+            }
+        }
+        value
+    }
+
+    pub(super) fn ensure_internal_auth_path_allowed(&self, url: &str) -> Result<(), EndpointError> {
+        if self.config.internal_auth_path_allowlist.is_empty() {
+            return Err(EndpointError::invalid(
+                "internal_auth path allowlist not configured",
+            ));
+        }
+        let parsed =
+            url::Url::parse(url).map_err(|_| EndpointError::invalid("invalid internal url"))?;
+        let path = parsed.path();
+        let allowed = self
+            .config
+            .internal_auth_path_allowlist
+            .iter()
+            .any(|entry| {
+                if entry.ends_with('/') {
+                    path.starts_with(entry)
+                } else {
+                    path == entry
+                }
+            });
+        if allowed {
+            Ok(())
+        } else {
+            Err(EndpointError::invalid("internal_auth path not allowed"))
+        }
+    }
+
+    pub(super) fn apply_internal_auth_headers(
+        &self,
+        headers: &mut HeaderMap,
+        request_context: Option<&RequestContext>,
+    ) -> Result<(), EndpointError> {
+        if let Some(internal_api_key) = self.resolve_internal_api_key(request_context) {
+            if !headers.contains_key("x-api-key") {
+                let value = HeaderValue::from_str(&internal_api_key)
+                    .map_err(|_| EndpointError::invalid("invalid internal api key"))?;
+                headers.insert(HeaderName::from_static("x-api-key"), value);
+            }
+        }
+        if let Some(tenant_id) = request_context.and_then(|ctx| ctx.tenant_id.as_ref()) {
+            let value = HeaderValue::from_str(tenant_id)
+                .map_err(|_| EndpointError::invalid("invalid tenant id"))?;
+            headers.insert(HeaderName::from_static("x-tenant-id"), value);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- Move endpoint network internal auth helpers into network_exec/internal_auth.rs
- Extract internal request header injection helper
- Keep network execution, SSRF, retry/catch/select, trace schema, and public API behavior unchanged

## Verification
- cargo fmt
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage405 cargo test -p rulemorph_endpoint internal_auth -- --test-threads=1
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage405 cargo test -p rulemorph_endpoint multipart_import_body_is_available_to_network_rule -- --test-threads=1 (sandbox内 bind failure 後、sandbox外で pass)
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage405-net cargo test -p rulemorph_endpoint network_response_too_large_returns_error -- --test-threads=1 (sandbox内 bind failure 後、sandbox外で pass)
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage405 cargo test -p rulemorph_endpoint network_url_eval_error_runs_catch -- --test-threads=1
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage405-full cargo test -p rulemorph_endpoint -- --test-threads=1 (sandbox外; 61 passed / 1 ignored + rules_dir_validation 7 passed)
- cargo fmt --check
- git diff --check