### PR TITLE
Refactor transform string dispatch

### DIFF
--- a/crates/rulemorph/src/transform/operators/dispatch.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch.rs
@@ -8,14 +8,13 @@ use super::json::{
 };
 use super::lookup::eval_lookup;
 use super::number::{eval_numeric_op, eval_round, eval_to_base};
-use super::simple::{eval_coalesce, eval_concat};
-use super::string::{eval_pad, eval_replace, eval_split, eval_unary_string_op};
-use super::value::{value_as_string, value_to_string};
 use super::*;
 
 mod array_dispatch;
+mod string_dispatch;
 
 use self::array_dispatch::{eval_array_dispatch, is_array_operator};
+use self::string_dispatch::{eval_string_dispatch, is_string_operator};
 
 pub(crate) fn eval_op(
     expr_op: &ExprOp,
@@ -36,95 +35,9 @@ pub(crate) fn eval_op(
     }
 
     match expr_op.op.as_str() {
-        "concat" => eval_concat(expr_op, injected, record, context, out, base_path, locals),
-        "coalesce" => eval_coalesce(expr_op, injected, record, context, out, base_path, locals),
-        "to_string" => eval_unary_string_op(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-            |value, path| value_to_string(value, path).map(JsonValue::String),
-        ),
-        "trim" => eval_unary_string_op(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-            |value, path| {
-                let s = value_as_string(value, path)?;
-                Ok(JsonValue::String(s.trim().to_string()))
-            },
-        ),
-        "lowercase" => eval_unary_string_op(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-            |value, path| {
-                let s = value_as_string(value, path)?;
-                Ok(JsonValue::String(s.to_lowercase()))
-            },
-        ),
-        "uppercase" => eval_unary_string_op(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-            |value, path| {
-                let s = value_as_string(value, path)?;
-                Ok(JsonValue::String(s.to_uppercase()))
-            },
-        ),
-        "replace" => eval_replace(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "split" => eval_split(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "pad_start" => eval_pad(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            true,
-            locals,
-        ),
-        "pad_end" => eval_pad(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            false,
-            locals,
-        ),
+        op if is_string_operator(op) => {
+            eval_string_dispatch(expr_op, record, context, out, base_path, injected, locals)
+        }
         "lookup" => eval_lookup(
             &expr_op.args,
             injected,

--- a/crates/rulemorph/src/transform/operators/dispatch/string_dispatch.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch/string_dispatch.rs
@@ -1,0 +1,123 @@
+use super::super::simple::{eval_coalesce, eval_concat};
+use super::super::string::{eval_pad, eval_replace, eval_split, eval_unary_string_op};
+use super::super::value::{value_as_string, value_to_string};
+use super::super::*;
+
+pub(super) fn is_string_operator(op: &str) -> bool {
+    matches!(
+        op,
+        "concat"
+            | "coalesce"
+            | "to_string"
+            | "trim"
+            | "lowercase"
+            | "uppercase"
+            | "replace"
+            | "split"
+            | "pad_start"
+            | "pad_end"
+    )
+}
+
+pub(super) fn eval_string_dispatch(
+    expr_op: &ExprOp,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    injected: Option<&EvalValue>,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    match expr_op.op.as_str() {
+        "concat" => eval_concat(expr_op, injected, record, context, out, base_path, locals),
+        "coalesce" => eval_coalesce(expr_op, injected, record, context, out, base_path, locals),
+        "to_string" => eval_unary_string_op(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+            |value, path| value_to_string(value, path).map(JsonValue::String),
+        ),
+        "trim" => eval_unary_string_op(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+            |value, path| {
+                let s = value_as_string(value, path)?;
+                Ok(JsonValue::String(s.trim().to_string()))
+            },
+        ),
+        "lowercase" => eval_unary_string_op(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+            |value, path| {
+                let s = value_as_string(value, path)?;
+                Ok(JsonValue::String(s.to_lowercase()))
+            },
+        ),
+        "uppercase" => eval_unary_string_op(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+            |value, path| {
+                let s = value_as_string(value, path)?;
+                Ok(JsonValue::String(s.to_uppercase()))
+            },
+        ),
+        "replace" => eval_replace(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "split" => eval_split(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "pad_start" => eval_pad(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            true,
+            locals,
+        ),
+        "pad_end" => eval_pad(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            false,
+            locals,
+        ),
+        _ => unreachable!("string dispatch called for non-string operator"),
+    }
+}


### PR DESCRIPTION
## Summary
- Move string/simple operator dispatch arms from transform operator dispatch into a private string_dispatch module
- Keep total arg validation and non-string operator routing in the parent dispatcher
- Preserve transform semantics, trace schema, public APIs, CLI/MCP/HTTP contracts, and docs/specs

## Verification
- cargo fmt
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage406-post cargo test -p rulemorph --test transform_golden t13_expr_extended -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage406-post cargo test -p rulemorph --test transform_trace -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage406-post2 cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage406-post3 cargo test -p rulemorph --lib -- --test-threads=1
- cargo fmt --check
- git diff --check