### PR TITLE
Refactor JSON operator dispatch

### DIFF
--- a/crates/rulemorph/src/transform/operators/dispatch.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch.rs
@@ -1,19 +1,16 @@
 use super::args::args_len;
 use super::boolean::{eval_bool_and_or, eval_bool_not, eval_compare};
 use super::date::{eval_date_format, eval_to_unixtime};
-use super::json::{
-    eval_json_entries, eval_json_from_entries, eval_json_get, eval_json_keys, eval_json_merge,
-    eval_json_object_flatten, eval_json_object_unflatten, eval_json_omit, eval_json_pick,
-    eval_json_values, eval_len,
-};
 use super::lookup::eval_lookup;
 use super::number::{eval_numeric_op, eval_round, eval_to_base};
 use super::*;
 
 mod array_dispatch;
+mod json_dispatch;
 mod string_dispatch;
 
 use self::array_dispatch::{eval_array_dispatch, is_array_operator};
+use self::json_dispatch::{eval_json_dispatch, is_json_operator};
 use self::string_dispatch::{eval_string_dispatch, is_string_operator};
 
 pub(crate) fn eval_op(
@@ -58,116 +55,9 @@ pub(crate) fn eval_op(
             true,
             locals,
         ),
-        "merge" => eval_json_merge(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            false,
-            locals,
-        ),
-        "deep_merge" => eval_json_merge(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            true,
-            locals,
-        ),
-        "get" => eval_json_get(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "pick" => eval_json_pick(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "omit" => eval_json_omit(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "keys" => eval_json_keys(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "values" => eval_json_values(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "entries" => eval_json_entries(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "len" => eval_len(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "from_entries" => eval_json_from_entries(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "object_flatten" => eval_json_object_flatten(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
-        "object_unflatten" => eval_json_object_unflatten(
-            &expr_op.args,
-            injected,
-            record,
-            context,
-            out,
-            base_path,
-            locals,
-        ),
+        op if is_json_operator(op) => {
+            eval_json_dispatch(expr_op, record, context, out, base_path, injected, locals)
+        }
         op if is_array_operator(op) => {
             eval_array_dispatch(expr_op, record, context, out, base_path, injected, locals)
         }

--- a/crates/rulemorph/src/transform/operators/dispatch/json_dispatch.rs
+++ b/crates/rulemorph/src/transform/operators/dispatch/json_dispatch.rs
@@ -1,0 +1,148 @@
+use super::super::json::{
+    eval_json_entries, eval_json_from_entries, eval_json_get, eval_json_keys, eval_json_merge,
+    eval_json_object_flatten, eval_json_object_unflatten, eval_json_omit, eval_json_pick,
+    eval_json_values, eval_len,
+};
+use super::*;
+
+pub(super) fn is_json_operator(op: &str) -> bool {
+    matches!(
+        op,
+        "merge"
+            | "deep_merge"
+            | "get"
+            | "pick"
+            | "omit"
+            | "keys"
+            | "values"
+            | "entries"
+            | "len"
+            | "from_entries"
+            | "object_flatten"
+            | "object_unflatten"
+    )
+}
+
+pub(super) fn eval_json_dispatch(
+    expr_op: &ExprOp,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    out: &JsonValue,
+    base_path: &str,
+    injected: Option<&EvalValue>,
+    locals: Option<&EvalLocals<'_>>,
+) -> Result<EvalValue, TransformError> {
+    match expr_op.op.as_str() {
+        "merge" => eval_json_merge(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            false,
+            locals,
+        ),
+        "deep_merge" => eval_json_merge(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            true,
+            locals,
+        ),
+        "get" => eval_json_get(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "pick" => eval_json_pick(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "omit" => eval_json_omit(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "keys" => eval_json_keys(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "values" => eval_json_values(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "entries" => eval_json_entries(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "len" => eval_len(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "from_entries" => eval_json_from_entries(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "object_flatten" => eval_json_object_flatten(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        "object_unflatten" => eval_json_object_unflatten(
+            &expr_op.args,
+            injected,
+            record,
+            context,
+            out,
+            base_path,
+            locals,
+        ),
+        _ => unreachable!("json dispatch called for non-json operator"),
+    }
+}


### PR DESCRIPTION
## Summary
- move JSON operator routing out of the top-level operator dispatch
- keep JSON operator implementations and unsupported-op behavior unchanged
- preserve transform behavior, trace parity, public APIs, docs, and trace JSON schema

## Tests
- cargo fmt
- cargo test -p rulemorph --test transform_golden json_ops
- cargo test -p rulemorph --test transform_golden t25_json_ops_get_chain
- cargo test -p rulemorph --test transform_golden t13_expr_extended
- cargo test -p rulemorph --test transform_trace
- cargo test -p rulemorph --test transform_trace_semantics
- cargo fmt --check
- git diff --check