### PR TITLE
Refactor UI API client helpers

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -23,6 +23,15 @@ import {
 } from "./auth";
 import { __resetTenantCachesForTest, getTenantId } from "./tenant";
 import {
+  API_BASE,
+  INTERNAL_BASE,
+  buildHeaders,
+  fetchJson,
+  loadFinalize,
+  loadNodeChunks,
+  loadRecordChunks
+} from "./api_client";
+import {
   TIME_RANGE_OPTIONS,
   applyTraceFilters,
   formatDuration,
@@ -39,14 +48,10 @@ import {
 } from "./trace_list_helpers";
 import {
   mergeNodesIntoRecords,
-  normalizeRecord,
   normalizeTracePayload,
-  parseNumericIndex,
   type EndpointRule,
-  type TraceDetailRef,
   type TraceManifest,
   type TraceNode,
-  type TraceNodeChunkEntry,
   type TracePayload,
   type TraceRecord
 } from "./trace_payload";
@@ -102,9 +107,6 @@ type ApiGraphResponse = {
   edges: ApiGraphEdge[];
 };
 
-const API_BASE = "/api";
-const INTERNAL_BASE = "/internal";
-
 const graphDefaults = {
   rankdir: "LR",
   nodesep: 220,
@@ -113,93 +115,6 @@ const graphDefaults = {
 
 const INITIAL_CENTER_X_RATIO = 0.45;
 const INITIAL_CENTER_PADDING = 0.22;
-
-type FetchAuth = "api" | "internal";
-
-function buildHeaders(auth: FetchAuth): Record<string, string> {
-  const headers: Record<string, string> = { "x-rulemorph-ui": "1" };
-  if (auth === "internal") {
-    const internalKey = getInternalKey();
-    if (internalKey) {
-      headers["x-api-key"] = internalKey;
-    }
-    const tenantId = getTenantId();
-    if (tenantId) {
-      headers["x-tenant-id"] = tenantId;
-    }
-    return headers;
-  }
-  const apiKey = getApiKey();
-  if (apiKey) {
-    headers["x-api-key"] = apiKey;
-  }
-  return headers;
-}
-
-async function fetchJson<T>(path: string, auth: FetchAuth = "api"): Promise<T | null> {
-  try {
-    const headers = buildHeaders(auth);
-    const res = await fetch(path, { headers });
-    if (!res.ok) return null;
-    return (await res.json()) as T;
-  } catch (err) {
-    console.error("fetch failed", err);
-    return null;
-  }
-}
-
-async function loadRecordChunks(traceId: string, detail: TraceDetailRef): Promise<TraceRecord[]> {
-  const chunks = detail.records ?? [];
-  const records: TraceRecord[] = [];
-  for (let i = 0; i < chunks.length; i += 1) {
-    const payload = await fetchJson<{ records: TraceRecord[] }>(
-      `${API_BASE}/traces/${traceId}/records/${i}`
-    );
-    if (!payload) {
-      throw new Error(`record chunk ${i} load failed`);
-    }
-    const offset = records.length;
-    const normalized = payload.records.map((record, index) =>
-      normalizeRecord(record, offset + index)
-    );
-    records.push(...normalized);
-  }
-  return records;
-}
-
-async function loadNodeChunks(
-  traceId: string,
-  detail: TraceDetailRef
-): Promise<Map<number, TraceNode[]>> {
-  const chunks = detail.nodes ?? [];
-  const nodesByRecord = new Map<number, TraceNode[]>();
-  for (let i = 0; i < chunks.length; i += 1) {
-    const payload = await fetchJson<{ nodes: TraceNodeChunkEntry[] }>(
-      `${API_BASE}/traces/${traceId}/nodes/${i}`
-    );
-    if (!payload) {
-      throw new Error(`node chunk ${i} load failed`);
-    }
-    payload.nodes.forEach((entry) => {
-      const recordIndex = parseNumericIndex(entry.record_index);
-      if (recordIndex == null) return;
-      const list = nodesByRecord.get(recordIndex) ?? [];
-      list.push(entry.node);
-      nodesByRecord.set(recordIndex, list);
-    });
-  }
-  return nodesByRecord;
-}
-
-async function loadFinalize(traceId: string) {
-  const payload = await fetchJson<{ finalize: TracePayload["finalize"] }>(
-    `${API_BASE}/traces/${traceId}/finalize`
-  );
-  if (!payload) {
-    throw new Error("finalize chunk load failed");
-  }
-  return payload.finalize ?? null;
-}
 
 function formatEdgeDurationMs(valueUs: number | undefined) {
   if (valueUs == null) return "-";

--- a/crates/rulemorph_ui/ui/src/api_client.ts
+++ b/crates/rulemorph_ui/ui/src/api_client.ts
@@ -1,0 +1,104 @@
+import { getApiKey, getInternalKey } from "./auth";
+import { getTenantId } from "./tenant";
+import {
+  normalizeRecord,
+  parseNumericIndex,
+  type TraceDetailRef,
+  type TraceNode,
+  type TraceNodeChunkEntry,
+  type TracePayload,
+  type TraceRecord
+} from "./trace_payload";
+
+export const API_BASE = "/api";
+export const INTERNAL_BASE = "/internal";
+
+export type FetchAuth = "api" | "internal";
+
+export function buildHeaders(auth: FetchAuth): Record<string, string> {
+  const headers: Record<string, string> = { "x-rulemorph-ui": "1" };
+  if (auth === "internal") {
+    const internalKey = getInternalKey();
+    if (internalKey) {
+      headers["x-api-key"] = internalKey;
+    }
+    const tenantId = getTenantId();
+    if (tenantId) {
+      headers["x-tenant-id"] = tenantId;
+    }
+    return headers;
+  }
+  const apiKey = getApiKey();
+  if (apiKey) {
+    headers["x-api-key"] = apiKey;
+  }
+  return headers;
+}
+
+export async function fetchJson<T>(path: string, auth: FetchAuth = "api"): Promise<T | null> {
+  try {
+    const headers = buildHeaders(auth);
+    const res = await fetch(path, { headers });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch (err) {
+    console.error("fetch failed", err);
+    return null;
+  }
+}
+
+export async function loadRecordChunks(
+  traceId: string,
+  detail: TraceDetailRef
+): Promise<TraceRecord[]> {
+  const chunks = detail.records ?? [];
+  const records: TraceRecord[] = [];
+  for (let i = 0; i < chunks.length; i += 1) {
+    const payload = await fetchJson<{ records: TraceRecord[] }>(
+      `${API_BASE}/traces/${traceId}/records/${i}`
+    );
+    if (!payload) {
+      throw new Error(`record chunk ${i} load failed`);
+    }
+    const offset = records.length;
+    const normalized = payload.records.map((record, index) =>
+      normalizeRecord(record, offset + index)
+    );
+    records.push(...normalized);
+  }
+  return records;
+}
+
+export async function loadNodeChunks(
+  traceId: string,
+  detail: TraceDetailRef
+): Promise<Map<number, TraceNode[]>> {
+  const chunks = detail.nodes ?? [];
+  const nodesByRecord = new Map<number, TraceNode[]>();
+  for (let i = 0; i < chunks.length; i += 1) {
+    const payload = await fetchJson<{ nodes: TraceNodeChunkEntry[] }>(
+      `${API_BASE}/traces/${traceId}/nodes/${i}`
+    );
+    if (!payload) {
+      throw new Error(`node chunk ${i} load failed`);
+    }
+    payload.nodes.forEach((entry) => {
+      const recordIndex = parseNumericIndex(entry.record_index);
+      if (recordIndex == null) return;
+      const list = nodesByRecord.get(recordIndex) ?? [];
+      list.push(entry.node);
+      nodesByRecord.set(recordIndex, list);
+    });
+  }
+  return nodesByRecord;
+}
+
+export async function loadFinalize(traceId: string) {
+  const payload = await fetchJson<{ finalize: TracePayload["finalize"] }>(
+    `${API_BASE}/traces/${traceId}/finalize`
+  );
+  if (!payload) {
+    throw new Error("finalize chunk load failed");
+  }
+  return payload.finalize ?? null;
+}


### PR DESCRIPTION
## Summary
- Move UI API constants, auth header construction, fetchJson, and trace chunk loaders from App.tsx into api_client.ts.
- Keep App.tsx focused on graph construction/rendering and import the extracted helpers.
- Preserve request paths, auth/tenant headers, ZIP import headers, trace chunk normalization, public re-exports, and UI behavior.

## Tests
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

## Browser smoke
- Vite dev server at http://127.0.0.1:5174/
- Verified .app, .topbar, .trace-panel, ZIP import button, Duration unit group, and status combobox are present.

## Review
- Subagent no-behavior-change review: PASS