### PR TITLE
Refactor endpoint request body helper

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine.rs
@@ -35,6 +35,7 @@ mod multipart_import;
 mod network_exec;
 mod network_rule;
 mod reply_context;
+mod request_body;
 mod request_input;
 mod request_runtime;
 mod rule_exec;

--- a/crates/rulemorph_endpoint/src/endpoint_engine/request_body.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/request_body.rs
@@ -1,0 +1,63 @@
+use axum::body::Body;
+use axum::http::{HeaderMap, Method};
+use http_body_util::LengthLimitError;
+use serde_json::Value as JsonValue;
+
+use super::error::EndpointError;
+use super::multipart_import::build_multipart_import_body;
+use super::request_input::is_multipart_import_request;
+
+pub(super) struct RequestBody {
+    pub(super) value: Option<JsonValue>,
+    pub(super) multipart_temp_dir: Option<tempfile::TempDir>,
+}
+
+pub(super) async fn read_request_body(
+    method: &Method,
+    path: &str,
+    headers: &HeaderMap,
+    body: Body,
+    max_body_bytes: usize,
+) -> Result<RequestBody, EndpointError> {
+    if is_multipart_import_request(method, path, headers) {
+        let (body, temp_dir) = build_multipart_import_body(headers, body).await?;
+        return Ok(RequestBody {
+            value: Some(body),
+            multipart_temp_dir: Some(temp_dir),
+        });
+    }
+
+    match axum::body::to_bytes(body, max_body_bytes).await {
+        Ok(body_bytes) if body_bytes.is_empty() => Ok(RequestBody {
+            value: None,
+            multipart_temp_dir: None,
+        }),
+        Ok(body_bytes) => serde_json::from_slice::<JsonValue>(&body_bytes)
+            .map(|value| RequestBody {
+                value: Some(value),
+                multipart_temp_dir: None,
+            })
+            .map_err(|err| EndpointError::invalid(err.to_string())),
+        Err(err) if is_length_limit_error(&err) => {
+            Err(EndpointError::payload_too_large(max_body_bytes))
+        }
+        Err(err) => Err(EndpointError::network(format!(
+            "request body read error: {}",
+            err
+        ))),
+    }
+}
+
+fn is_length_limit_error(err: &axum::Error) -> bool {
+    let mut current: &(dyn std::error::Error + 'static) = err;
+    if current.is::<LengthLimitError>() {
+        return true;
+    }
+    while let Some(source) = current.source() {
+        if source.is::<LengthLimitError>() {
+            return true;
+        }
+        current = source;
+    }
+    false
+}

--- a/crates/rulemorph_endpoint/src/endpoint_engine/request_runtime.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/request_runtime.rs
@@ -3,32 +3,15 @@ use std::time::Instant;
 use anyhow::{Result, anyhow};
 use axum::http::Request;
 use axum::response::Response;
-use http_body_util::LengthLimitError;
 use rulemorph::v2_eval::{V2EvalContext, eval_v2_condition};
 use serde_json::Value as JsonValue;
 use tracing::warn;
 
 use super::error::EndpointError;
 use super::expr::apply_mappings_via_rule;
-use super::multipart_import::build_multipart_import_body;
-use super::request_input::{
-    build_input, build_input_from_parts, is_multipart_import_request, parse_query,
-};
+use super::request_body::read_request_body;
+use super::request_input::{build_input, build_input_from_parts, parse_query};
 use super::{EndpointEngine, empty_object};
-
-fn is_length_limit_error(err: &axum::Error) -> bool {
-    let mut current: &(dyn std::error::Error + 'static) = err;
-    if current.is::<LengthLimitError>() {
-        return true;
-    }
-    while let Some(source) = current.source() {
-        if source.is::<LengthLimitError>() {
-            return true;
-        }
-        current = source;
-    }
-    false
-}
 
 impl EndpointEngine {
     pub async fn handle_request(&self, request: Request<axum::body::Body>) -> Result<Response> {
@@ -46,31 +29,21 @@ impl EndpointEngine {
             .endpoint_rule
             .match_endpoint(&method, &path)
             .ok_or_else(|| anyhow!("no endpoint matched"))?;
-        let is_multipart = is_multipart_import_request(&method, &path, &parts.headers);
         let mut _multipart_temp_dir: Option<tempfile::TempDir> = None;
-        let body_value = if is_multipart {
-            match build_multipart_import_body(&parts.headers, body).await {
-                Ok((body, temp_dir)) => {
-                    _multipart_temp_dir = Some(temp_dir);
-                    Ok(Some(body))
-                }
-                Err(err) => Err(err),
+        let body_value = match read_request_body(
+            &method,
+            &path,
+            &parts.headers,
+            body,
+            self.config.max_body_bytes,
+        )
+        .await
+        {
+            Ok(body) => {
+                _multipart_temp_dir = body.multipart_temp_dir;
+                Ok(body.value)
             }
-        } else {
-            let body_limit = self.config.max_body_bytes;
-            match axum::body::to_bytes(body, body_limit).await {
-                Ok(body_bytes) if body_bytes.is_empty() => Ok(None),
-                Ok(body_bytes) => serde_json::from_slice::<JsonValue>(&body_bytes)
-                    .map(Some)
-                    .map_err(|err| EndpointError::invalid(err.to_string())),
-                Err(err) if is_length_limit_error(&err) => {
-                    Err(EndpointError::payload_too_large(body_limit))
-                }
-                Err(err) => Err(EndpointError::network(format!(
-                    "request body read error: {}",
-                    err
-                ))),
-            }
+            Err(err) => Err(err),
         };
 
         let endpoint = endpoint_match.endpoint;


### PR DESCRIPTION
Summary:
- Move endpoint request body parsing into endpoint_engine/request_body.rs.
- Keep handle_request matching, catch handling, step execution, reply, and trace writing in request_runtime.rs.
- No HTTP behavior, public export, trace schema, transform semantics, CLI/MCP, docs/specs changes.

Verification:
- cargo fmt
- sandbox outside: env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage412 cargo test -p rulemorph_endpoint multipart_import -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage412 cargo test -p rulemorph_endpoint request_body_too_large_writes_trace -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage412 cargo test -p rulemorph_endpoint endpoint_invalid_json_keeps_query_in_catch -- --test-threads=1
- sandbox outside: env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage412 cargo test -p rulemorph_endpoint -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-base-update: transform_stream focused, request_body_too_large_writes_trace, cargo fmt --check, git diff --check origin/v0.3.1...HEAD

Notes:
- Sandbox runs that require local bind failed with Operation not permitted and were rerun outside sandbox.
- Subagent review PASS: behavior and dependency direction unchanged.