### PR TITLE
Refactor JSON len operator

### DIFF
--- a/crates/rulemorph/src/transform/operators/json.rs
+++ b/crates/rulemorph/src/transform/operators/json.rs
@@ -1,8 +1,10 @@
 use super::*;
 
+mod len;
 mod object;
 mod paths;
 
+pub(super) use self::len::eval_len;
 pub(super) use self::object::{
     eval_json_entries, eval_json_from_entries, eval_json_keys, eval_json_object_flatten,
     eval_json_object_unflatten, eval_json_values,
@@ -242,54 +244,4 @@ pub(super) fn eval_json_omit(
     }
 
     Ok(EvalValue::Value(base_value))
-}
-
-pub(super) fn eval_len(
-    args: &[Expr],
-    injected: Option<&EvalValue>,
-    record: &JsonValue,
-    context: Option<&JsonValue>,
-    out: &JsonValue,
-    base_path: &str,
-    locals: Option<&EvalLocals<'_>>,
-) -> Result<EvalValue, TransformError> {
-    let total_len = args_len(args, injected);
-    if total_len != 1 {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr.args must contain exactly one item",
-        )
-        .with_path(format!("{}.args", base_path)));
-    }
-
-    let arg_path = format!("{}.args[0]", base_path);
-    let value = eval_expr_at_index(0, args, injected, record, context, out, base_path, locals)?;
-    let value = match value {
-        EvalValue::Missing => return Ok(EvalValue::Missing),
-        EvalValue::Value(value) => value,
-    };
-    if value.is_null() {
-        return Err(TransformError::new(
-            TransformErrorKind::ExprError,
-            "expr arg must not be null",
-        )
-        .with_path(arg_path));
-    }
-
-    let len = match value {
-        JsonValue::String(value) => value.chars().count(),
-        JsonValue::Array(items) => items.len(),
-        JsonValue::Object(map) => map.len(),
-        _ => {
-            return Err(TransformError::new(
-                TransformErrorKind::ExprError,
-                "expr arg must be string, array, or object",
-            )
-            .with_path(arg_path));
-        }
-    };
-
-    Ok(EvalValue::Value(JsonValue::Number(
-        serde_json::Number::from(len as u64),
-    )))
 }

--- a/crates/rulemorph/src/transform/operators/json/len.rs
+++ b/crates/rulemorph/src/transform/operators/json/len.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+pub(in crate::transform::operators) fn eval_len(
+    args: &[Expr],
+    injected: Option<&EvalValue>,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    let total_len = args_len(args, injected);
+    if total_len != 1 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr.args must contain exactly one item",
+        )
+        .with_path(format!("{}.args", base_path)));
+    }
+
+    let arg_path = format!("{}.args[0]", base_path);
+    let value = eval_expr_at_index(0, args, injected, record, context, out, base_path, locals)?;
+    let value = match value {
+        EvalValue::Missing => return Ok(EvalValue::Missing),
+        EvalValue::Value(value) => value,
+    };
+    if value.is_null() {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "expr arg must not be null",
+        )
+        .with_path(arg_path));
+    }
+
+    let len = match value {
+        JsonValue::String(value) => value.chars().count(),
+        JsonValue::Array(items) => items.len(),
+        JsonValue::Object(map) => map.len(),
+        _ => {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "expr arg must be string, array, or object",
+            )
+            .with_path(arg_path));
+        }
+    };
+
+    Ok(EvalValue::Value(JsonValue::Number(
+        serde_json::Number::from(len as u64),
+    )))
+}


### PR DESCRIPTION
Summary
- Move the JSON len operator helper into a private json/len module.
- Keep len routing, errors, accepted input types, transform semantics, trace schema, and public/API contracts unchanged.

Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden t29_json_ops_len -- --test-threads=1
- cargo test -p rulemorph --test validation valid_rules_should_pass_validation -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives -- --test-threads=1
- cargo fmt --check
- git diff --check