### PR TITLE
Refactor v2 eval string operators

### DIFF
--- a/crates/rulemorph/src/v2_eval/operators.rs
+++ b/crates/rulemorph/src/v2_eval/operators.rs
@@ -1,12 +1,13 @@
 use serde_json::Value as JsonValue;
 
 mod number;
+mod string;
 
 use self::number::eval_number_op;
+use self::string::eval_string_op;
 use super::{
     EvalValue, V2EvalContext, eval_collection_op, eval_comparison_op, eval_lookup_op,
-    eval_type_cast, eval_v2_expr, eval_v2_op_with_v1_fallback, eval_v2_ref, eval_value_as_string,
-    value_as_bool,
+    eval_type_cast, eval_v2_expr, eval_v2_op_with_v1_fallback, eval_v2_ref, value_as_bool,
 };
 use crate::error::{TransformError, TransformErrorKind};
 use crate::v2_model::{V2Expr, V2OpStep, V2Pipe, V2Start};
@@ -39,56 +40,8 @@ pub fn eval_v2_op_step<'a>(
 
     match op_step.op.as_str() {
         // String operations
-        "trim" => {
-            if matches!(pipe_value, EvalValue::Missing) {
-                return Ok(EvalValue::Missing);
-            }
-            let s = eval_value_as_string(&pipe_value, path)?;
-            Ok(EvalValue::Value(JsonValue::String(s.trim().to_string())))
-        }
-        "lowercase" => {
-            if matches!(pipe_value, EvalValue::Missing) {
-                return Ok(EvalValue::Missing);
-            }
-            let s = eval_value_as_string(&pipe_value, path)?;
-            Ok(EvalValue::Value(JsonValue::String(s.to_lowercase())))
-        }
-        "uppercase" => {
-            if matches!(pipe_value, EvalValue::Missing) {
-                return Ok(EvalValue::Missing);
-            }
-            let s = eval_value_as_string(&pipe_value, path)?;
-            Ok(EvalValue::Value(JsonValue::String(s.to_uppercase())))
-        }
-        "to_string" => match &pipe_value {
-            EvalValue::Missing => Ok(EvalValue::Missing),
-            EvalValue::Value(v) => {
-                let s = match v {
-                    JsonValue::String(s) => s.clone(),
-                    JsonValue::Number(n) => n.to_string(),
-                    JsonValue::Bool(b) => b.to_string(),
-                    JsonValue::Null => "null".to_string(),
-                    JsonValue::Array(_) | JsonValue::Object(_) => v.to_string(),
-                };
-                Ok(EvalValue::Value(JsonValue::String(s)))
-            }
-        },
-        "concat" => {
-            // Pipe value is first, then args
-            let mut parts = Vec::new();
-            if matches!(pipe_value, EvalValue::Missing) {
-                return Ok(EvalValue::Missing);
-            }
-            parts.push(eval_value_as_string(&pipe_value, path)?);
-            for (i, arg) in op_step.args.iter().enumerate() {
-                let arg_path = format!("{}.args[{}]", path, i);
-                let arg_value = eval_v2_expr(arg, record, context, out, &arg_path, &step_ctx)?;
-                if matches!(arg_value, EvalValue::Missing) {
-                    return Ok(EvalValue::Missing);
-                }
-                parts.push(eval_value_as_string(&arg_value, &arg_path)?);
-            }
-            Ok(EvalValue::Value(JsonValue::String(parts.join(""))))
+        "trim" | "lowercase" | "uppercase" | "to_string" | "concat" => {
+            eval_string_op(op_step, pipe_value, record, context, out, path, &step_ctx)
         }
         "string" | "int" | "float" | "bool" => {
             eval_type_cast(op_step.op.as_str(), &pipe_value, path)

--- a/crates/rulemorph/src/v2_eval/operators/string.rs
+++ b/crates/rulemorph/src/v2_eval/operators/string.rs
@@ -1,0 +1,69 @@
+use super::super::{EvalValue, V2EvalContext, eval_v2_expr, eval_value_as_string};
+use crate::error::TransformError;
+use crate::v2_model::V2OpStep;
+use serde_json::Value as JsonValue;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn eval_string_op<'a>(
+    op_step: &V2OpStep,
+    pipe_value: EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    step_ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    match op_step.op.as_str() {
+        "trim" => {
+            if matches!(pipe_value, EvalValue::Missing) {
+                return Ok(EvalValue::Missing);
+            }
+            let s = eval_value_as_string(&pipe_value, path)?;
+            Ok(EvalValue::Value(JsonValue::String(s.trim().to_string())))
+        }
+        "lowercase" => {
+            if matches!(pipe_value, EvalValue::Missing) {
+                return Ok(EvalValue::Missing);
+            }
+            let s = eval_value_as_string(&pipe_value, path)?;
+            Ok(EvalValue::Value(JsonValue::String(s.to_lowercase())))
+        }
+        "uppercase" => {
+            if matches!(pipe_value, EvalValue::Missing) {
+                return Ok(EvalValue::Missing);
+            }
+            let s = eval_value_as_string(&pipe_value, path)?;
+            Ok(EvalValue::Value(JsonValue::String(s.to_uppercase())))
+        }
+        "to_string" => match &pipe_value {
+            EvalValue::Missing => Ok(EvalValue::Missing),
+            EvalValue::Value(v) => {
+                let s = match v {
+                    JsonValue::String(s) => s.clone(),
+                    JsonValue::Number(n) => n.to_string(),
+                    JsonValue::Bool(b) => b.to_string(),
+                    JsonValue::Null => "null".to_string(),
+                    JsonValue::Array(_) | JsonValue::Object(_) => v.to_string(),
+                };
+                Ok(EvalValue::Value(JsonValue::String(s)))
+            }
+        },
+        "concat" => {
+            let mut parts = Vec::new();
+            if matches!(pipe_value, EvalValue::Missing) {
+                return Ok(EvalValue::Missing);
+            }
+            parts.push(eval_value_as_string(&pipe_value, path)?);
+            for (i, arg) in op_step.args.iter().enumerate() {
+                let arg_path = format!("{}.args[{}]", path, i);
+                let arg_value = eval_v2_expr(arg, record, context, out, &arg_path, step_ctx)?;
+                if matches!(arg_value, EvalValue::Missing) {
+                    return Ok(EvalValue::Missing);
+                }
+                parts.push(eval_value_as_string(&arg_value, &arg_path)?);
+            }
+            Ok(EvalValue::Value(JsonValue::String(parts.join(""))))
+        }
+        _ => unreachable!("string dispatcher only calls direct string operators"),
+    }
+}


### PR DESCRIPTION
## Summary
- Move direct v2 string operator evaluation into a private operators::string module
- Keep operators.rs focused on op step routing and fallback dispatch
- Preserve missing propagation, to_string conversion, concat arg paths, and v1 fallback string ops

## Verification
- cargo fmt
- cargo test -p rulemorph --lib test_eval_op_trim -- --test-threads=1
- cargo test -p rulemorph --lib test_eval_op_lowercase -- --test-threads=1
- cargo test -p rulemorph --lib test_eval_op_uppercase -- --test-threads=1
- cargo test -p rulemorph --lib test_eval_op_to_string -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives -- --test-threads=1
- cargo test -p rulemorph --test transform_trace trace_v2_operator_inputs_preserve_missing_values -- --test-threads=1
- cargo fmt --check
- git diff --check