### PR TITLE
Refactor array dispatch inventory

### DIFF
--- a/crates/rulemorph/src/transform/operators/dispatch/array_dispatch.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch/array_dispatch.rs
@@ -8,38 +8,9 @@ use super::super::array::{
 };
 use super::super::*;
 
-pub(super) fn is_array_operator(op: &str) -> bool {
-    matches!(
-        op,
-        "map"
-            | "filter"
-            | "flat_map"
-            | "flatten"
-            | "take"
-            | "drop"
-            | "slice"
-            | "chunk"
-            | "zip"
-            | "zip_with"
-            | "unzip"
-            | "group_by"
-            | "key_by"
-            | "partition"
-            | "unique"
-            | "distinct_by"
-            | "sort_by"
-            | "find"
-            | "find_index"
-            | "index_of"
-            | "contains"
-            | "sum"
-            | "avg"
-            | "min"
-            | "max"
-            | "reduce"
-            | "fold"
-    )
-}
+mod inventory;
+
+pub(super) use inventory::is_array_operator;
 
 pub(super) fn eval_array_dispatch(
     expr_op: &ExprOp,

--- a/crates/rulemorph/src/transform/operators/dispatch/array_dispatch/inventory.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch/array_dispatch/inventory.rs
@@ -1,0 +1,32 @@
+pub(in crate::transform::operators::dispatch) fn is_array_operator(op: &str) -> bool {
+    matches!(
+        op,
+        "map"
+            | "filter"
+            | "flat_map"
+            | "flatten"
+            | "take"
+            | "drop"
+            | "slice"
+            | "chunk"
+            | "zip"
+            | "zip_with"
+            | "unzip"
+            | "group_by"
+            | "key_by"
+            | "partition"
+            | "unique"
+            | "distinct_by"
+            | "sort_by"
+            | "find"
+            | "find_index"
+            | "index_of"
+            | "contains"
+            | "sum"
+            | "avg"
+            | "min"
+            | "max"
+            | "reduce"
+            | "fold"
+    )
+}


### PR DESCRIPTION
Summary
- Move the v1 array operator predicate into a private dispatch inventory module.
- Keep the array operator name set, dispatch body, transform semantics, trace schema, and public/API contracts unchanged.

Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden t16_array_ops -- --test-threads=1
- cargo test -p rulemorph --test validation valid_rules_should_pass_validation -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives -- --test-threads=1
- cargo fmt --check
- git diff --check