### PR TITLE
Refactor UI app trace detail state

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -34,7 +34,6 @@ import {
   type TracePayload,
   type TraceRecord
 } from "./trace_payload";
-import { loadSelectedTraceDetail } from "./app_trace_detail_loader";
 import { InspectorDrawer } from "./inspector_drawer";
 import { RecordPanel } from "./record_panel";
 import { Topbar } from "./topbar";
@@ -56,6 +55,7 @@ import {
   subscribeTraceListRefresh
 } from "./app_trace_list_refresh";
 import { loadApiGraph, resetApiGraphSelection } from "./app_api_graph_state";
+import { loadTraceDetailForSelection } from "./app_trace_detail_state";
 
 export { getApiKey, getInternalKey } from "./auth";
 export { __getTenantIdFromQueryOrStorageForTest, resolveTenantId } from "./tenant";
@@ -199,38 +199,20 @@ export default function App() {
   }, [viewMode]);
 
   useEffect(() => {
-    if (!selectedId) {
-      setTrace(null);
-      setTraceManifest(null);
-      setDetailLoading(false);
-      setDetailError(null);
-      return;
-    }
-    let mounted = true;
-    setTrace(null);
-    setTraceManifest(null);
-    setDetailLoading(false);
-    setDetailError(null);
-    setRecordIndex(0);
-    setSelectedNode(null);
-    setSelectedOp(null);
-    setExpandedRuleIds([]);
-    setFocusedRuleId(null);
-    setInspectorOpen(false);
-    setPinnedPositions({});
-    (async () => {
-      await loadSelectedTraceDetail({
-        selectedId,
-        isMounted: () => mounted,
-        setTrace,
-        setTraceManifest,
-        setDetailLoading,
-        setDetailError
-      });
-    })();
-    return () => {
-      mounted = false;
-    };
+    return loadTraceDetailForSelection({
+      selectedId,
+      setTrace,
+      setTraceManifest,
+      setDetailLoading,
+      setDetailError,
+      setRecordIndex,
+      setSelectedNode,
+      setSelectedOp,
+      setExpandedRuleIds,
+      setFocusedRuleId,
+      setInspectorOpen,
+      setPinnedPositions
+    });
   }, [selectedId]);
 
   const overviewGraph = useMemo(

--- a/crates/rulemorph_ui/ui/src/app_trace_detail_state.ts
+++ b/crates/rulemorph_ui/ui/src/app_trace_detail_state.ts
@@ -1,0 +1,70 @@
+import type { Dispatch, SetStateAction } from "react";
+import { loadSelectedTraceDetail } from "./app_trace_detail_loader";
+import type { TraceManifest, TraceNode, TracePayload } from "./trace_payload";
+
+type PositionMap = Record<string, { x: number; y: number }>;
+
+type TraceDetailStateArgs = {
+  setTrace: Dispatch<SetStateAction<TracePayload | null>>;
+  setTraceManifest: Dispatch<SetStateAction<TraceManifest | null>>;
+  setDetailLoading: Dispatch<SetStateAction<boolean>>;
+  setDetailError: Dispatch<SetStateAction<string | null>>;
+  setRecordIndex: Dispatch<SetStateAction<number>>;
+  setSelectedNode: Dispatch<SetStateAction<TraceNode | null>>;
+  setSelectedOp: Dispatch<SetStateAction<TraceNode | null>>;
+  setExpandedRuleIds: Dispatch<SetStateAction<string[]>>;
+  setFocusedRuleId: Dispatch<SetStateAction<string | null>>;
+  setInspectorOpen: Dispatch<SetStateAction<boolean>>;
+  setPinnedPositions: Dispatch<SetStateAction<PositionMap>>;
+};
+
+type LoadTraceDetailForSelectionArgs = TraceDetailStateArgs & {
+  selectedId: string | null;
+};
+
+function resetEmptyTraceDetail({
+  setTrace,
+  setTraceManifest,
+  setDetailLoading,
+  setDetailError
+}: TraceDetailStateArgs): void {
+  setTrace(null);
+  setTraceManifest(null);
+  setDetailLoading(false);
+  setDetailError(null);
+}
+
+function resetSelectedTraceDetail(args: TraceDetailStateArgs): void {
+  resetEmptyTraceDetail(args);
+  args.setRecordIndex(0);
+  args.setSelectedNode(null);
+  args.setSelectedOp(null);
+  args.setExpandedRuleIds([]);
+  args.setFocusedRuleId(null);
+  args.setInspectorOpen(false);
+  args.setPinnedPositions({});
+}
+
+export function loadTraceDetailForSelection(
+  args: LoadTraceDetailForSelectionArgs
+): void | (() => void) {
+  const { selectedId } = args;
+  if (!selectedId) {
+    resetEmptyTraceDetail(args);
+    return undefined;
+  }
+
+  let mounted = true;
+  resetSelectedTraceDetail(args);
+  void loadSelectedTraceDetail({
+    selectedId,
+    isMounted: () => mounted,
+    setTrace: args.setTrace,
+    setTraceManifest: args.setTraceManifest,
+    setDetailLoading: args.setDetailLoading,
+    setDetailError: args.setDetailError
+  });
+  return () => {
+    mounted = false;
+  };
+}


### PR DESCRIPTION
## Summary
- move selected trace detail lifecycle reset/load logic out of App.tsx
- keep App.tsx responsible for hook orchestration and rendering
- preserve trace detail loading behavior, reset order, mounted guard, UI behavior, API contracts, Rust code, docs, and trace schema

## Tests
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e
- browser smoke on http://127.0.0.1:5176/
- cargo fmt --check
- git diff --check