### PR TITLE
Refactor UI trace graph layout helpers

### DIFF
--- a/crates/rulemorph_ui/ui/src/trace_graph.tsx
+++ b/crates/rulemorph_ui/ui/src/trace_graph.tsx
@@ -1,6 +1,4 @@
-import { type ReactNode } from "react";
 import { Edge, Node, Position } from "reactflow";
-import dagre from "dagre";
 import {
   isErrorStatus,
   resolveDurationUs,
@@ -20,6 +18,8 @@ import {
   type DetailBundle,
   type OverviewGraph
 } from "./trace_graph_types";
+import { buildEdgeLabel, formatEdgeDurationMs } from "./trace_graph_edges";
+import { graphDefaults, layoutGraph, layoutGraphWithSizes } from "./trace_graph_layout";
 
 export {
   DetailNode,
@@ -36,32 +36,7 @@ export type {
   DetailEntry,
   OverviewGraph
 } from "./trace_graph_types";
-
-const graphDefaults = {
-  rankdir: "LR",
-  nodesep: 220,
-  ranksep: 80
-};
-
-function formatEdgeDurationMs(valueUs: number | undefined) {
-  if (valueUs == null) return "-";
-  const valueMs = valueUs / 1000;
-  const formatted = valueMs >= 100 ? valueMs.toFixed(0) : valueMs >= 10 ? valueMs.toFixed(1) : valueMs.toFixed(2);
-  return `${formatted}ms`;
-}
-
-function buildEdgeLabel(label: string, duration: string): ReactNode {
-  return (
-    <>
-      <tspan x="0" dy="0">
-        {label}
-      </tspan>
-      <tspan x="0" dy="1.2em">
-        {duration}
-      </tspan>
-    </>
-  );
-}
+export { getNodesBounds } from "./trace_graph_layout";
 
 function traceNodeHasError(node: TraceNode) {
   if (isErrorStatus(node.status) || node.error) return true;
@@ -470,77 +445,6 @@ export function buildMergedGraph(
   });
 
   return { nodes, edges: [...edges, ...refEdges] };
-}
-
-function layoutGraph(nodes: Node[], edges: Edge[], direction: "LR" | "TB") {
-  const dagreGraph = new dagre.graphlib.Graph();
-  dagreGraph.setDefaultEdgeLabel(() => ({}));
-  dagreGraph.setGraph({ rankdir: direction, nodesep: graphDefaults.nodesep, ranksep: graphDefaults.ranksep });
-
-  nodes.forEach((node) => {
-    dagreGraph.setNode(node.id, { width: 240, height: 80 });
-  });
-  edges.forEach((edge) => {
-    dagreGraph.setEdge(edge.source, edge.target);
-  });
-
-  dagre.layout(dagreGraph);
-
-  const layouted = nodes.map((node) => {
-    const { x, y } = dagreGraph.node(node.id);
-    return { ...node, position: { x: x - 110, y: y - 36 } };
-  });
-
-  return { nodes: layouted, edges };
-}
-
-export function getNodesBounds(nodes: Node[]) {
-  const initial = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
-  const bounds = nodes.reduce((acc, node) => {
-    const width = typeof node.style?.width === "number" ? node.style.width : 240;
-    const height = typeof node.style?.height === "number" ? node.style.height : 80;
-    acc.minX = Math.min(acc.minX, node.position.x);
-    acc.minY = Math.min(acc.minY, node.position.y);
-    acc.maxX = Math.max(acc.maxX, node.position.x + width);
-    acc.maxY = Math.max(acc.maxY, node.position.y + height);
-    return acc;
-  }, initial);
-  return {
-    ...bounds,
-    width: Math.max(1, bounds.maxX - bounds.minX),
-    height: Math.max(1, bounds.maxY - bounds.minY)
-  };
-}
-
-function layoutGraphWithSizes(
-  nodes: Node[],
-  edges: Edge[],
-  direction: "LR" | "TB",
-  sizes: Map<string, { width: number; height: number }>,
-  nodesep: number,
-  ranksep: number
-) {
-  const dagreGraph = new dagre.graphlib.Graph();
-  dagreGraph.setDefaultEdgeLabel(() => ({}));
-  dagreGraph.setGraph({ rankdir: direction, nodesep, ranksep });
-
-  nodes.forEach((node) => {
-    const size = sizes.get(node.id) ?? { width: 240, height: 80 };
-    dagreGraph.setNode(node.id, { width: size.width, height: size.height });
-  });
-  edges.forEach((edge) => {
-    dagreGraph.setEdge(edge.source, edge.target);
-  });
-
-  dagre.layout(dagreGraph);
-
-  const layouted = nodes.map((node) => {
-    const size = sizes.get(node.id) ?? { width: 240, height: 80 };
-    const { x, y } = dagreGraph.node(node.id);
-    return { ...node, position: { x: x - size.width / 2, y: y - size.height / 2 } };
-  });
-
-  return { nodes: layouted, edges };
 }
 
 export function buildMergedApiGraph(

--- a/crates/rulemorph_ui/ui/src/trace_graph_edges.tsx
+++ b/crates/rulemorph_ui/ui/src/trace_graph_edges.tsx
@@ -1,0 +1,21 @@
+import { type ReactNode } from "react";
+
+export function formatEdgeDurationMs(valueUs: number | undefined) {
+  if (valueUs == null) return "-";
+  const valueMs = valueUs / 1000;
+  const formatted = valueMs >= 100 ? valueMs.toFixed(0) : valueMs >= 10 ? valueMs.toFixed(1) : valueMs.toFixed(2);
+  return `${formatted}ms`;
+}
+
+export function buildEdgeLabel(label: string, duration: string): ReactNode {
+  return (
+    <>
+      <tspan x="0" dy="0">
+        {label}
+      </tspan>
+      <tspan x="0" dy="1.2em">
+        {duration}
+      </tspan>
+    </>
+  );
+}

--- a/crates/rulemorph_ui/ui/src/trace_graph_layout.ts
+++ b/crates/rulemorph_ui/ui/src/trace_graph_layout.ts
@@ -1,0 +1,79 @@
+import { Edge, Node } from "reactflow";
+import dagre from "dagre";
+
+export const graphDefaults = {
+  rankdir: "LR",
+  nodesep: 220,
+  ranksep: 80
+};
+
+export function layoutGraph(nodes: Node[], edges: Edge[], direction: "LR" | "TB") {
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({ rankdir: direction, nodesep: graphDefaults.nodesep, ranksep: graphDefaults.ranksep });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: 240, height: 80 });
+  });
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  const layouted = nodes.map((node) => {
+    const { x, y } = dagreGraph.node(node.id);
+    return { ...node, position: { x: x - 110, y: y - 36 } };
+  });
+
+  return { nodes: layouted, edges };
+}
+
+export function getNodesBounds(nodes: Node[]) {
+  const initial = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+  const bounds = nodes.reduce((acc, node) => {
+    const width = typeof node.style?.width === "number" ? node.style.width : 240;
+    const height = typeof node.style?.height === "number" ? node.style.height : 80;
+    acc.minX = Math.min(acc.minX, node.position.x);
+    acc.minY = Math.min(acc.minY, node.position.y);
+    acc.maxX = Math.max(acc.maxX, node.position.x + width);
+    acc.maxY = Math.max(acc.maxY, node.position.y + height);
+    return acc;
+  }, initial);
+  return {
+    ...bounds,
+    width: Math.max(1, bounds.maxX - bounds.minX),
+    height: Math.max(1, bounds.maxY - bounds.minY)
+  };
+}
+
+export function layoutGraphWithSizes(
+  nodes: Node[],
+  edges: Edge[],
+  direction: "LR" | "TB",
+  sizes: Map<string, { width: number; height: number }>,
+  nodesep: number,
+  ranksep: number
+) {
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({ rankdir: direction, nodesep, ranksep });
+
+  nodes.forEach((node) => {
+    const size = sizes.get(node.id) ?? { width: 240, height: 80 };
+    dagreGraph.setNode(node.id, { width: size.width, height: size.height });
+  });
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  const layouted = nodes.map((node) => {
+    const size = sizes.get(node.id) ?? { width: 240, height: 80 };
+    const { x, y } = dagreGraph.node(node.id);
+    return { ...node, position: { x: x - size.width / 2, y: y - size.height / 2 } };
+  });
+
+  return { nodes: layouted, edges };
+}


### PR DESCRIPTION
## Summary
- Move trace graph layout helpers into trace_graph_layout.ts
- Move edge duration label rendering helpers into trace_graph_edges.tsx
- Preserve ./trace_graph getNodesBounds re-export compatibility

## Verification
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e -- --list
- npm --prefix crates/rulemorph_ui/ui run test:e2e (sandbox Chromium launch failed first; elevated rerun passed 9 tests)
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- Browser smoke on http://127.0.0.1:5177/: app/topbar/trace canvas/trace panel/React Flow controls/Trace一覧 visible, pageErrors none