### PR TITLE
Refactor trace writer detail file checks

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer/bundle.rs
+++ b/crates/rulemorph_trace/src/trace_writer/bundle.rs
@@ -24,9 +24,11 @@ use crate::trace_schema::{
 };
 
 mod detail_cleanup;
+mod detail_files;
 mod manifest_build;
 mod manifest_payload;
 use self::detail_cleanup::{add_detail_reason, reset_detail_to_basic, total_detail_bytes};
+use self::detail_files::ensure_detail_files_exist;
 use self::manifest_build::build_trace_manifest;
 use self::manifest_payload::write_manifest_payload;
 
@@ -273,27 +275,7 @@ pub(crate) fn write_trace_bundle_sync(
         &options,
     );
 
-    // Ensure any temporary files were created (record files already written).
-    if detail.status == "full" {
-        for path in record_files {
-            if !path.exists() {
-                return Err(anyhow::anyhow!("record chunk missing: {}", path.display()));
-            }
-        }
-        for path in node_files {
-            if !path.exists() {
-                return Err(anyhow::anyhow!("node chunk missing: {}", path.display()));
-            }
-        }
-        if let Some(path) = finalize_file {
-            if !path.exists() {
-                return Err(anyhow::anyhow!(
-                    "finalize chunk missing: {}",
-                    path.display()
-                ));
-            }
-        }
-    }
+    ensure_detail_files_exist(&detail.status, record_files, node_files, finalize_file)?;
 
     let manifest_path = trace_dir.join("trace.json");
     write_manifest_payload(&manifest_path, &mut manifest, &mut detail)?;

--- a/crates/rulemorph_trace/src/trace_writer/bundle/detail_files.rs
+++ b/crates/rulemorph_trace/src/trace_writer/bundle/detail_files.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+pub(super) fn ensure_detail_files_exist(
+    detail_status: &str,
+    record_files: Vec<PathBuf>,
+    node_files: Vec<PathBuf>,
+    finalize_file: Option<PathBuf>,
+) -> Result<()> {
+    if detail_status != "full" {
+        return Ok(());
+    }
+
+    for path in record_files {
+        if !path.exists() {
+            return Err(anyhow::anyhow!("record chunk missing: {}", path.display()));
+        }
+    }
+    for path in node_files {
+        if !path.exists() {
+            return Err(anyhow::anyhow!("node chunk missing: {}", path.display()));
+        }
+    }
+    if let Some(path) = finalize_file {
+        if !path.exists() {
+            return Err(anyhow::anyhow!(
+                "finalize chunk missing: {}",
+                path.display()
+            ));
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Move trace writer detail chunk file existence verification into a private bundle helper
- Keep bundle.rs focused on orchestration, downgrade handling, manifest build, and manifest write
- Preserve masking/externalization/chunking order, downgrade behavior, cleanup guard behavior, and error messages

## Verification
- cargo fmt
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_default_compression_loads -- --test-threads=1
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_roundtrips_finalize_zstd -- --test-threads=1
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_emits_chunk_metadata_offsets -- --test-threads=1
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_masks_preview_for_externalized_payloads -- --test-threads=1
- cargo test -p rulemorph_trace --lib write_trace_bundle_cleans_up_on_manifest_write_failure -- --test-threads=1
- cargo fmt --check
- git diff --check