### PR TITLE
Refactor xlsx DynamoDB fixture

### DIFF
--- a/crates/rulemorph/tests/common/xlsx.rs
+++ b/crates/rulemorph/tests/common/xlsx.rs
@@ -2,6 +2,10 @@ use std::io::{Cursor, Write};
 
 use zip::{CompressionMethod, ZipWriter, write::FileOptions};
 
+mod dynamodb;
+
+pub(crate) use dynamodb::build_dynamodb_users_xlsx;
+
 #[derive(Default)]
 pub(crate) struct XlsxFixtureOptions {
     pub(crate) duplicate_header: bool,
@@ -254,88 +258,9 @@ pub(crate) fn build_test_xlsx(options: XlsxFixtureOptions) -> Vec<u8> {
     zip.finish().expect("finish xlsx").into_inner()
 }
 
-pub(crate) fn build_dynamodb_users_xlsx() -> Vec<u8> {
-    let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
-    let file_options = FileOptions::default().compression_method(CompressionMethod::Deflated);
-    write_zip_file(
-        &mut zip,
-        "[Content_Types].xml",
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
-  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
-  <Default Extension="xml" ContentType="application/xml"/>
-  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
-  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
-  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
-  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
-</Types>"#,
-        file_options,
-    );
-    write_zip_file(
-        &mut zip,
-        "_rels/.rels",
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
-</Relationships>"#,
-        file_options,
-    );
-    write_zip_file(
-        &mut zip,
-        "xl/workbook.xml",
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <sheets><sheet name="Users" sheetId="1" r:id="rId1"/></sheets>
-</workbook>"#,
-        file_options,
-    );
-    write_zip_file(
-        &mut zip,
-        "xl/_rels/workbook.xml.rels",
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
-  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
-  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
-</Relationships>"#,
-        file_options,
-    );
-    write_zip_file(
-        &mut zip,
-        "xl/sharedStrings.xml",
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="8" uniqueCount="8">
-  <si><t>user_id</t></si><si><t>email</t></si><si><t>age</t></si><si><t>active</t></si>
-  <si><t>u001</t></si><si><t>alice@example.com</t></si><si><t>u002</t></si><si><t>bob@example.com</t></si>
-</sst>"#,
-        file_options,
-    );
-    write_zip_file(
-        &mut zip,
-        "xl/styles.xml",
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs></styleSheet>"#,
-        file_options,
-    );
-    write_zip_file(
-        &mut zip,
-        "xl/worksheets/sheet1.xml",
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c><c r="D1" t="s"><v>3</v></c></row>
-    <row r="2"><c r="A2" t="s"><v>4</v></c><c r="B2" t="s"><v>5</v></c><c r="C2"><v>31</v></c><c r="D2" t="b"><v>1</v></c></row>
-    <row r="3"><c r="A3" t="s"><v>6</v></c><c r="B3" t="s"><v>7</v></c><c r="C3"><v>28</v></c><c r="D3" t="b"><v>0</v></c></row>
-  </sheetData>
-</worksheet>"#,
-        file_options,
-    );
-    zip.finish().expect("finish dynamodb xlsx").into_inner()
-}
-
 include!("xlsx/string_table.rs");
 
-fn write_zip_file(
+pub(super) fn write_zip_file(
     zip: &mut ZipWriter<Cursor<Vec<u8>>>,
     name: &str,
     contents: &str,

--- a/crates/rulemorph/tests/common/xlsx/dynamodb.rs
+++ b/crates/rulemorph/tests/common/xlsx/dynamodb.rs
@@ -1,0 +1,84 @@
+use std::io::Cursor;
+
+use zip::{CompressionMethod, ZipWriter, write::FileOptions};
+
+use super::write_zip_file;
+
+pub(crate) fn build_dynamodb_users_xlsx() -> Vec<u8> {
+    let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
+    let file_options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+    write_zip_file(
+        &mut zip,
+        "[Content_Types].xml",
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>"#,
+        file_options,
+    );
+    write_zip_file(
+        &mut zip,
+        "_rels/.rels",
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#,
+        file_options,
+    );
+    write_zip_file(
+        &mut zip,
+        "xl/workbook.xml",
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Users" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#,
+        file_options,
+    );
+    write_zip_file(
+        &mut zip,
+        "xl/_rels/workbook.xml.rels",
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>"#,
+        file_options,
+    );
+    write_zip_file(
+        &mut zip,
+        "xl/sharedStrings.xml",
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="8" uniqueCount="8">
+  <si><t>user_id</t></si><si><t>email</t></si><si><t>age</t></si><si><t>active</t></si>
+  <si><t>u001</t></si><si><t>alice@example.com</t></si><si><t>u002</t></si><si><t>bob@example.com</t></si>
+</sst>"#,
+        file_options,
+    );
+    write_zip_file(
+        &mut zip,
+        "xl/styles.xml",
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs></styleSheet>"#,
+        file_options,
+    );
+    write_zip_file(
+        &mut zip,
+        "xl/worksheets/sheet1.xml",
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c><c r="D1" t="s"><v>3</v></c></row>
+    <row r="2"><c r="A2" t="s"><v>4</v></c><c r="B2" t="s"><v>5</v></c><c r="C2"><v>31</v></c><c r="D2" t="b"><v>1</v></c></row>
+    <row r="3"><c r="A3" t="s"><v>6</v></c><c r="B3" t="s"><v>7</v></c><c r="C3"><v>28</v></c><c r="D3" t="b"><v>0</v></c></row>
+  </sheetData>
+</worksheet>"#,
+        file_options,
+    );
+    zip.finish().expect("finish dynamodb xlsx").into_inner()
+}


### PR DESCRIPTION
## Summary
- move the DynamoDB users XLSX fixture builder into a dedicated test-support module
- keep the parent common xlsx helper as the public test facade and shared ZIP writer owner

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden dynamodb -- --test-threads=1
- cargo test -p rulemorph --test transform_golden excel -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

No production code, public API, transform semantics, trace JSON schema, CLI/MCP/HTTP contract, or docs/specs changes.