### PR TITLE
Refactor UI app runtime hooks

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -2,14 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import "reactflow/dist/style.css";
 import {
   __resetAuthCachesForTest as resetAuthCachesForTest,
-  captureAuthSecretsFromLocation,
   getApiKey,
   getInternalKey
 } from "./auth";
 import { __resetTenantCachesForTest, getTenantId } from "./tenant";
 import {
   applyTraceFilters,
-  type DurationUnit,
   type TimeRange,
   type TraceListItem
 } from "./trace_list_helpers";
@@ -56,6 +54,7 @@ import {
 } from "./app_trace_list_refresh";
 import { loadApiGraph, resetApiGraphSelection } from "./app_api_graph_state";
 import { loadTraceDetailForSelection } from "./app_trace_detail_state";
+import { useAuthSecretCapture, useStoredDurationUnit } from "./app_runtime";
 
 export { getApiKey, getInternalKey } from "./auth";
 export { __getTenantIdFromQueryOrStorageForTest, resolveTenantId } from "./tenant";
@@ -68,23 +67,9 @@ export function __resetAuthCachesForTest(): void {
 }
 
 export default function App() {
-  captureAuthSecretsFromLocation();
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const capture = () => captureAuthSecretsFromLocation();
-    window.addEventListener("hashchange", capture);
-    window.addEventListener("popstate", capture);
-    return () => {
-      window.removeEventListener("hashchange", capture);
-      window.removeEventListener("popstate", capture);
-    };
-  }, []);
+  useAuthSecretCapture();
   const [viewMode, setViewMode] = useState<"trace" | "api">("trace");
-  const [durationUnit, setDurationUnit] = useState<DurationUnit>(() => {
-    if (typeof window === "undefined") return "us";
-    const stored = window.localStorage.getItem("traceDurationUnit");
-    return stored === "ms" ? "ms" : "us";
-  });
+  const [durationUnit, setDurationUnit] = useStoredDurationUnit();
   const [traces, setTraces] = useState<TraceListItem[]>([]);
   const [traceFilterStatus, setTraceFilterStatus] = useState("all");
   const [traceFilterRule, setTraceFilterRule] = useState("all");
@@ -262,10 +247,6 @@ export default function App() {
   );
   const activeGraph = viewMode === "api" ? apiMergedGraph : mergedGraph;
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem("traceDurationUnit", durationUnit);
-  }, [durationUnit]);
   const detailNodeMap = useMemo(() => collectDetailNodeMap(bundles), [bundles]);
   const apiDetailNodeMap = useMemo(() => collectApiDetailNodeMap(apiBundles), [apiBundles]);
   const detailStatus = resolveDetailStatus(traceManifest, trace);

--- a/crates/rulemorph_ui/ui/src/__tests__/app_runtime.test.ts
+++ b/crates/rulemorph_ui/ui/src/__tests__/app_runtime.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { persistDurationUnit, resolveStoredDurationUnit } from "../app_runtime";
+
+function storageWithValue(value: string | null): Storage {
+  return {
+    getItem: vi.fn(() => value),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+    key: vi.fn(),
+    length: value === null ? 0 : 1
+  };
+}
+
+describe("app runtime helpers", () => {
+  it("resolves only ms from storage and falls back to microseconds", () => {
+    expect(resolveStoredDurationUnit(storageWithValue("ms"))).toBe("ms");
+    expect(resolveStoredDurationUnit(storageWithValue("us"))).toBe("us");
+    expect(resolveStoredDurationUnit(storageWithValue("bad"))).toBe("us");
+    expect(resolveStoredDurationUnit(storageWithValue(null))).toBe("us");
+  });
+
+  it("persists the selected duration unit without changing the storage key", () => {
+    const storage = storageWithValue(null);
+
+    persistDurationUnit("ms", storage);
+    persistDurationUnit("us", storage);
+
+    expect(storage.setItem).toHaveBeenNthCalledWith(1, "traceDurationUnit", "ms");
+    expect(storage.setItem).toHaveBeenNthCalledWith(2, "traceDurationUnit", "us");
+  });
+});

--- a/crates/rulemorph_ui/ui/src/app_runtime.ts
+++ b/crates/rulemorph_ui/ui/src/app_runtime.ts
@@ -1,0 +1,45 @@
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { captureAuthSecretsFromLocation } from "./auth";
+import type { DurationUnit } from "./trace_list_helpers";
+
+const TRACE_DURATION_UNIT_STORAGE_KEY = "traceDurationUnit";
+
+function resolveStorage(storage?: Storage): Storage | null {
+  if (storage) return storage;
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+export function resolveStoredDurationUnit(storage?: Storage): DurationUnit {
+  const stored = resolveStorage(storage)?.getItem(TRACE_DURATION_UNIT_STORAGE_KEY);
+  return stored === "ms" ? "ms" : "us";
+}
+
+export function persistDurationUnit(unit: DurationUnit, storage?: Storage): void {
+  resolveStorage(storage)?.setItem(TRACE_DURATION_UNIT_STORAGE_KEY, unit);
+}
+
+export function useAuthSecretCapture(): void {
+  captureAuthSecretsFromLocation();
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const capture = () => captureAuthSecretsFromLocation();
+    window.addEventListener("hashchange", capture);
+    window.addEventListener("popstate", capture);
+    return () => {
+      window.removeEventListener("hashchange", capture);
+      window.removeEventListener("popstate", capture);
+    };
+  }, []);
+}
+
+export function useStoredDurationUnit(): [
+  DurationUnit,
+  Dispatch<SetStateAction<DurationUnit>>
+] {
+  const [durationUnit, setDurationUnit] = useState<DurationUnit>(() => resolveStoredDurationUnit());
+  useEffect(() => {
+    persistDurationUnit(durationUnit);
+  }, [durationUnit]);
+  return [durationUnit, setDurationUnit];
+}


### PR DESCRIPTION
## Summary
- move App auth secret capture wiring into app_runtime.ts
- move traceDurationUnit localStorage restore/persist logic into a runtime hook
- add characterization coverage for duration unit storage key, ms restore, us fallback, and persistence

## Verification
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e
- browser smoke on http://127.0.0.1:5178/ with app/topbar/trace canvas/trace panel/Trace一覧/zip import button present and no page errors
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

No Rust code, API contract, public exports, transform semantics, trace JSON schema, docs/specs, or Trace Console behavior changes. Subagent review found no issues.