### PR TITLE
Refactor path merge helper

### DIFF
--- a/crates/rulemorph/src/transform/path_ops.rs
+++ b/crates/rulemorph/src/transform/path_ops.rs
@@ -2,12 +2,12 @@ use super::*;
 
 mod conflict;
 mod flatten;
+mod merge;
 mod mutation;
 mod refs;
 
 pub(super) use conflict::{has_duplicate_path, has_path_conflict};
 pub(super) use flatten::flatten_object;
-pub(super) use mutation::{
-    merge_object, remove_path, set_path, set_path_object_only, set_path_with_indexes,
-};
+pub(super) use merge::merge_object;
+pub(super) use mutation::{remove_path, set_path, set_path_object_only, set_path_with_indexes};
 pub(super) use refs::{parse_path_tokens, parse_ref, parse_source};

--- a/crates/rulemorph/src/transform/path_ops/merge.rs
+++ b/crates/rulemorph/src/transform/path_ops/merge.rs
@@ -1,0 +1,19 @@
+use super::*;
+
+pub(in crate::transform) fn merge_object(
+    target: &mut Map<String, JsonValue>,
+    incoming: &Map<String, JsonValue>,
+    deep: bool,
+) {
+    for (key, value) in incoming {
+        if deep {
+            if let (Some(JsonValue::Object(target_obj)), JsonValue::Object(incoming_obj)) =
+                (target.get_mut(key), value)
+            {
+                merge_object(target_obj, incoming_obj, true);
+                continue;
+            }
+        }
+        target.insert(key.clone(), value.clone());
+    }
+}

--- a/crates/rulemorph/src/transform/path_ops/mutation.rs
+++ b/crates/rulemorph/src/transform/path_ops/mutation.rs
@@ -1,23 +1,5 @@
 use super::*;
 
-pub(in crate::transform) fn merge_object(
-    target: &mut Map<String, JsonValue>,
-    incoming: &Map<String, JsonValue>,
-    deep: bool,
-) {
-    for (key, value) in incoming {
-        if deep {
-            if let (Some(JsonValue::Object(target_obj)), JsonValue::Object(incoming_obj)) =
-                (target.get_mut(key), value)
-            {
-                merge_object(target_obj, incoming_obj, true);
-                continue;
-            }
-        }
-        target.insert(key.clone(), value.clone());
-    }
-}
-
 pub(in crate::transform) fn set_path_object_only(
     root: &mut JsonValue,
     tokens: &[PathToken],


### PR DESCRIPTION
Summary
- Move the path object merge helper into a sibling path_ops/merge module.
- Keep shallow/deep merge behavior, transform semantics, trace schema, and public/API contracts unchanged.

Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden t17_json_ops_merge -- --test-threads=1
- cargo test -p rulemorph --test transform_golden t18_json_ops_deep_merge -- --test-threads=1
- cargo test -p rulemorph --test validation valid_rules_should_pass_validation -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives -- --test-threads=1
- cargo fmt --check
- git diff --check