### PR TITLE
Refactor v1 trace lazy operators

### DIFF
--- a/crates/rulemorph/src/transform/v1_trace.rs
+++ b/crates/rulemorph/src/transform/v1_trace.rs
@@ -2,12 +2,14 @@ use super::*;
 
 mod args;
 mod collection;
+mod lazy;
 
 use args::{
     emit_arg_eval, eval_array_arg_traced, eval_eager_op_traced, eval_expr_at_index_traced,
     v1_operator_has_scoped_expr_args,
 };
 use collection::{eval_array_fold_traced, eval_array_map_traced, eval_array_reduce_traced};
+use lazy::{eval_bool_and_or_traced, eval_coalesce_traced};
 
 pub(super) fn eval_expr_traced(
     expr: &Expr,
@@ -158,96 +160,4 @@ pub(super) fn eval_expr_traced(
     }
 
     result
-}
-
-#[allow(clippy::too_many_arguments)]
-fn eval_coalesce_traced(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-    collector: &mut TraceCollector,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len == 0 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must be a non-empty array",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    for index in 0..total_len {
-        let arg_path = format!("{}.args[{}]", base_path, index);
-        let value = eval_expr_at_index_traced(
-            index, args, injected, record, context, out, base_path, locals, collector,
-        )?;
-        emit_arg_eval(collector, &arg_path, index, &value);
-        match value {
-            EvalValue::Missing => continue,
-            EvalValue::Value(value) => {
-                if value.is_null() {
-                    continue;
-                }
-                return Ok(EvalValue::Value(value));
-            }
-        }
-    }
-    Ok(EvalValue::Missing)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn eval_bool_and_or_traced(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    is_and: bool,
-    locals: Option<&EvalLocals<'_>>,
-    collector: &mut TraceCollector,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len < 2 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain at least two items",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let mut saw_missing = false;
-    for index in 0..total_len {
-        let arg_path = format!("{}.args[{}]", base_path, index);
-        let value = eval_expr_at_index_traced(
-            index, args, injected, record, context, out, base_path, locals, collector,
-        )?;
-        emit_arg_eval(collector, &arg_path, index, &value);
-        match value {
-            EvalValue::Missing => {
-                saw_missing = true;
-                continue;
-            }
-            EvalValue::Value(value) => {
-                let flag = value_as_bool(&value, &arg_path)?;
-                if is_and {
-                    if !flag {
-                        return Ok(EvalValue::Value(JsonValue::Bool(false)));
-                    }
-                } else if flag {
-                    return Ok(EvalValue::Value(JsonValue::Bool(true)));
-                }
-            }
-        }
-    }
-
-    if saw_missing {
-        Ok(EvalValue::Missing)
-    } else {
-        Ok(EvalValue::Value(JsonValue::Bool(is_and)))
-    }
 }

--- a/crates/rulemorph/src/transform/v1_trace/lazy.rs
+++ b/crates/rulemorph/src/transform/v1_trace/lazy.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn eval_coalesce_traced(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len == 0 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must be a non-empty array",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    for index in 0..total_len {
+        let arg_path = format!("{}.args[{}]", base_path, index);
+        let value = eval_expr_at_index_traced(
+            index, args, injected, record, context, out, base_path, locals, collector,
+        )?;
+        emit_arg_eval(collector, &arg_path, index, &value);
+        match value {
+            EvalValue::Missing => continue,
+            EvalValue::Value(value) => {
+                if value.is_null() {
+                    continue;
+                }
+                return Ok(EvalValue::Value(value));
+            }
+        }
+    }
+    Ok(EvalValue::Missing)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn eval_bool_and_or_traced(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    is_and: bool,
+    locals: Option<&EvalLocals<'_>>,
+    collector: &mut TraceCollector,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len < 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain at least two items",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let mut saw_missing = false;
+    for index in 0..total_len {
+        let arg_path = format!("{}.args[{}]", base_path, index);
+        let value = eval_expr_at_index_traced(
+            index, args, injected, record, context, out, base_path, locals, collector,
+        )?;
+        emit_arg_eval(collector, &arg_path, index, &value);
+        match value {
+            EvalValue::Missing => {
+                saw_missing = true;
+                continue;
+            }
+            EvalValue::Value(value) => {
+                let flag = value_as_bool(&value, &arg_path)?;
+                if is_and {
+                    if !flag {
+                        return Ok(EvalValue::Value(JsonValue::Bool(false)));
+                    }
+                } else if flag {
+                    return Ok(EvalValue::Value(JsonValue::Bool(true)));
+                }
+            }
+        }
+    }
+
+    if saw_missing {
+        Ok(EvalValue::Missing)
+    } else {
+        Ok(EvalValue::Value(JsonValue::Bool(is_and)))
+    }
+}


### PR DESCRIPTION
Summary:
- move v1 traced coalesce/and/or lazy short-circuit helpers into transform/v1_trace/lazy.rs
- keep v1_trace.rs focused on expression/operator lifecycle dispatch and module wiring
- no behavior, public API, transform semantics, trace schema, CLI/MCP/HTTP contract, or docs/spec changes

Verification:
- cargo fmt
- cargo test -p rulemorph --test transform_trace_semantics trace_v1_coalesce_does_not_evaluate_short_circuited_arg -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics trace_v1_and_does_not_evaluate_short_circuited_arg -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics trace_v1_missing_short_circuit_does_not_evaluate_later_invalid_arg -- --test-threads=1
- cargo test -p rulemorph --test transform_trace trace_v1_expression_operator_lifecycle -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit quick: cargo test -p rulemorph --test transform_trace_semantics trace_v1_coalesce_does_not_evaluate_short_circuited_arg -- --test-threads=1