### PR TITLE
Refactor transform API input wrappers

### DIFF
--- a/crates/rulemorph/src/transform/api.rs
+++ b/crates/rulemorph/src/transform/api.rs
@@ -16,7 +16,15 @@ mod preflight;
 mod record;
 mod trace;
 
-use input::transform_with_warnings_inner;
+pub use input::{
+    transform, transform_input, transform_input_with_base_dir,
+    transform_input_with_base_dir_and_options, transform_input_with_options,
+    transform_input_with_warnings, transform_input_with_warnings_with_base_dir,
+    transform_input_with_warnings_with_base_dir_and_options,
+    transform_input_with_warnings_with_options, transform_with_base_dir, transform_with_options,
+    transform_with_warnings, transform_with_warnings_with_base_dir,
+    transform_with_warnings_with_base_dir_and_options, transform_with_warnings_with_options,
+};
 
 pub use preflight::{
     preflight_validate, preflight_validate_input, preflight_validate_input_with_base_dir,
@@ -34,158 +42,3 @@ pub use trace::{
     transform_input_with_trace, transform_input_with_trace_with_base_dir_and_options,
     transform_record_with_trace,
 };
-
-pub fn transform(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-) -> Result<JsonValue, TransformError> {
-    transform_with_warnings(rule, input, context).map(|(output, _)| output)
-}
-
-pub fn transform_input(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-) -> Result<JsonValue, TransformError> {
-    transform_input_with_warnings(rule, input, context).map(|(output, _)| output)
-}
-
-pub fn transform_with_options(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-    options: &NormalizationOptions,
-) -> Result<JsonValue, TransformError> {
-    transform_with_warnings_with_options(rule, input, context, options).map(|(output, _)| output)
-}
-
-pub fn transform_input_with_options(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    options: &NormalizationOptions,
-) -> Result<JsonValue, TransformError> {
-    transform_input_with_warnings_with_options(rule, input, context, options)
-        .map(|(output, _)| output)
-}
-
-pub fn transform_with_base_dir(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<JsonValue, TransformError> {
-    transform_with_warnings_with_base_dir(rule, input, context, base_dir).map(|(output, _)| output)
-}
-
-pub fn transform_input_with_base_dir(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<JsonValue, TransformError> {
-    transform_input_with_warnings_with_base_dir(rule, input, context, base_dir)
-        .map(|(output, _)| output)
-}
-
-pub fn transform_input_with_base_dir_and_options(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-    options: &NormalizationOptions,
-) -> Result<JsonValue, TransformError> {
-    transform_input_with_warnings_with_base_dir_and_options(rule, input, context, base_dir, options)
-        .map(|(output, _)| output)
-}
-
-pub fn transform_with_warnings(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_input_with_warnings(rule, InputData::Text(input), context)
-}
-
-pub fn transform_input_with_warnings(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_with_warnings_inner(rule, input, context, None, &NormalizationOptions::default())
-}
-
-pub fn transform_with_warnings_with_options(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-    options: &NormalizationOptions,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_input_with_warnings_with_options(rule, InputData::Text(input), context, options)
-}
-
-pub fn transform_input_with_warnings_with_options(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    options: &NormalizationOptions,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_with_warnings_inner(rule, input, context, None, options)
-}
-
-pub fn transform_with_warnings_with_base_dir(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_with_warnings_with_base_dir_and_options(
-        rule,
-        input,
-        context,
-        base_dir,
-        &NormalizationOptions::default(),
-    )
-}
-
-pub fn transform_input_with_warnings_with_base_dir(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_input_with_warnings_with_base_dir_and_options(
-        rule,
-        input,
-        context,
-        base_dir,
-        &NormalizationOptions::default(),
-    )
-}
-
-pub fn transform_with_warnings_with_base_dir_and_options(
-    rule: &RuleFile,
-    input: &str,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-    options: &NormalizationOptions,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_input_with_warnings_with_base_dir_and_options(
-        rule,
-        InputData::Text(input),
-        context,
-        base_dir,
-        options,
-    )
-}
-
-pub fn transform_input_with_warnings_with_base_dir_and_options(
-    rule: &RuleFile,
-    input: InputData<'_>,
-    context: Option<&JsonValue>,
-    base_dir: &Path,
-    options: &NormalizationOptions,
-) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
-    transform_with_warnings_inner(rule, input, context, Some(base_dir), options)
-}

--- a/crates/rulemorph/src/transform/api/input.rs
+++ b/crates/rulemorph/src/transform/api/input.rs
@@ -1,5 +1,160 @@
 use super::*;
 
+pub fn transform(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+) -> Result<JsonValue, TransformError> {
+    transform_with_warnings(rule, input, context).map(|(output, _)| output)
+}
+
+pub fn transform_input(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+) -> Result<JsonValue, TransformError> {
+    transform_input_with_warnings(rule, input, context).map(|(output, _)| output)
+}
+
+pub fn transform_with_options(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+    options: &NormalizationOptions,
+) -> Result<JsonValue, TransformError> {
+    transform_with_warnings_with_options(rule, input, context, options).map(|(output, _)| output)
+}
+
+pub fn transform_input_with_options(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    options: &NormalizationOptions,
+) -> Result<JsonValue, TransformError> {
+    transform_input_with_warnings_with_options(rule, input, context, options)
+        .map(|(output, _)| output)
+}
+
+pub fn transform_with_base_dir(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<JsonValue, TransformError> {
+    transform_with_warnings_with_base_dir(rule, input, context, base_dir).map(|(output, _)| output)
+}
+
+pub fn transform_input_with_base_dir(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<JsonValue, TransformError> {
+    transform_input_with_warnings_with_base_dir(rule, input, context, base_dir)
+        .map(|(output, _)| output)
+}
+
+pub fn transform_input_with_base_dir_and_options(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+    options: &NormalizationOptions,
+) -> Result<JsonValue, TransformError> {
+    transform_input_with_warnings_with_base_dir_and_options(rule, input, context, base_dir, options)
+        .map(|(output, _)| output)
+}
+
+pub fn transform_with_warnings(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_input_with_warnings(rule, InputData::Text(input), context)
+}
+
+pub fn transform_input_with_warnings(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_with_warnings_inner(rule, input, context, None, &NormalizationOptions::default())
+}
+
+pub fn transform_with_warnings_with_options(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+    options: &NormalizationOptions,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_input_with_warnings_with_options(rule, InputData::Text(input), context, options)
+}
+
+pub fn transform_input_with_warnings_with_options(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    options: &NormalizationOptions,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_with_warnings_inner(rule, input, context, None, options)
+}
+
+pub fn transform_with_warnings_with_base_dir(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_with_warnings_with_base_dir_and_options(
+        rule,
+        input,
+        context,
+        base_dir,
+        &NormalizationOptions::default(),
+    )
+}
+
+pub fn transform_input_with_warnings_with_base_dir(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_input_with_warnings_with_base_dir_and_options(
+        rule,
+        input,
+        context,
+        base_dir,
+        &NormalizationOptions::default(),
+    )
+}
+
+pub fn transform_with_warnings_with_base_dir_and_options(
+    rule: &RuleFile,
+    input: &str,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+    options: &NormalizationOptions,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_input_with_warnings_with_base_dir_and_options(
+        rule,
+        InputData::Text(input),
+        context,
+        base_dir,
+        options,
+    )
+}
+
+pub fn transform_input_with_warnings_with_base_dir_and_options(
+    rule: &RuleFile,
+    input: InputData<'_>,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+    options: &NormalizationOptions,
+) -> Result<(JsonValue, Vec<TransformWarning>), TransformError> {
+    transform_with_warnings_inner(rule, input, context, Some(base_dir), options)
+}
+
 pub(super) fn transform_with_warnings_inner(
     rule: &RuleFile,
     input: InputData<'_>,


### PR DESCRIPTION
Summary:
- move transform input public wrapper functions from transform/api.rs into transform/api/input.rs
- keep transform/api.rs as the public facade with re-exports
- no behavior, public API name/signature, transform semantics, trace schema, CLI/MCP/HTTP contract, or docs/spec changes

Verification:
- cargo fmt
- cargo test -p rulemorph --test transform_stream -- --test-threads=1
- cargo test -p rulemorph --test transform_record -- --test-threads=1
- cargo test -p rulemorph --test transform_trace trace_max_snapshot_bytes_marks_incomplete_without_breaking_parent_ids -- --test-threads=1
- cargo test -p rulemorph --test transform_golden t05_expr_transforms -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit quick: cargo test -p rulemorph --test transform_stream -- --test-threads=1