### PR TITLE
Refactor v2 trace map collection helpers

### DIFF
--- a/crates/rulemorph/src/transform/v2_trace/collection.rs
+++ b/crates/rulemorph/src/transform/v2_trace/collection.rs
@@ -1,10 +1,12 @@
 use super::*;
 
 mod keyed;
+mod map;
 mod predicate;
 mod sort;
 
 use keyed::eval_v2_keyed_collection_traced;
+use map::{eval_v2_flat_map_traced, eval_v2_map_traced};
 use predicate::eval_v2_predicate_collection_traced;
 use sort::eval_v2_sort_by_traced;
 pub(in crate::transform) use sort::sort_key_to_json;
@@ -150,81 +152,15 @@ pub(in crate::transform) fn eval_v2_collection_op_traced<'a>(
     let operator = op_step.op.as_str();
 
     match operator {
-        "map" => {
-            if op_step.args.len() != 1 {
-                return Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "map requires exactly one argument",
-                )
-                .with_path(path));
-            }
-            let array = v2_eval_array_from_value(pipe_value, path)?;
-            let arg_path = format!("{}.args[0]", path);
-            let mut results = Vec::new();
-            for (index, item) in array.iter().enumerate() {
-                let item_path = format!("{}[{}]", path, index);
-                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
-                let item_ctx = step_ctx
-                    .clone()
-                    .with_pipe_value(V2EvalValue::Value(item.clone()))
-                    .with_item(V2EvalItem { value: item, index });
-                let value = eval_v2_expr_traced(
-                    &op_step.args[0],
-                    record,
-                    context,
-                    out,
-                    &arg_path,
-                    &item_ctx,
-                    collector,
-                )?;
-                emit_v2_arg_eval(collector, &arg_path, 0, operator, &value);
-                finish_v2_collection_item(collector, &item_path, operator, index, &value, None);
-                if let V2EvalValue::Value(value) = value {
-                    results.push(value);
-                }
-            }
-            Ok(V2EvalValue::Value(JsonValue::Array(results)))
-        }
+        "map" => eval_v2_map_traced(
+            op_step, pipe_value, record, context, out, path, &step_ctx, collector,
+        ),
         "filter" | "partition" | "find" | "find_index" => eval_v2_predicate_collection_traced(
             op_step, pipe_value, record, context, out, path, &step_ctx, collector,
         ),
-        "flat_map" => {
-            if op_step.args.len() != 1 {
-                return Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "flat_map requires exactly one argument",
-                )
-                .with_path(path));
-            }
-            let array = v2_eval_array_from_value(pipe_value, path)?;
-            let arg_path = format!("{}.args[0]", path);
-            let mut results = Vec::new();
-            for (index, item) in array.iter().enumerate() {
-                let item_path = format!("{}[{}]", path, index);
-                emit_v2_collection_item_start(collector, &item_path, operator, index, item);
-                let item_ctx = step_ctx
-                    .clone()
-                    .with_pipe_value(V2EvalValue::Value(item.clone()))
-                    .with_item(V2EvalItem { value: item, index });
-                let value = eval_v2_expr_or_null_traced(
-                    &op_step.args[0],
-                    record,
-                    context,
-                    out,
-                    &arg_path,
-                    &item_ctx,
-                    collector,
-                )?;
-                let output = V2EvalValue::Value(value.clone());
-                emit_v2_arg_eval(collector, &arg_path, 0, operator, &output);
-                finish_v2_collection_item(collector, &item_path, operator, index, &output, None);
-                match value {
-                    JsonValue::Array(items) => results.extend(items),
-                    value => results.push(value),
-                }
-            }
-            Ok(V2EvalValue::Value(JsonValue::Array(results)))
-        }
+        "flat_map" => eval_v2_flat_map_traced(
+            op_step, pipe_value, record, context, out, path, &step_ctx, collector,
+        ),
         "group_by" | "key_by" | "distinct_by" => eval_v2_keyed_collection_traced(
             op_step, pipe_value, record, context, out, path, &step_ctx, collector,
         ),

--- a/crates/rulemorph/src/transform/v2_trace/collection/map.rs
+++ b/crates/rulemorph/src/transform/v2_trace/collection/map.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn eval_v2_map_traced<'a>(
+    op_step: &crate::v2_model::V2OpStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    step_ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    let operator = op_step.op.as_str();
+    if op_step.args.len() != 1 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "map requires exactly one argument",
+        )
+        .with_path(path));
+    }
+    let array = v2_eval_array_from_value(pipe_value, path)?;
+    let arg_path = format!("{}.args[0]", path);
+    let mut results = Vec::new();
+    for (index, item) in array.iter().enumerate() {
+        let item_path = format!("{}[{}]", path, index);
+        emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+        let item_ctx = step_ctx
+            .clone()
+            .with_pipe_value(V2EvalValue::Value(item.clone()))
+            .with_item(V2EvalItem { value: item, index });
+        let value = eval_v2_expr_traced(
+            &op_step.args[0],
+            record,
+            context,
+            out,
+            &arg_path,
+            &item_ctx,
+            collector,
+        )?;
+        emit_v2_arg_eval(collector, &arg_path, 0, operator, &value);
+        finish_v2_collection_item(collector, &item_path, operator, index, &value, None);
+        if let V2EvalValue::Value(value) = value {
+            results.push(value);
+        }
+    }
+    Ok(V2EvalValue::Value(JsonValue::Array(results)))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn eval_v2_flat_map_traced<'a>(
+    op_step: &crate::v2_model::V2OpStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    step_ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<V2EvalValue, TransformError> {
+    let operator = op_step.op.as_str();
+    if op_step.args.len() != 1 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "flat_map requires exactly one argument",
+        )
+        .with_path(path));
+    }
+    let array = v2_eval_array_from_value(pipe_value, path)?;
+    let arg_path = format!("{}.args[0]", path);
+    let mut results = Vec::new();
+    for (index, item) in array.iter().enumerate() {
+        let item_path = format!("{}[{}]", path, index);
+        emit_v2_collection_item_start(collector, &item_path, operator, index, item);
+        let item_ctx = step_ctx
+            .clone()
+            .with_pipe_value(V2EvalValue::Value(item.clone()))
+            .with_item(V2EvalItem { value: item, index });
+        let value = eval_v2_expr_or_null_traced(
+            &op_step.args[0],
+            record,
+            context,
+            out,
+            &arg_path,
+            &item_ctx,
+            collector,
+        )?;
+        let output = V2EvalValue::Value(value.clone());
+        emit_v2_arg_eval(collector, &arg_path, 0, operator, &output);
+        finish_v2_collection_item(collector, &item_path, operator, index, &output, None);
+        match value {
+            JsonValue::Array(items) => results.extend(items),
+            value => results.push(value),
+        }
+    }
+    Ok(V2EvalValue::Value(JsonValue::Array(results)))
+}


### PR DESCRIPTION
## Summary
- Move traced v2 map and flat_map collection helpers into a private collection::map module
- Keep collection item events, ArgEval emission, and item scope behavior unchanged
- Preserve transform semantics and trace schema

## Tests
- cargo fmt
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage418 cargo test -p rulemorph --test transform_trace trace_v2_pipe_operator_lifecycle_and_collection_items -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage418 cargo test -p rulemorph --test transform_trace_semantics trace_v2_collection_operators_emit_item_level_events -- --test-threads=1
- env CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/private/tmp/rulemorph-target-stage418 cargo test -p rulemorph --test transform_trace_semantics trace_v2_map_nested_error_closes_collection_and_map_spans -- --test-threads=1
- cargo fmt --check
- git diff --check