### PR TITLE
Refactor MCP rule warning diagnostics

### DIFF
--- a/crates/rulemorph_mcp/src/diagnostics.rs
+++ b/crates/rulemorph_mcp/src/diagnostics.rs
@@ -1,12 +1,16 @@
 use std::path::Path;
 
 use rulemorph::{
-    Expr, ExprChain, ExprOp, InputData, RuleError, RuleFile, TransformError, TransformErrorKind,
-    TransformWarning, transform_stream_input, transform_stream_input_with_base_dir,
+    InputData, RuleError, RuleFile, TransformError, TransformErrorKind, TransformWarning,
+    transform_stream_input, transform_stream_input_with_base_dir,
 };
 use serde_json::{Value, json};
 
 use crate::errors::CallError;
+
+mod rule_warnings;
+
+pub(crate) use self::rule_warnings::{collect_rule_warnings, rule_warnings_to_json};
 
 pub(crate) fn transform_to_ndjson(
     rule: &RuleFile,
@@ -49,113 +53,6 @@ pub(crate) fn transform_to_ndjson(
     Ok((output, warnings))
 }
 
-pub(crate) struct RuleWarning {
-    code: &'static str,
-    message: String,
-    path: Option<String>,
-}
-
-pub(crate) fn collect_rule_warnings(rule: &RuleFile) -> Vec<RuleWarning> {
-    let mut warnings = Vec::new();
-    if let Some(expr) = &rule.record_when {
-        collect_expr_warnings(expr, "record_when", &mut warnings);
-    }
-    for (index, mapping) in rule.mappings.iter().enumerate() {
-        let base_path = format!("mappings[{}]", index);
-        if let Some(expr) = &mapping.expr {
-            collect_expr_warnings(expr, &format!("{}.expr", base_path), &mut warnings);
-        }
-        if let Some(expr) = &mapping.when {
-            collect_expr_warnings(expr, &format!("{}.when", base_path), &mut warnings);
-        }
-    }
-    warnings
-}
-
-fn collect_expr_warnings(expr: &Expr, path: &str, warnings: &mut Vec<RuleWarning>) {
-    match expr {
-        Expr::Ref(_) | Expr::Literal(_) => {}
-        Expr::Op(expr_op) => collect_op_warnings(expr_op, path, false, warnings),
-        Expr::Chain(chain) => collect_chain_warnings(chain, path, warnings),
-    }
-}
-
-fn collect_chain_warnings(chain: &ExprChain, path: &str, warnings: &mut Vec<RuleWarning>) {
-    for (index, step) in chain.chain.iter().enumerate() {
-        let step_path = format!("{}.chain[{}]", path, index);
-        if index == 0 {
-            collect_expr_warnings(step, &step_path, warnings);
-            continue;
-        }
-
-        match step {
-            Expr::Op(expr_op) => collect_op_warnings(expr_op, &step_path, true, warnings),
-            _ => collect_expr_warnings(step, &step_path, warnings),
-        }
-    }
-}
-
-fn collect_op_warnings(
-    expr_op: &ExprOp,
-    path: &str,
-    chain_step: bool,
-    warnings: &mut Vec<RuleWarning>,
-) {
-    if expr_op.op == "date_format" {
-        warn_date_format_missing_input_format(expr_op, path, chain_step, warnings);
-    } else if expr_op.op == "to_unixtime" {
-        warnings.push(RuleWarning {
-            code: "to_unixtime_auto_parse",
-            message: "to_unixtime relies on heuristic date parsing; consider normalizing with date_format + input_format.".to_string(),
-            path: Some(path.to_string()),
-        });
-    }
-
-    for (index, arg) in expr_op.args.iter().enumerate() {
-        let arg_path = format!("{}.args[{}]", path, index);
-        collect_expr_warnings(arg, &arg_path, warnings);
-    }
-}
-
-fn warn_date_format_missing_input_format(
-    expr_op: &ExprOp,
-    path: &str,
-    chain_step: bool,
-    warnings: &mut Vec<RuleWarning>,
-) {
-    let input_index = if chain_step { 1 } else { 2 };
-    if expr_op.args.len() <= input_index {
-        warnings.push(RuleWarning {
-            code: "date_format_missing_input_format",
-            message: "date_format without input_format relies on heuristic parsing; consider providing input_format.".to_string(),
-            path: Some(format!("{}.args", path)),
-        });
-        return;
-    }
-
-    if expr_looks_like_timezone(&expr_op.args[input_index]) {
-        warnings.push(RuleWarning {
-            code: "date_format_missing_input_format",
-            message: "date_format without input_format relies on heuristic parsing; consider providing input_format.".to_string(),
-            path: Some(format!("{}.args[{}]", path, input_index)),
-        });
-    }
-}
-
-fn expr_looks_like_timezone(expr: &Expr) -> bool {
-    match expr {
-        Expr::Literal(Value::String(value)) => looks_like_timezone(value),
-        _ => false,
-    }
-}
-
-fn looks_like_timezone(value: &str) -> bool {
-    if value.eq_ignore_ascii_case("utc") || value == "Z" {
-        return true;
-    }
-    matches!(value.chars().next(), Some('+') | Some('-'))
-}
-
 pub(crate) fn validation_errors_to_text(errors: &[RuleError]) -> String {
     let values = validation_errors_to_values(errors);
     serde_json::to_string(&values).unwrap_or_else(|_| "validation error".to_string())
@@ -180,23 +77,6 @@ fn validation_error_json(err: &RuleError) -> Value {
         value["column"] = json!(location.column);
     }
 
-    value
-}
-
-pub(crate) fn rule_warnings_to_json(warnings: &[RuleWarning]) -> Value {
-    let values: Vec<_> = warnings.iter().map(rule_warning_json).collect();
-    Value::Array(values)
-}
-
-fn rule_warning_json(warning: &RuleWarning) -> Value {
-    let mut value = json!({
-        "type": "warning",
-        "code": warning.code,
-        "message": warning.message,
-    });
-    if let Some(path) = &warning.path {
-        value["path"] = json!(path);
-    }
     value
 }
 

--- a/crates/rulemorph_mcp/src/diagnostics/rule_warnings.rs
+++ b/crates/rulemorph_mcp/src/diagnostics/rule_warnings.rs
@@ -1,0 +1,126 @@
+use rulemorph::{Expr, ExprChain, ExprOp, RuleFile};
+use serde_json::{Value, json};
+
+pub(crate) struct RuleWarning {
+    code: &'static str,
+    message: String,
+    path: Option<String>,
+}
+
+pub(crate) fn collect_rule_warnings(rule: &RuleFile) -> Vec<RuleWarning> {
+    let mut warnings = Vec::new();
+    if let Some(expr) = &rule.record_when {
+        collect_expr_warnings(expr, "record_when", &mut warnings);
+    }
+    for (index, mapping) in rule.mappings.iter().enumerate() {
+        let base_path = format!("mappings[{}]", index);
+        if let Some(expr) = &mapping.expr {
+            collect_expr_warnings(expr, &format!("{}.expr", base_path), &mut warnings);
+        }
+        if let Some(expr) = &mapping.when {
+            collect_expr_warnings(expr, &format!("{}.when", base_path), &mut warnings);
+        }
+    }
+    warnings
+}
+
+fn collect_expr_warnings(expr: &Expr, path: &str, warnings: &mut Vec<RuleWarning>) {
+    match expr {
+        Expr::Ref(_) | Expr::Literal(_) => {}
+        Expr::Op(expr_op) => collect_op_warnings(expr_op, path, false, warnings),
+        Expr::Chain(chain) => collect_chain_warnings(chain, path, warnings),
+    }
+}
+
+fn collect_chain_warnings(chain: &ExprChain, path: &str, warnings: &mut Vec<RuleWarning>) {
+    for (index, step) in chain.chain.iter().enumerate() {
+        let step_path = format!("{}.chain[{}]", path, index);
+        if index == 0 {
+            collect_expr_warnings(step, &step_path, warnings);
+            continue;
+        }
+
+        match step {
+            Expr::Op(expr_op) => collect_op_warnings(expr_op, &step_path, true, warnings),
+            _ => collect_expr_warnings(step, &step_path, warnings),
+        }
+    }
+}
+
+fn collect_op_warnings(
+    expr_op: &ExprOp,
+    path: &str,
+    chain_step: bool,
+    warnings: &mut Vec<RuleWarning>,
+) {
+    if expr_op.op == "date_format" {
+        warn_date_format_missing_input_format(expr_op, path, chain_step, warnings);
+    } else if expr_op.op == "to_unixtime" {
+        warnings.push(RuleWarning {
+            code: "to_unixtime_auto_parse",
+            message: "to_unixtime relies on heuristic date parsing; consider normalizing with date_format + input_format.".to_string(),
+            path: Some(path.to_string()),
+        });
+    }
+
+    for (index, arg) in expr_op.args.iter().enumerate() {
+        let arg_path = format!("{}.args[{}]", path, index);
+        collect_expr_warnings(arg, &arg_path, warnings);
+    }
+}
+
+fn warn_date_format_missing_input_format(
+    expr_op: &ExprOp,
+    path: &str,
+    chain_step: bool,
+    warnings: &mut Vec<RuleWarning>,
+) {
+    let input_index = if chain_step { 1 } else { 2 };
+    if expr_op.args.len() <= input_index {
+        warnings.push(RuleWarning {
+            code: "date_format_missing_input_format",
+            message: "date_format without input_format relies on heuristic parsing; consider providing input_format.".to_string(),
+            path: Some(format!("{}.args", path)),
+        });
+        return;
+    }
+
+    if expr_looks_like_timezone(&expr_op.args[input_index]) {
+        warnings.push(RuleWarning {
+            code: "date_format_missing_input_format",
+            message: "date_format without input_format relies on heuristic parsing; consider providing input_format.".to_string(),
+            path: Some(format!("{}.args[{}]", path, input_index)),
+        });
+    }
+}
+
+fn expr_looks_like_timezone(expr: &Expr) -> bool {
+    match expr {
+        Expr::Literal(Value::String(value)) => looks_like_timezone(value),
+        _ => false,
+    }
+}
+
+fn looks_like_timezone(value: &str) -> bool {
+    if value.eq_ignore_ascii_case("utc") || value == "Z" {
+        return true;
+    }
+    matches!(value.chars().next(), Some('+') | Some('-'))
+}
+
+pub(crate) fn rule_warnings_to_json(warnings: &[RuleWarning]) -> Value {
+    let values: Vec<_> = warnings.iter().map(rule_warning_json).collect();
+    Value::Array(values)
+}
+
+fn rule_warning_json(warning: &RuleWarning) -> Value {
+    let mut value = json!({
+        "type": "warning",
+        "code": warning.code,
+        "message": warning.message,
+    });
+    if let Some(path) = &warning.path {
+        value["path"] = json!(path);
+    }
+    value
+}

--- a/crates/rulemorph_mcp/tests/stdio.rs
+++ b/crates/rulemorph_mcp/tests/stdio.rs
@@ -75,6 +75,73 @@ mappings:
 }
 
 #[test]
+fn validate_rules_success_includes_rule_warnings() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let rules_text = r#"version: 1
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "formatted"
+    expr:
+      op: "date_format"
+      args:
+        - { ref: "input.date" }
+        - "%Y-%m-%d"
+  - target: "epoch"
+    expr:
+      op: "to_unixtime"
+      args:
+        - { ref: "input.date" }
+  - target: "chain_formatted"
+    expr:
+      chain:
+        - { ref: "input.date" }
+        - op: "date_format"
+          args:
+            - "%Y-%m-%d"
+"#;
+
+    let request = tool_call_request(
+        9,
+        "validate_rules",
+        json!({
+            "rules_text": rules_text
+        }),
+    );
+
+    let response = server.send(&request);
+    assert_eq!(content_text(&response), "ok");
+    assert_eq!(
+        response["result"]["meta"]["warnings"],
+        json!([
+            {
+                "type": "warning",
+                "code": "date_format_missing_input_format",
+                "message": "date_format without input_format relies on heuristic parsing; consider providing input_format.",
+                "path": "mappings[0].expr.args"
+            },
+            {
+                "type": "warning",
+                "code": "to_unixtime_auto_parse",
+                "message": "to_unixtime relies on heuristic date parsing; consider normalizing with date_format + input_format.",
+                "path": "mappings[1].expr"
+            },
+            {
+                "type": "warning",
+                "code": "date_format_missing_input_format",
+                "message": "date_format without input_format relies on heuristic parsing; consider providing input_format.",
+                "path": "mappings[2].expr.chain[1].args"
+            }
+        ])
+    );
+
+    server.shutdown();
+}
+
+#[test]
 fn validate_rules_failure() {
     let mut server = McpServer::start();
     initialize(&mut server);


### PR DESCRIPTION
Summary:
- add a characterization test for validate_rules warning metadata
- move MCP rule warning collection and warning JSON formatting into diagnostics/rule_warnings.rs
- keep transform, validation, parse diagnostic formatting in diagnostics.rs
- no behavior, public API, transform semantics, trace schema, CLI/HTTP contract, or docs/spec changes

Verification:
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio validate_rules_success_includes_rule_warnings -- --test-threads=1 before split
- cargo test -p rulemorph_mcp --test stdio validate_rules_success_includes_rule_warnings -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio validate_rules_success -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio validate_rules_failure -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit quick: cargo test -p rulemorph_mcp --test stdio validate_rules_success_includes_rule_warnings -- --test-threads=1