### PR TITLE
Refactor endpoint rule node step outputs

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes.rs
@@ -1,16 +1,18 @@
 use std::path::Path;
 use std::time::Instant;
 
-use rulemorph::{RuleFile, TransformError, TransformErrorKind, transform_record_with_base_dir};
+use rulemorph::{RuleFile, TransformError, TransformErrorKind};
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 use self::branch_trace::apply_branch_trace_meta;
+use self::step_outputs::collect_step_outputs;
 use super::condition::eval_trace_condition;
 use super::duration::sum_rule_trace_duration_us;
 use super::finalize::build_finalize_trace;
 use super::mapping_ops::build_mapping_ops_with_values;
 
 mod branch_trace;
+mod step_outputs;
 
 pub(in crate::endpoint_engine) struct RuleTraceNodes {
     pub(in crate::endpoint_engine) nodes: Vec<JsonValue>,
@@ -29,16 +31,7 @@ pub(in crate::endpoint_engine) fn build_rule_nodes_from_rule(
     let mut finalize_trace: Option<JsonValue> = None;
     let mut pre_finalize_output: Option<JsonValue> = None;
     if let Some(steps) = &rule.steps {
-        let mut step_outputs = Vec::with_capacity(steps.len());
-        for index in 0..steps.len() {
-            let mut partial_rule = rule.clone();
-            partial_rule.steps = Some(steps[..=index].to_vec());
-            partial_rule.finalize = None;
-            let started = Instant::now();
-            let result = transform_record_with_base_dir(&partial_rule, record, context, base_dir);
-            let duration_us = started.elapsed().as_micros() as u64;
-            step_outputs.push((result, duration_us));
-        }
+        let step_outputs = collect_step_outputs(rule, record, context, base_dir);
 
         let mut prev_output = JsonValue::Object(JsonMap::new());
         let mut halted = false;

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/step_outputs.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/step_outputs.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+use std::time::Instant;
+
+use rulemorph::{RuleFile, TransformError, transform_record_with_base_dir};
+use serde_json::Value as JsonValue;
+
+pub(super) fn collect_step_outputs(
+    rule: &RuleFile,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Vec<(Result<Option<JsonValue>, TransformError>, u64)> {
+    let Some(steps) = rule.steps.as_deref() else {
+        return Vec::new();
+    };
+    let mut step_outputs = Vec::with_capacity(steps.len());
+    for index in 0..steps.len() {
+        let mut partial_rule = rule.clone();
+        partial_rule.steps = Some(steps[..=index].to_vec());
+        partial_rule.finalize = None;
+        let started = Instant::now();
+        let result = transform_record_with_base_dir(&partial_rule, record, context, base_dir);
+        let duration_us = started.elapsed().as_micros() as u64;
+        step_outputs.push((result, duration_us));
+    }
+    step_outputs
+}


### PR DESCRIPTION
## Summary
- move endpoint rule trace step-output collection into a private child module
- keep trace node assembly, branch/finalize/mapping orchestration, and public surfaces unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_endpoint rule_nodes_include_step_duration_us -- --test-threads=1
- cargo test -p rulemorph_endpoint endpoint_trace_branch_step_includes_rule_refs_and_child_trace -- --test-threads=1
- cargo test -p rulemorph_server --test cloud_scenarios cloud_scenario_trace_full_detail_roundtrip -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

Note: an initial parallel test attempt failed to compile because the helper briefly referenced a non-exported Step type from the rulemorph crate. The final implementation avoids exposing private model types by taking RuleFile and reading rule.steps internally.

No public API, transform semantics, trace JSON schema, CLI/MCP/HTTP contract, security invariant, or docs/specs changes.