### PR TITLE
Refactor UI app trace detail loader

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -10,10 +10,7 @@ import { __resetTenantCachesForTest, getTenantId } from "./tenant";
 import {
   API_BASE,
   INTERNAL_BASE,
-  fetchJson,
-  loadFinalize,
-  loadNodeChunks,
-  loadRecordChunks
+  fetchJson
 } from "./api_client";
 import {
   applyTraceFilters,
@@ -37,13 +34,12 @@ import {
   resolveRecordLabel
 } from "./app_derived_state";
 import {
-  mergeNodesIntoRecords,
-  normalizeTracePayload,
   type TraceManifest,
   type TraceNode,
   type TracePayload,
   type TraceRecord
 } from "./trace_payload";
+import { loadSelectedTraceDetail } from "./app_trace_detail_loader";
 import { InspectorDrawer } from "./inspector_drawer";
 import { RecordPanel } from "./record_panel";
 import { Topbar } from "./topbar";
@@ -249,70 +245,14 @@ export default function App() {
     setInspectorOpen(false);
     setPinnedPositions({});
     (async () => {
-      const manifestResult = await fetchJson<{ manifest: TraceManifest }>(
-        `${API_BASE}/traces/${selectedId}/manifest`
-      );
-      if (!mounted) return;
-      if (!manifestResult?.manifest) {
-        const result = await fetchJson<{ trace: TracePayload }>(`${API_BASE}/traces/${selectedId}`);
-        if (!mounted) return;
-        setTrace(normalizeTracePayload(result?.trace ?? null));
-        return;
-      }
-      const manifest = manifestResult.manifest;
-      setTraceManifest(manifest);
-      const baseTrace: TracePayload = {
-        trace_id: manifest.trace_id,
-        timestamp: manifest.timestamp,
-        status: manifest.status,
-        rule: manifest.rule,
-        rule_source: manifest.rule_source,
-        records: [],
-        finalize: undefined,
-        summary: manifest.summary,
-        input_format: manifest.input_format
-      };
-      setTrace(baseTrace);
-      const detail = manifest.detail;
-      if (!detail || detail.status !== "full") {
-        return;
-      }
-      setDetailLoading(true);
-      try {
-        const records = await loadRecordChunks(selectedId, detail);
-        if (!mounted) return;
-        let nextTrace: TracePayload = { ...baseTrace, records };
-        setTrace(nextTrace);
-        if (detail.layout === "records_nodes_split" && (detail.nodes?.length ?? 0) > 0) {
-          const nodesByRecord = await loadNodeChunks(selectedId, detail);
-          if (!mounted) return;
-          const mergedRecords = mergeNodesIntoRecords(records, nodesByRecord);
-          nextTrace = { ...nextTrace, records: mergedRecords };
-          setTrace(nextTrace);
-        }
-        if (detail.finalize) {
-          const finalize = await loadFinalize(selectedId);
-          if (!mounted) return;
-          if (finalize) {
-            setTrace((prev) => (prev ? { ...prev, finalize } : { ...nextTrace, finalize }));
-          }
-        }
-      } catch (err) {
-        if (!mounted) return;
-        const fallback = await fetchJson<{ trace: TracePayload }>(`${API_BASE}/traces/${selectedId}`);
-        if (!mounted) return;
-        if (fallback?.trace) {
-          setTraceManifest(null);
-          setTrace(normalizeTracePayload(fallback.trace));
-          setDetailError(null);
-          return;
-        }
-        setDetailError("trace detail load failed");
-      } finally {
-        if (mounted) {
-          setDetailLoading(false);
-        }
-      }
+      await loadSelectedTraceDetail({
+        selectedId,
+        isMounted: () => mounted,
+        setTrace,
+        setTraceManifest,
+        setDetailLoading,
+        setDetailError
+      });
     })();
     return () => {
       mounted = false;

--- a/crates/rulemorph_ui/ui/src/app_trace_detail_loader.ts
+++ b/crates/rulemorph_ui/ui/src/app_trace_detail_loader.ts
@@ -1,0 +1,104 @@
+import {
+  API_BASE,
+  fetchJson,
+  loadFinalize,
+  loadNodeChunks,
+  loadRecordChunks
+} from "./api_client";
+import {
+  mergeNodesIntoRecords,
+  normalizeTracePayload,
+  type TraceManifest,
+  type TracePayload
+} from "./trace_payload";
+
+type TraceSetter = (
+  value: TracePayload | null | ((prev: TracePayload | null) => TracePayload | null)
+) => void;
+
+type LoadSelectedTraceDetailArgs = {
+  selectedId: string;
+  isMounted: () => boolean;
+  setTrace: TraceSetter;
+  setTraceManifest: (manifest: TraceManifest | null) => void;
+  setDetailLoading: (loading: boolean) => void;
+  setDetailError: (message: string | null) => void;
+};
+
+function buildBaseTrace(manifest: TraceManifest): TracePayload {
+  return {
+    trace_id: manifest.trace_id,
+    timestamp: manifest.timestamp,
+    status: manifest.status,
+    rule: manifest.rule,
+    rule_source: manifest.rule_source,
+    records: [],
+    finalize: undefined,
+    summary: manifest.summary,
+    input_format: manifest.input_format
+  };
+}
+
+export async function loadSelectedTraceDetail({
+  selectedId,
+  isMounted,
+  setTrace,
+  setTraceManifest,
+  setDetailLoading,
+  setDetailError
+}: LoadSelectedTraceDetailArgs): Promise<void> {
+  const manifestResult = await fetchJson<{ manifest: TraceManifest }>(
+    `${API_BASE}/traces/${selectedId}/manifest`
+  );
+  if (!isMounted()) return;
+  if (!manifestResult?.manifest) {
+    const result = await fetchJson<{ trace: TracePayload }>(`${API_BASE}/traces/${selectedId}`);
+    if (!isMounted()) return;
+    setTrace(normalizeTracePayload(result?.trace ?? null));
+    return;
+  }
+  const manifest = manifestResult.manifest;
+  setTraceManifest(manifest);
+  const baseTrace = buildBaseTrace(manifest);
+  setTrace(baseTrace);
+  const detail = manifest.detail;
+  if (!detail || detail.status !== "full") {
+    return;
+  }
+  setDetailLoading(true);
+  try {
+    const records = await loadRecordChunks(selectedId, detail);
+    if (!isMounted()) return;
+    let nextTrace: TracePayload = { ...baseTrace, records };
+    setTrace(nextTrace);
+    if (detail.layout === "records_nodes_split" && (detail.nodes?.length ?? 0) > 0) {
+      const nodesByRecord = await loadNodeChunks(selectedId, detail);
+      if (!isMounted()) return;
+      const mergedRecords = mergeNodesIntoRecords(records, nodesByRecord);
+      nextTrace = { ...nextTrace, records: mergedRecords };
+      setTrace(nextTrace);
+    }
+    if (detail.finalize) {
+      const finalize = await loadFinalize(selectedId);
+      if (!isMounted()) return;
+      if (finalize) {
+        setTrace((prev) => (prev ? { ...prev, finalize } : { ...nextTrace, finalize }));
+      }
+    }
+  } catch (err) {
+    if (!isMounted()) return;
+    const fallback = await fetchJson<{ trace: TracePayload }>(`${API_BASE}/traces/${selectedId}`);
+    if (!isMounted()) return;
+    if (fallback?.trace) {
+      setTraceManifest(null);
+      setTrace(normalizeTracePayload(fallback.trace));
+      setDetailError(null);
+      return;
+    }
+    setDetailError("trace detail load failed");
+  } finally {
+    if (isMounted()) {
+      setDetailLoading(false);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract selected trace detail loading from App.tsx into app_trace_detail_loader.ts
- keep selectedId reset/orchestration in App.tsx
- preserve manifest fallback, chunk load order, finalize merge, and fallback error behavior

## Verification
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e
- npm --prefix crates/rulemorph_ui/ui run test:e2e -- --list
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- browser smoke on http://127.0.0.1:5176/