### PR TITLE
Refactor finalize pagination helpers

### DIFF
--- a/crates/rulemorph/src/transform/finalize.rs
+++ b/crates/rulemorph/src/transform/finalize.rs
@@ -1,8 +1,10 @@
 use super::*;
 
+mod pagination;
 mod sort;
 mod wrap;
 
+use pagination::{apply_limit, apply_limit_traced, apply_offset, apply_offset_traced};
 pub(super) use sort::sort_key_from_value;
 use wrap::eval_wrap_value;
 
@@ -97,17 +99,11 @@ pub(super) fn apply_finalize(
     }
 
     if let Some(offset) = finalize.offset {
-        if offset > 0 && offset < records.len() {
-            records = records.split_off(offset);
-        } else if offset >= records.len() {
-            records = Vec::new();
-        }
+        apply_offset(&mut records, offset);
     }
 
     if let Some(limit) = finalize.limit {
-        if limit < records.len() {
-            records.truncate(limit);
-        }
+        apply_limit(&mut records, limit);
     }
 
     let output = JsonValue::Array(records);
@@ -245,27 +241,11 @@ pub(super) fn apply_finalize_traced(
     }
 
     if let Some(offset) = finalize.offset {
-        if offset > 0 && offset < records.len() {
-            records = records.split_off(offset);
-        } else if offset >= records.len() {
-            records = Vec::new();
-        }
-        collector
-            .emit(TraceEventKind::FinalizeOffset, TracePhase::Instant)
-            .rule_path("finalize.offset")
-            .attr_index("offset", offset)
-            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+        apply_offset_traced(&mut records, offset, collector);
     }
 
     if let Some(limit) = finalize.limit {
-        if limit < records.len() {
-            records.truncate(limit);
-        }
-        collector
-            .emit(TraceEventKind::FinalizeLimit, TracePhase::Instant)
-            .rule_path("finalize.limit")
-            .attr_count("limit", limit)
-            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+        apply_limit_traced(&mut records, limit, collector);
     }
 
     let output = JsonValue::Array(records);

--- a/crates/rulemorph/src/transform/finalize/pagination.rs
+++ b/crates/rulemorph/src/transform/finalize/pagination.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+pub(super) fn apply_offset(records: &mut Vec<JsonValue>, offset: usize) {
+    if offset > 0 && offset < records.len() {
+        *records = records.split_off(offset);
+    } else if offset >= records.len() {
+        records.clear();
+    }
+}
+
+pub(super) fn apply_limit(records: &mut Vec<JsonValue>, limit: usize) {
+    if limit < records.len() {
+        records.truncate(limit);
+    }
+}
+
+pub(super) fn apply_offset_traced(
+    records: &mut Vec<JsonValue>,
+    offset: usize,
+    collector: &mut TraceCollector,
+) {
+    apply_offset(records, offset);
+    collector
+        .emit(TraceEventKind::FinalizeOffset, TracePhase::Instant)
+        .rule_path("finalize.offset")
+        .attr_index("offset", offset)
+        .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+}
+
+pub(super) fn apply_limit_traced(
+    records: &mut Vec<JsonValue>,
+    limit: usize,
+    collector: &mut TraceCollector,
+) {
+    apply_limit(records, limit);
+    collector
+        .emit(TraceEventKind::FinalizeLimit, TracePhase::Instant)
+        .rule_path("finalize.limit")
+        .attr_count("limit", limit)
+        .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+}


### PR DESCRIPTION
## Summary
- Move finalize offset/limit slicing into a private pagination helper module
- Preserve traced FinalizeOffset/FinalizeLimit event emission shape
- Keep transform output and trace schema unchanged

## Tests
- cargo fmt
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage416 cargo test -p rulemorph --test transform_golden tv38_finalize_filter_offset -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage416 cargo test -p rulemorph --test transform_trace finalize -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage416 cargo test -p rulemorph --test transform_trace_semantics trace_branch_child_rule_applies_finalize_like_normal_execution -- --test-threads=1
- cargo fmt --check
- git diff --check