### PR TITLE
Refactor UI app API graph state

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -7,7 +7,6 @@ import {
   getInternalKey
 } from "./auth";
 import { __resetTenantCachesForTest, getTenantId } from "./tenant";
-import { API_BASE, fetchJson } from "./api_client";
 import {
   applyTraceFilters,
   type DurationUnit,
@@ -56,6 +55,7 @@ import {
   reconcileFilteredTraceSelection,
   subscribeTraceListRefresh
 } from "./app_trace_list_refresh";
+import { loadApiGraph, resetApiGraphSelection } from "./app_api_graph_state";
 
 export { getApiKey, getInternalKey } from "./auth";
 export { __getTenantIdFromQueryOrStorageForTest, resolveTenantId } from "./tenant";
@@ -184,20 +184,18 @@ export default function App() {
 
   useEffect(() => {
     if (viewMode !== "api") return;
-    fetchJson<ApiGraphResponse>(`${API_BASE}/api-graph`).then((data) => {
-      if (data) {
-        setApiGraph(data);
-      }
-    });
+    void loadApiGraph({ setApiGraph });
   }, [viewMode]);
 
   useEffect(() => {
     if (viewMode !== "api") return;
-    setSelectedApiNode(null);
-    setSelectedApiOp(null);
-    setApiExpandedRuleIds([]);
-    setApiFocusedRuleId(null);
-    setInspectorOpen(false);
+    resetApiGraphSelection({
+      setSelectedApiNode,
+      setSelectedApiOp,
+      setApiExpandedRuleIds,
+      setApiFocusedRuleId,
+      setInspectorOpen
+    });
   }, [viewMode]);
 
   useEffect(() => {

--- a/crates/rulemorph_ui/ui/src/app_api_graph_state.ts
+++ b/crates/rulemorph_ui/ui/src/app_api_graph_state.ts
@@ -1,0 +1,36 @@
+import type { Dispatch, SetStateAction } from "react";
+import { API_BASE, fetchJson } from "./api_client";
+import type { ApiGraphNode, ApiGraphOp, ApiGraphResponse } from "./trace_graph";
+
+type LoadApiGraphArgs = {
+  setApiGraph: Dispatch<SetStateAction<ApiGraphResponse | null>>;
+};
+
+export async function loadApiGraph({ setApiGraph }: LoadApiGraphArgs): Promise<void> {
+  const data = await fetchJson<ApiGraphResponse>(`${API_BASE}/api-graph`);
+  if (data) {
+    setApiGraph(data);
+  }
+}
+
+type ResetApiGraphSelectionArgs = {
+  setSelectedApiNode: Dispatch<SetStateAction<ApiGraphNode | null>>;
+  setSelectedApiOp: Dispatch<SetStateAction<ApiGraphOp | null>>;
+  setApiExpandedRuleIds: Dispatch<SetStateAction<string[]>>;
+  setApiFocusedRuleId: Dispatch<SetStateAction<string | null>>;
+  setInspectorOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+export function resetApiGraphSelection({
+  setSelectedApiNode,
+  setSelectedApiOp,
+  setApiExpandedRuleIds,
+  setApiFocusedRuleId,
+  setInspectorOpen
+}: ResetApiGraphSelectionArgs): void {
+  setSelectedApiNode(null);
+  setSelectedApiOp(null);
+  setApiExpandedRuleIds([]);
+  setApiFocusedRuleId(null);
+  setInspectorOpen(false);
+}


### PR DESCRIPTION
## Summary
- extract API graph loading from App.tsx into app_api_graph_state.ts
- extract API graph selection reset into app_api_graph_state.ts
- keep viewMode guards and App render orchestration unchanged

## Verification
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e
- npm --prefix crates/rulemorph_ui/ui run test:e2e -- --list
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD
- browser smoke on http://127.0.0.1:5176/