### PR TITLE
Refactor UI trace list sections

### DIFF
--- a/crates/rulemorph_ui/ui/src/trace_list_filters.tsx
+++ b/crates/rulemorph_ui/ui/src/trace_list_filters.tsx
@@ -1,0 +1,101 @@
+import {
+  TIME_RANGE_OPTIONS,
+  type TimeRange,
+  type TraceListItem
+} from "./trace_list_helpers";
+
+type TraceListFiltersProps = {
+  traceFilterQuery: string;
+  setTraceFilterQuery: (value: string) => void;
+  traceFilterStatus: string;
+  setTraceFilterStatus: (value: string) => void;
+  traceFilterRule: string;
+  setTraceFilterRule: (value: string) => void;
+  traceFilterRange: TimeRange;
+  setTraceFilterRange: (value: TimeRange) => void;
+  statusOptions: string[];
+  ruleOptions: string[];
+  filteredTraces: TraceListItem[];
+  traces: TraceListItem[];
+};
+
+export function TraceListFilters({
+  traceFilterQuery,
+  setTraceFilterQuery,
+  traceFilterStatus,
+  setTraceFilterStatus,
+  traceFilterRule,
+  setTraceFilterRule,
+  traceFilterRange,
+  setTraceFilterRange,
+  statusOptions,
+  ruleOptions,
+  filteredTraces,
+  traces
+}: TraceListFiltersProps) {
+  return (
+    <div className="trace-panel__filters">
+      <input
+        className="trace-filter__search"
+        type="search"
+        aria-label="Trace検索"
+        placeholder="trace / rule を検索"
+        value={traceFilterQuery}
+        onChange={(event) => setTraceFilterQuery(event.target.value)}
+      />
+      <select
+        className="trace-filter__select"
+        aria-label="ステータス"
+        value={traceFilterStatus}
+        onChange={(event) => setTraceFilterStatus(event.target.value)}
+      >
+        <option value="all">status: all</option>
+        {statusOptions.map((status) => (
+          <option key={status} value={status}>
+            {status}
+          </option>
+        ))}
+      </select>
+      <select
+        className="trace-filter__select"
+        aria-label="ルール"
+        value={traceFilterRule}
+        onChange={(event) => setTraceFilterRule(event.target.value)}
+      >
+        <option value="all">rule: all</option>
+        {ruleOptions.map((rule) => (
+          <option key={rule} value={rule}>
+            {rule}
+          </option>
+        ))}
+      </select>
+      <select
+        className="trace-filter__select"
+        aria-label="期間"
+        value={traceFilterRange}
+        onChange={(event) => setTraceFilterRange(event.target.value as TimeRange)}
+      >
+        {TIME_RANGE_OPTIONS.map((range) => (
+          <option key={range.value} value={range.value}>
+            {range.label}
+          </option>
+        ))}
+      </select>
+      <button
+        className="trace-filter__reset"
+        type="button"
+        onClick={() => {
+          setTraceFilterStatus("all");
+          setTraceFilterRule("all");
+          setTraceFilterQuery("");
+          setTraceFilterRange("all");
+        }}
+      >
+        リセット
+      </button>
+      <span className="trace-filter__count">
+        {filteredTraces.length} / {traces.length}
+      </span>
+    </div>
+  );
+}

--- a/crates/rulemorph_ui/ui/src/trace_list_items.tsx
+++ b/crates/rulemorph_ui/ui/src/trace_list_items.tsx
@@ -1,0 +1,92 @@
+import clsx from "clsx";
+import {
+  formatDuration,
+  formatTime,
+  isErrorStatus,
+  resolveDurationUs,
+  type DurationUnit,
+  type TraceListItem
+} from "./trace_list_helpers";
+
+type TraceListItemsProps = {
+  durationUnit: DurationUnit;
+  filteredTraces: TraceListItem[];
+  traces: TraceListItem[];
+  selectedId: string | null;
+  setSelectedId: (traceId: string) => void;
+  detailStatus?: string;
+  detailError: string | null;
+  detailReason: string[];
+};
+
+export function TraceListItems({
+  durationUnit,
+  filteredTraces,
+  traces,
+  selectedId,
+  setSelectedId,
+  detailStatus,
+  detailError,
+  detailReason
+}: TraceListItemsProps) {
+  return (
+    <div className="trace-list">
+      {(detailStatus && detailStatus !== "full") || detailError ? (
+        <div className="trace-panel__note">
+          {detailError ? (
+            <>
+              <p>detail の読み込みに失敗しました。</p>
+              <p className="muted">manifest または chunk の取得に失敗しています。</p>
+            </>
+          ) : (
+            <>
+              <p>detail は {detailStatus} です。</p>
+              {detailReason.length > 0 && (
+                <p className="muted">reason: {detailReason.join(", ")}</p>
+              )}
+            </>
+          )}
+        </div>
+      ) : null}
+      {traces.length === 0 && (
+        <div className="empty-trace">
+          <p>traces が見つかりません。</p>
+          <p className="muted">data_dir（既定: ./.rulemorph）の traces/ に JSON を配置してください。</p>
+        </div>
+      )}
+      {traces.length > 0 && filteredTraces.length === 0 && (
+        <div className="empty-trace">
+          <p>フィルタ条件に一致するトレースがありません。</p>
+          <p className="muted">検索語や期間を調整してください。</p>
+        </div>
+      )}
+      {filteredTraces.map((item) => (
+        <button
+          key={item.trace_id}
+          className={clsx("trace-card", selectedId === item.trace_id && "is-active")}
+          onClick={() => setSelectedId(item.trace_id)}
+        >
+          <div>
+            <span className={clsx("chip", isErrorStatus(item.status) && "chip--error")}>
+              {item.status ?? "ok"}
+            </span>
+            <h3>{item.rule?.name ?? item.trace_id}</h3>
+            <p className="muted">{item.rule?.path ?? "(no path)"}</p>
+          </div>
+          <div className="trace-meta">
+            <div>
+              <span>time: </span>
+              <strong>{formatTime(item.timestamp)}</strong>
+            </div>
+            <div>
+              <span>duration: </span>
+              <strong>
+                {formatDuration(resolveDurationUs(item.duration_us, item.duration_ms), durationUnit)}
+              </strong>
+            </div>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/crates/rulemorph_ui/ui/src/trace_list_panel.tsx
+++ b/crates/rulemorph_ui/ui/src/trace_list_panel.tsx
@@ -1,14 +1,8 @@
 import clsx from "clsx";
-import {
-  TIME_RANGE_OPTIONS,
-  formatDuration,
-  formatTime,
-  isErrorStatus,
-  resolveDurationUs,
-  type DurationUnit,
-  type TimeRange,
-  type TraceListItem
-} from "./trace_list_helpers";
+import type { DurationUnit, TimeRange, TraceListItem } from "./trace_list_helpers";
+import { TraceListFilters } from "./trace_list_filters";
+import { TraceListItems } from "./trace_list_items";
+export { ZipImportModal } from "./zip_import_modal";
 
 type TraceListPanelProps = {
   traceListOpen: boolean;
@@ -35,17 +29,6 @@ type TraceListPanelProps = {
   detailReason: string[];
   setZipMessage: (value: string | null) => void;
   setZipModalOpen: (open: boolean) => void;
-};
-
-type ZipImportModalProps = {
-  tenantId: string | null;
-  zipMessage: string | null;
-  zipUploading: boolean;
-  zipFile: File | null;
-  setZipFile: (file: File | null) => void;
-  setZipMessage: (value: string | null) => void;
-  setZipModalOpen: (open: boolean) => void;
-  handleZipImport: () => void;
 };
 
 export function TraceListPanel({
@@ -118,132 +101,30 @@ export function TraceListPanel({
               </button>
             </div>
           </div>
-          <div className="trace-panel__filters">
-            <input
-              className="trace-filter__search"
-              type="search"
-              aria-label="Trace検索"
-              placeholder="trace / rule を検索"
-              value={traceFilterQuery}
-              onChange={(event) => setTraceFilterQuery(event.target.value)}
-            />
-            <select
-              className="trace-filter__select"
-              aria-label="ステータス"
-              value={traceFilterStatus}
-              onChange={(event) => setTraceFilterStatus(event.target.value)}
-            >
-              <option value="all">status: all</option>
-              {statusOptions.map((status) => (
-                <option key={status} value={status}>
-                  {status}
-                </option>
-              ))}
-            </select>
-            <select
-              className="trace-filter__select"
-              aria-label="ルール"
-              value={traceFilterRule}
-              onChange={(event) => setTraceFilterRule(event.target.value)}
-            >
-              <option value="all">rule: all</option>
-              {ruleOptions.map((rule) => (
-                <option key={rule} value={rule}>
-                  {rule}
-                </option>
-              ))}
-            </select>
-            <select
-              className="trace-filter__select"
-              aria-label="期間"
-              value={traceFilterRange}
-              onChange={(event) => setTraceFilterRange(event.target.value as TimeRange)}
-            >
-              {TIME_RANGE_OPTIONS.map((range) => (
-                <option key={range.value} value={range.value}>
-                  {range.label}
-                </option>
-              ))}
-            </select>
-            <button
-              className="trace-filter__reset"
-              type="button"
-              onClick={() => {
-                setTraceFilterStatus("all");
-                setTraceFilterRule("all");
-                setTraceFilterQuery("");
-                setTraceFilterRange("all");
-              }}
-            >
-              リセット
-            </button>
-            <span className="trace-filter__count">
-              {filteredTraces.length} / {traces.length}
-            </span>
-          </div>
-          <div className="trace-list">
-            {(detailStatus && detailStatus !== "full") || detailError ? (
-              <div className="trace-panel__note">
-                {detailError ? (
-                  <>
-                    <p>detail の読み込みに失敗しました。</p>
-                    <p className="muted">manifest または chunk の取得に失敗しています。</p>
-                  </>
-                ) : (
-                  <>
-                    <p>detail は {detailStatus} です。</p>
-                    {detailReason.length > 0 && (
-                      <p className="muted">reason: {detailReason.join(", ")}</p>
-                    )}
-                  </>
-                )}
-              </div>
-            ) : null}
-            {traces.length === 0 && (
-              <div className="empty-trace">
-                <p>traces が見つかりません。</p>
-                <p className="muted">
-                  data_dir（既定: ./.rulemorph）の traces/ に JSON を配置してください。
-                </p>
-              </div>
-            )}
-            {traces.length > 0 && filteredTraces.length === 0 && (
-              <div className="empty-trace">
-                <p>フィルタ条件に一致するトレースがありません。</p>
-                <p className="muted">検索語や期間を調整してください。</p>
-              </div>
-            )}
-            {filteredTraces.map((item) => (
-              <button
-                key={item.trace_id}
-                className={clsx("trace-card", selectedId === item.trace_id && "is-active")}
-                onClick={() => setSelectedId(item.trace_id)}
-              >
-                <div>
-                  <span className={clsx("chip", isErrorStatus(item.status) && "chip--error")}>
-                    {item.status ?? "ok"}
-                  </span>
-                  <h3>{item.rule?.name ?? item.trace_id}</h3>
-                  <p className="muted">{item.rule?.path ?? "(no path)"}</p>
-                </div>
-                <div className="trace-meta">
-                  <div>
-                    <span>time: </span>
-                    <strong>{formatTime(item.timestamp)}</strong>
-                  </div>
-                  <div>
-                    <span>duration: </span>
-                    <strong>
-                      {formatDuration(
-                        resolveDurationUs(item.duration_us, item.duration_ms),
-                        durationUnit
-                      )}
-                    </strong>
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
+          <TraceListFilters
+            traceFilterQuery={traceFilterQuery}
+            setTraceFilterQuery={setTraceFilterQuery}
+            traceFilterStatus={traceFilterStatus}
+            setTraceFilterStatus={setTraceFilterStatus}
+            traceFilterRule={traceFilterRule}
+            setTraceFilterRule={setTraceFilterRule}
+            traceFilterRange={traceFilterRange}
+            setTraceFilterRange={setTraceFilterRange}
+            statusOptions={statusOptions}
+            ruleOptions={ruleOptions}
+            filteredTraces={filteredTraces}
+            traces={traces}
+          />
+          <TraceListItems
+            durationUnit={durationUnit}
+            filteredTraces={filteredTraces}
+            traces={traces}
+            selectedId={selectedId}
+            setSelectedId={setSelectedId}
+            detailStatus={detailStatus}
+            detailError={detailError}
+            detailReason={detailReason}
+          />
         </>
       ) : (
         <button className="trace-panel__chip" onClick={() => setTraceListOpen(true)}>
@@ -252,78 +133,5 @@ export function TraceListPanel({
         </button>
       )}
     </aside>
-  );
-}
-
-export function ZipImportModal({
-  tenantId,
-  zipMessage,
-  zipUploading,
-  zipFile,
-  setZipFile,
-  setZipMessage,
-  setZipModalOpen,
-  handleZipImport
-}: ZipImportModalProps) {
-  return (
-    <div className="modal-overlay" role="dialog" aria-modal="true">
-      <div className="modal">
-        <div className="modal__header">
-          <div>
-            <h3>ZIPインポート</h3>
-            <p className="muted">traces/ と rules/ を含むZIPをアップロードしてください。</p>
-          </div>
-          <button
-            className="icon-button"
-            onClick={() => {
-              setZipModalOpen(false);
-              setZipFile(null);
-            }}
-          >
-            ×
-          </button>
-        </div>
-        <div className="modal__body">
-          {tenantId && <p className="muted">tenant: {tenantId}</p>}
-          <input
-            className="modal__file"
-            data-testid="zip-import-file"
-            type="file"
-            accept=".zip"
-            onChange={(event) => {
-              const file = event.currentTarget.files?.[0] ?? null;
-              setZipFile(file);
-              setZipMessage(null);
-            }}
-          />
-          {zipMessage && (
-            <div className="modal__message" data-testid="zip-import-message">
-              {zipMessage}
-            </div>
-          )}
-        </div>
-        <div className="modal__actions">
-          <button
-            className="modal__button"
-            type="button"
-            onClick={() => {
-              setZipModalOpen(false);
-              setZipFile(null);
-            }}
-          >
-            閉じる
-          </button>
-          <button
-            className="modal__button modal__button--primary"
-            data-testid="zip-import-submit"
-            type="button"
-            disabled={zipUploading || !zipFile}
-            onClick={handleZipImport}
-          >
-            {zipUploading ? "アップロード中..." : "インポート"}
-          </button>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/crates/rulemorph_ui/ui/src/zip_import_modal.tsx
+++ b/crates/rulemorph_ui/ui/src/zip_import_modal.tsx
@@ -1,0 +1,83 @@
+type ZipImportModalProps = {
+  tenantId: string | null;
+  zipMessage: string | null;
+  zipUploading: boolean;
+  zipFile: File | null;
+  setZipFile: (file: File | null) => void;
+  setZipMessage: (value: string | null) => void;
+  setZipModalOpen: (open: boolean) => void;
+  handleZipImport: () => void;
+};
+
+export function ZipImportModal({
+  tenantId,
+  zipMessage,
+  zipUploading,
+  zipFile,
+  setZipFile,
+  setZipMessage,
+  setZipModalOpen,
+  handleZipImport
+}: ZipImportModalProps) {
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true">
+      <div className="modal">
+        <div className="modal__header">
+          <div>
+            <h3>ZIPインポート</h3>
+            <p className="muted">traces/ と rules/ を含むZIPをアップロードしてください。</p>
+          </div>
+          <button
+            className="icon-button"
+            onClick={() => {
+              setZipModalOpen(false);
+              setZipFile(null);
+            }}
+          >
+            ×
+          </button>
+        </div>
+        <div className="modal__body">
+          {tenantId && <p className="muted">tenant: {tenantId}</p>}
+          <input
+            className="modal__file"
+            data-testid="zip-import-file"
+            type="file"
+            accept=".zip"
+            onChange={(event) => {
+              const file = event.currentTarget.files?.[0] ?? null;
+              setZipFile(file);
+              setZipMessage(null);
+            }}
+          />
+          {zipMessage && (
+            <div className="modal__message" data-testid="zip-import-message">
+              {zipMessage}
+            </div>
+          )}
+        </div>
+        <div className="modal__actions">
+          <button
+            className="modal__button"
+            type="button"
+            onClick={() => {
+              setZipModalOpen(false);
+              setZipFile(null);
+            }}
+          >
+            閉じる
+          </button>
+          <button
+            className="modal__button modal__button--primary"
+            data-testid="zip-import-submit"
+            type="button"
+            disabled={zipUploading || !zipFile}
+            onClick={handleZipImport}
+          >
+            {zipUploading ? "アップロード中..." : "インポート"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Split Trace list panel filters, trace list items, and ZIP import modal into focused internal modules
- Keep TraceListPanel and ZipImportModal import compatibility through trace_list_panel.tsx
- Keep filter controls, trace cards, detail notes, collapsed chip, duration unit controls, ZIP modal labels/data-testid, and import UI behavior unchanged
- Leave App.tsx, Rust code, public APIs, trace schema, docs/specs, and transform semantics unchanged

## Verification
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e
- npm --prefix crates/rulemorph_ui/ui run test:e2e -- --list
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- Browser smoke on http://127.0.0.1:5176/ for trace list filters and ZIP modal with no page errors

No immediate merge after creation; this PR should wait for review/comment checks.