### PR TITLE
Refactor UI trace graph API builder

### DIFF
--- a/crates/rulemorph_ui/ui/src/trace_graph.tsx
+++ b/crates/rulemorph_ui/ui/src/trace_graph.tsx
@@ -7,13 +7,11 @@ import {
 } from "./trace_graph_detail";
 import {
   type ApiDetailBundle,
-  type ApiGraphNode,
-  type ApiGraphResponse,
   type DetailBundle,
   type OverviewGraph
 } from "./trace_graph_types";
 import { buildEdgeLabel, formatEdgeDurationMs } from "./trace_graph_edges";
-import { graphDefaults, layoutGraph, layoutGraphWithSizes } from "./trace_graph_layout";
+import { layoutGraphWithSizes } from "./trace_graph_layout";
 
 export {
   DetailNode,
@@ -32,42 +30,7 @@ export type {
 } from "./trace_graph_types";
 export { getNodesBounds } from "./trace_graph_layout";
 export { buildOverviewGraph } from "./trace_graph_overview";
-
-export function buildApiGraph(
-  graph: ApiGraphResponse
-): { nodes: Node[]; edges: Edge[]; nodeMap: Map<string, ApiGraphNode>; edgeLabelMap: Map<string, string> } {
-  const nodeMap = new Map<string, ApiGraphNode>();
-  const edgeLabelMap = new Map<string, string>();
-  const nodes: Node[] = graph.nodes.map((node) => {
-    nodeMap.set(node.id, node);
-    return {
-      id: node.id,
-      position: { x: 0, y: 0 },
-      data: { label: node.label },
-      type: "default",
-      className: "trace-node trace-node--overview",
-      style: { width: 240, height: 80 }
-    };
-  });
-  const edges: Edge[] = graph.edges.map((edge, index) => {
-    if (edge.label) {
-      edgeLabelMap.set(`${edge.source}::${edge.target}`, edge.label);
-    }
-    return {
-      id: `${edge.source}->${edge.target}-${index}`,
-      source: edge.source,
-      target: edge.target,
-      label: edge.label,
-      labelBgPadding: edge.label ? [6, 4] : undefined,
-      labelBgBorderRadius: edge.label ? 8 : undefined,
-      className: edge.label ? "edge--endpoint" : edge.kind === "ref" ? "edge--ref" : undefined,
-      type: "smoothstep",
-      style: { strokeWidth: 1.4 }
-    };
-  });
-  const layouted = layoutGraph(nodes, edges, graphDefaults.rankdir as "LR" | "TB");
-  return { nodes: layouted.nodes, edges: layouted.edges, nodeMap, edgeLabelMap };
-}
+export { buildApiGraph } from "./trace_graph_api";
 
 export function buildMergedGraph(
   overview: OverviewGraph,

--- a/crates/rulemorph_ui/ui/src/trace_graph_api.ts
+++ b/crates/rulemorph_ui/ui/src/trace_graph_api.ts
@@ -1,0 +1,39 @@
+import { Edge, Node } from "reactflow";
+import { type ApiGraphNode, type ApiGraphResponse } from "./trace_graph_types";
+import { graphDefaults, layoutGraph } from "./trace_graph_layout";
+
+export function buildApiGraph(
+  graph: ApiGraphResponse
+): { nodes: Node[]; edges: Edge[]; nodeMap: Map<string, ApiGraphNode>; edgeLabelMap: Map<string, string> } {
+  const nodeMap = new Map<string, ApiGraphNode>();
+  const edgeLabelMap = new Map<string, string>();
+  const nodes: Node[] = graph.nodes.map((node) => {
+    nodeMap.set(node.id, node);
+    return {
+      id: node.id,
+      position: { x: 0, y: 0 },
+      data: { label: node.label },
+      type: "default",
+      className: "trace-node trace-node--overview",
+      style: { width: 240, height: 80 }
+    };
+  });
+  const edges: Edge[] = graph.edges.map((edge, index) => {
+    if (edge.label) {
+      edgeLabelMap.set(`${edge.source}::${edge.target}`, edge.label);
+    }
+    return {
+      id: `${edge.source}->${edge.target}-${index}`,
+      source: edge.source,
+      target: edge.target,
+      label: edge.label,
+      labelBgPadding: edge.label ? [6, 4] : undefined,
+      labelBgBorderRadius: edge.label ? 8 : undefined,
+      className: edge.label ? "edge--endpoint" : edge.kind === "ref" ? "edge--ref" : undefined,
+      type: "smoothstep",
+      style: { strokeWidth: 1.4 }
+    };
+  });
+  const layouted = layoutGraph(nodes, edges, graphDefaults.rankdir as "LR" | "TB");
+  return { nodes: layouted.nodes, edges: layouted.edges, nodeMap, edgeLabelMap };
+}


### PR DESCRIPTION
## Summary
- Move buildApiGraph into trace_graph_api.ts
- Keep ./trace_graph buildApiGraph re-export compatibility
- Preserve API graph node/edge ids, classes, styles, edge labels, edgeLabelMap keys, and layout behavior

## Verification
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run test:e2e
- npm --prefix crates/rulemorph_ui/ui run test:e2e -- --list
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- Browser smoke on http://127.0.0.1:5177/: app/topbar/trace canvas/trace panel/React Flow controls/Trace一覧 visible, pageErrors none
- Subagent review: PASS