### PR TITLE
Refactor trace writer detail chunks

### DIFF
--- a/crates/rulemorph_trace/src/trace_writer/bundle.rs
+++ b/crates/rulemorph_trace/src/trace_writer/bundle.rs
@@ -3,30 +3,24 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 
-use super::chunk_write::{
-    max_ndjson_line_bytes, write_finalize_chunk, write_node_chunks, write_record_chunks,
-};
 use super::cleanup::TraceDirGuard;
 use super::detail::{detail_status_for_level, initial_detail_reasons, strip_trace_detail};
 use super::externalize::externalize_trace_payloads;
-use super::manifest::count_inline_nodes;
 use super::masking::{apply_masking, normalize_masking_rules};
 use super::options::{TraceDetailLevel, TraceWriteOptions, clamp_max_chunk_bytes_uncompressed};
-use super::record_nodes::{normalize_inline_records, split_records_and_nodes};
 use super::sampling::should_keep_full_detail;
 use super::trace_dir::{
     ensure_unique_trace_dir, resolve_trace_timestamp, trace_dir_base_for_timestamp,
 };
 use super::trace_identity::resolve_trace_id;
-use crate::trace_schema::{
-    TRACE_CHUNK_COUNT_HARD_MAX, TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX,
-    TraceMasking,
-};
+use crate::trace_schema::{TRACE_CHUNK_COUNT_HARD_MAX, TraceMasking};
 
+mod detail_chunks;
 mod detail_cleanup;
 mod detail_files;
 mod manifest_build;
 mod manifest_payload;
+use self::detail_chunks::write_full_detail_chunks;
 use self::detail_cleanup::{add_detail_reason, reset_detail_to_basic, total_detail_bytes};
 use self::detail_files::ensure_detail_files_exist;
 use self::manifest_build::build_trace_manifest;
@@ -137,80 +131,26 @@ pub(crate) fn write_trace_bundle_sync(
                     .and_then(|value| value.as_array())
                     .cloned()
                     .unwrap_or_default();
-                let (records_for_chunks, nodes_for_chunks) = if options.split_nodes {
-                    detail_layout = "records_nodes_split".to_string();
-                    split_records_and_nodes(&records)
-                } else {
-                    (normalize_inline_records(&records), Vec::new())
-                };
-
-                let total_records = records_for_chunks.len();
-                let total_nodes = if options.split_nodes {
-                    nodes_for_chunks.len()
-                } else {
-                    count_inline_nodes(&records_for_chunks, TRACE_NODE_COUNT_HARD_MAX)
-                };
-                if total_records > TRACE_RECORD_COUNT_HARD_MAX
-                    || total_nodes > TRACE_NODE_COUNT_HARD_MAX
-                {
-                    budget_exceeded = true;
-                }
-
-                if !budget_exceeded {
-                    let max_record_line = max_ndjson_line_bytes(&records_for_chunks, "record")?;
-                    let max_node_line = max_ndjson_line_bytes(&nodes_for_chunks, "node")?;
-                    let max_line = max_record_line.max(max_node_line);
-                    if max_line > options.max_chunk_bytes_uncompressed {
-                        detail_status = "basic".to_string();
-                        detail_layout = "records_inline".to_string();
-                        if !detail_reason
-                            .iter()
-                            .any(|reason| reason == "chunk_too_large")
-                        {
-                            detail_reason.push("chunk_too_large".to_string());
-                        }
-                        chunk_too_large = true;
-                    } else {
-                        let record_result = write_record_chunks(
-                            &trace_dir,
-                            &records_for_chunks,
-                            &options,
-                            &mut budget_remaining,
-                            &mut chunk_budget_remaining,
-                        )?;
-                        record_chunks = record_result.chunks;
-                        record_files = record_result.files;
-                        budget_exceeded = record_result.budget_exceeded;
-
-                        if !budget_exceeded && options.split_nodes {
-                            let node_result = write_node_chunks(
-                                &trace_dir,
-                                &nodes_for_chunks,
-                                &options,
-                                &mut budget_remaining,
-                                &mut chunk_budget_remaining,
-                            )?;
-                            node_chunks = node_result.chunks;
-                            node_files = node_result.files;
-                            budget_exceeded = node_result.budget_exceeded;
-                        }
-
-                        if !budget_exceeded {
-                            let finalize_result = write_finalize_chunk(
-                                &trace_dir,
-                                &trace,
-                                &options,
-                                &mut budget_remaining,
-                                &mut chunk_budget_remaining,
-                            )?;
-                            finalize_chunk = finalize_result.chunk;
-                            finalize_file = finalize_result.file;
-                            budget_exceeded = finalize_result.budget_exceeded;
-                            if finalize_result.size_exceeded {
-                                chunk_too_large = true;
-                            }
-                        }
-                    }
+                let detail_result = write_full_detail_chunks(
+                    &trace_dir,
+                    &trace,
+                    &records,
+                    &options,
+                    &mut budget_remaining,
+                    &mut chunk_budget_remaining,
+                )?;
+                record_chunks = detail_result.record_chunks;
+                record_files = detail_result.record_files;
+                node_chunks = detail_result.node_chunks;
+                node_files = detail_result.node_files;
+                finalize_chunk = detail_result.finalize_chunk;
+                finalize_file = detail_result.finalize_file;
+                detail_layout = detail_result.detail_layout;
+                budget_exceeded = detail_result.budget_exceeded;
+                chunk_too_large = detail_result.chunk_too_large;
+                if chunk_too_large {
+                    detail_status = "basic".to_string();
+                    add_detail_reason(&mut detail_reason, "chunk_too_large");
                 }
             }
         }

--- a/crates/rulemorph_trace/src/trace_writer/bundle/detail_chunks.rs
+++ b/crates/rulemorph_trace/src/trace_writer/bundle/detail_chunks.rs
@@ -1,0 +1,112 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde_json::Value as JsonValue;
+
+use super::super::chunk_write::{
+    max_ndjson_line_bytes, write_finalize_chunk, write_node_chunks, write_record_chunks,
+};
+use super::super::manifest::count_inline_nodes;
+use super::super::options::TraceWriteOptions;
+use super::super::record_nodes::{normalize_inline_records, split_records_and_nodes};
+use crate::trace_schema::{TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX, TraceChunkRef};
+
+pub(super) struct DetailChunkWriteResult {
+    pub(super) record_chunks: Vec<TraceChunkRef>,
+    pub(super) record_files: Vec<PathBuf>,
+    pub(super) node_chunks: Vec<TraceChunkRef>,
+    pub(super) node_files: Vec<PathBuf>,
+    pub(super) finalize_chunk: Option<TraceChunkRef>,
+    pub(super) finalize_file: Option<PathBuf>,
+    pub(super) detail_layout: String,
+    pub(super) budget_exceeded: bool,
+    pub(super) chunk_too_large: bool,
+}
+
+pub(super) fn write_full_detail_chunks(
+    trace_dir: &Path,
+    trace: &JsonValue,
+    records: &[JsonValue],
+    options: &TraceWriteOptions,
+    budget_remaining: &mut u64,
+    chunk_budget_remaining: &mut usize,
+) -> Result<DetailChunkWriteResult> {
+    let mut result = DetailChunkWriteResult {
+        record_chunks: Vec::new(),
+        record_files: Vec::new(),
+        node_chunks: Vec::new(),
+        node_files: Vec::new(),
+        finalize_chunk: None,
+        finalize_file: None,
+        detail_layout: "records_inline".to_string(),
+        budget_exceeded: false,
+        chunk_too_large: false,
+    };
+
+    let (records_for_chunks, nodes_for_chunks) = if options.split_nodes {
+        result.detail_layout = "records_nodes_split".to_string();
+        split_records_and_nodes(records)
+    } else {
+        (normalize_inline_records(records), Vec::new())
+    };
+
+    let total_records = records_for_chunks.len();
+    let total_nodes = if options.split_nodes {
+        nodes_for_chunks.len()
+    } else {
+        count_inline_nodes(&records_for_chunks, TRACE_NODE_COUNT_HARD_MAX)
+    };
+    if total_records > TRACE_RECORD_COUNT_HARD_MAX || total_nodes > TRACE_NODE_COUNT_HARD_MAX {
+        result.budget_exceeded = true;
+        return Ok(result);
+    }
+
+    let max_record_line = max_ndjson_line_bytes(&records_for_chunks, "record")?;
+    let max_node_line = max_ndjson_line_bytes(&nodes_for_chunks, "node")?;
+    let max_line = max_record_line.max(max_node_line);
+    if max_line > options.max_chunk_bytes_uncompressed {
+        result.detail_layout = "records_inline".to_string();
+        result.chunk_too_large = true;
+        return Ok(result);
+    }
+
+    let record_result = write_record_chunks(
+        trace_dir,
+        &records_for_chunks,
+        options,
+        budget_remaining,
+        chunk_budget_remaining,
+    )?;
+    result.record_chunks = record_result.chunks;
+    result.record_files = record_result.files;
+    result.budget_exceeded = record_result.budget_exceeded;
+
+    if !result.budget_exceeded && options.split_nodes {
+        let node_result = write_node_chunks(
+            trace_dir,
+            &nodes_for_chunks,
+            options,
+            budget_remaining,
+            chunk_budget_remaining,
+        )?;
+        result.node_chunks = node_result.chunks;
+        result.node_files = node_result.files;
+        result.budget_exceeded = node_result.budget_exceeded;
+    }
+
+    if !result.budget_exceeded {
+        let finalize_result = write_finalize_chunk(
+            trace_dir,
+            trace,
+            options,
+            budget_remaining,
+            chunk_budget_remaining,
+        )?;
+        result.finalize_chunk = finalize_result.chunk;
+        result.finalize_file = finalize_result.file;
+        result.budget_exceeded = finalize_result.budget_exceeded;
+        result.chunk_too_large = finalize_result.size_exceeded;
+    }
+
+    Ok(result)
+}


### PR DESCRIPTION
## Summary
- Move Full detail record/node/finalize chunk writing orchestration into trace_writer/bundle/detail_chunks.rs
- Keep bundle.rs responsible for trace setup, sampling/masking/externalization, downgrade handling, and manifest write orchestration
- Preserve masking/externalization order by chunking the post-mask trace records

## Verification
- cargo fmt
- cargo test -p rulemorph_trace --test trace_writer
- cargo test -p rulemorph_trace
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

## Notes
- No public API, trace manifest schema, transform semantics, CLI/MCP/HTTP contract, or docs/spec changes.
- Initial trace_writer run caught a pre-mask records bug after extraction; fixed and reran successfully.
- Subagent review found no behavior-change issues.