### PR TITLE
Refactor array aggregate dispatch

### DIFF
--- a/crates/rulemorph/src/transform/operators/dispatch/array_dispatch.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch/array_dispatch.rs
@@ -1,15 +1,16 @@
 use super::super::array::{
-    eval_array_avg, eval_array_chunk, eval_array_contains, eval_array_distinct_by, eval_array_drop,
+    eval_array_chunk, eval_array_contains, eval_array_distinct_by, eval_array_drop,
     eval_array_filter, eval_array_find, eval_array_find_index, eval_array_flat_map,
-    eval_array_flatten, eval_array_fold, eval_array_group_by, eval_array_index_of,
-    eval_array_key_by, eval_array_map, eval_array_max, eval_array_min, eval_array_partition,
-    eval_array_reduce, eval_array_slice, eval_array_sort_by, eval_array_sum, eval_array_take,
+    eval_array_flatten, eval_array_group_by, eval_array_index_of, eval_array_key_by,
+    eval_array_map, eval_array_partition, eval_array_slice, eval_array_sort_by, eval_array_take,
     eval_array_unique, eval_array_unzip, eval_array_zip, eval_array_zip_with,
 };
 use super::super::*;
 
+mod aggregate;
 mod inventory;
 
+use aggregate::{eval_array_aggregate_dispatch, is_array_aggregate_operator};
 pub(super) use inventory::is_array_operator;
 
 pub(super) fn eval_array_dispatch(
@@ -211,59 +212,8 @@ pub(super) fn eval_array_dispatch(
             base_path,
             locals,
         ),
-        "sum" => eval_array_sum(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "avg" => eval_array_avg(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "min" => eval_array_min(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "max" => eval_array_max(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "reduce" => eval_array_reduce(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "fold" => eval_array_fold(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
+        op if is_array_aggregate_operator(op) => eval_array_aggregate_dispatch(
+            expr_op, record, context, out, base_path, injected, locals,
         ),
         _ => unreachable!("array dispatch called for non-array operator"),
     }

--- a/crates/rulemorph/src/transform/operators/dispatch/array_dispatch/aggregate.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch/array_dispatch/aggregate.rs
@@ -1,0 +1,77 @@
+use super::super::super::array::{
+    eval_array_avg, eval_array_fold, eval_array_max, eval_array_min, eval_array_reduce,
+    eval_array_sum,
+};
+use super::super::*;
+
+pub(super) fn is_array_aggregate_operator(op: &str) -> bool {
+    matches!(op, "sum" | "avg" | "min" | "max" | "reduce" | "fold")
+}
+
+pub(super) fn eval_array_aggregate_dispatch(
+    expr_op: &ExprOp,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    injected: Option<&EvalValue>,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    match expr_op.op.as_str() {
+        "sum" => eval_array_sum(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "avg" => eval_array_avg(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "min" => eval_array_min(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "max" => eval_array_max(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "reduce" => eval_array_reduce(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "fold" => eval_array_fold(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        _ => unreachable!("array aggregate dispatch called for non-aggregate operator"),
+    }
+}


### PR DESCRIPTION
## Summary
- move array aggregate and accumulator dispatch arms into a sibling helper module
- keep array operator inventory and operator implementations unchanged
- preserve transform behavior, trace parity, public APIs, docs, and trace JSON schema

## Tests
- cargo fmt
- cargo test -p rulemorph --test transform_golden t16_array_ops
- cargo test -p rulemorph --test array_ops_overflow_32bit
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_collection_operators_emit_item_level_events
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_item_scoped_collection_ops_match_normal
- cargo test -p rulemorph --test transform_trace_semantics
- cargo test -p rulemorph --test transform_trace
- cargo fmt --check
- git diff --check