### PR TITLE
Refactor CLI transform command

### DIFF
--- a/crates/rulemorph_cli/src/core_commands.rs
+++ b/crates/rulemorph_cli/src/core_commands.rs
@@ -1,12 +1,9 @@
-use std::io::Write;
 use std::path::PathBuf;
 
 use clap::Args;
 use rulemorph::{
-    InputData, NormalizationOptions, RuleFile,
-    preflight_validate_input_with_warnings_with_base_dir_and_options,
-    transform_input_with_warnings_with_base_dir_and_options,
-    transform_stream_input_with_base_dir_and_options, validate_rule_file_with_source,
+    InputData, preflight_validate_input_with_warnings_with_base_dir_and_options,
+    validate_rule_file_with_source,
 };
 
 use super::emit::{emit_transform_error, emit_transform_warnings, emit_validation_errors};
@@ -14,10 +11,10 @@ use super::input::{
     apply_format_override, load_context, load_input_bytes_with_limit, load_normalization_options,
     load_rule, rule_base_dir,
 };
-use super::output::{
-    create_output_writer, emit_text_output, serialize_json_output, write_json_line,
-};
 use super::{ErrorFormat, FormatOverride, LimitsProfileArg, RulesFormatArg};
+
+mod transform;
+pub(super) use transform::{TransformArgs, run_transform};
 
 #[derive(Args)]
 pub(super) struct ValidateArgs {
@@ -41,37 +38,6 @@ pub(super) struct PreflightArgs {
     format: Option<FormatOverride>,
     #[arg(short = 'c', long)]
     context: Option<PathBuf>,
-    #[arg(short = 'e', long, default_value = "text")]
-    error_format: ErrorFormat,
-    #[arg(long = "limit")]
-    limits: Vec<String>,
-    #[arg(long, value_enum)]
-    limits_profile: Option<LimitsProfileArg>,
-    #[arg(long)]
-    limits_file: Option<PathBuf>,
-}
-
-#[derive(Args)]
-pub(super) struct TransformArgs {
-    #[arg(short = 'r', long)]
-    rules: PathBuf,
-    #[arg(long)]
-    rules_format: Option<RulesFormatArg>,
-    #[arg(short = 'i', long)]
-    input: PathBuf,
-    #[arg(short = 'f', long)]
-    format: Option<FormatOverride>,
-    #[arg(short = 'c', long)]
-    context: Option<PathBuf>,
-    #[arg(short = 'o', long)]
-    output: Option<PathBuf>,
-    #[arg(
-        long,
-        help = "Emit one JSON object per line. This streams output, but input normalization is bounded by the configured limits."
-    )]
-    ndjson: bool,
-    #[arg(short = 'v', long)]
-    validate: bool,
     #[arg(short = 'e', long, default_value = "text")]
     error_format: ErrorFormat,
     #[arg(long = "limit")]
@@ -143,141 +109,6 @@ pub(super) fn run_preflight(args: PreflightArgs) -> i32 {
     };
 
     emit_transform_warnings(&warnings, args.error_format);
-
-    0
-}
-
-pub(super) fn run_transform(args: TransformArgs) -> i32 {
-    let (mut rule, yaml) = match load_rule(&args.rules, args.rules_format) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    apply_format_override(&mut rule, args.format);
-
-    if args.validate {
-        if let Err(errors) = validate_rule_file_with_source(&rule, &yaml) {
-            emit_validation_errors(&errors, args.error_format);
-            return 2;
-        }
-    }
-
-    let options = match load_normalization_options(
-        args.limits_profile,
-        args.limits_file.as_ref(),
-        &args.limits,
-    ) {
-        Ok(options) => options,
-        Err(message) => {
-            eprintln!("{}", message);
-            return 2;
-        }
-    };
-
-    let input = match load_input_bytes_with_limit(&args.input, options.max_input_bytes) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    let context_value = match load_context(&args.context) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
-
-    if args.ndjson {
-        return run_transform_ndjson(
-            &rule,
-            &input,
-            context_value.as_ref(),
-            args.output,
-            args.error_format,
-            &args.rules,
-            &options,
-        );
-    }
-
-    let base_dir = rule_base_dir(&args.rules);
-    let (output, warnings) = match transform_input_with_warnings_with_base_dir_and_options(
-        &rule,
-        InputData::Bytes(&input),
-        context_value.as_ref(),
-        &base_dir,
-        &options,
-    ) {
-        Ok(result) => result,
-        Err(err) => {
-            emit_transform_error(&err, args.error_format);
-            return 3;
-        }
-    };
-
-    let output_text = match serialize_json_output(&output) {
-        Ok(text) => text,
-        Err(()) => return 1,
-    };
-
-    emit_transform_warnings(&warnings, args.error_format);
-
-    if emit_text_output(&output_text, args.output.as_ref()).is_err() {
-        return 1;
-    }
-
-    0
-}
-
-fn run_transform_ndjson(
-    rule: &RuleFile,
-    input: &[u8],
-    context: Option<&serde_json::Value>,
-    output: Option<PathBuf>,
-    error_format: ErrorFormat,
-    rules_path: &PathBuf,
-    options: &NormalizationOptions,
-) -> i32 {
-    let base_dir = rule_base_dir(rules_path);
-    let stream = match transform_stream_input_with_base_dir_and_options(
-        rule,
-        InputData::Bytes(input),
-        context,
-        &base_dir,
-        options,
-    ) {
-        Ok(stream) => stream,
-        Err(err) => {
-            emit_transform_error(&err, error_format);
-            return 3;
-        }
-    };
-
-    let mut writer = match create_output_writer(output.as_ref()) {
-        Ok(writer) => writer,
-        Err(()) => return 1,
-    };
-
-    for item in stream {
-        let item = match item {
-            Ok(item) => item,
-            Err(err) => {
-                emit_transform_error(&err, error_format);
-                return 3;
-            }
-        };
-
-        emit_transform_warnings(&item.warnings, error_format);
-
-        let output = match item.output {
-            Some(output) => output,
-            None => continue,
-        };
-        if write_json_line(&mut writer, &output).is_err() {
-            return 1;
-        }
-    }
-
-    if let Err(err) = writer.flush() {
-        eprintln!("failed to write output: {}", err);
-        return 1;
-    }
 
     0
 }

--- a/crates/rulemorph_cli/src/core_commands/transform.rs
+++ b/crates/rulemorph_cli/src/core_commands/transform.rs
@@ -1,0 +1,185 @@
+use std::io::Write;
+use std::path::PathBuf;
+
+use clap::Args;
+use rulemorph::{
+    InputData, NormalizationOptions, RuleFile,
+    transform_input_with_warnings_with_base_dir_and_options,
+    transform_stream_input_with_base_dir_and_options, validate_rule_file_with_source,
+};
+
+use super::super::emit::{emit_transform_error, emit_transform_warnings, emit_validation_errors};
+use super::super::input::{
+    apply_format_override, load_context, load_input_bytes_with_limit, load_normalization_options,
+    load_rule, rule_base_dir,
+};
+use super::super::output::{
+    create_output_writer, emit_text_output, serialize_json_output, write_json_line,
+};
+use super::super::{ErrorFormat, FormatOverride, LimitsProfileArg, RulesFormatArg};
+
+#[derive(Args)]
+pub(crate) struct TransformArgs {
+    #[arg(short = 'r', long)]
+    rules: PathBuf,
+    #[arg(long)]
+    rules_format: Option<RulesFormatArg>,
+    #[arg(short = 'i', long)]
+    input: PathBuf,
+    #[arg(short = 'f', long)]
+    format: Option<FormatOverride>,
+    #[arg(short = 'c', long)]
+    context: Option<PathBuf>,
+    #[arg(short = 'o', long)]
+    output: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Emit one JSON object per line. This streams output, but input normalization is bounded by the configured limits."
+    )]
+    ndjson: bool,
+    #[arg(short = 'v', long)]
+    validate: bool,
+    #[arg(short = 'e', long, default_value = "text")]
+    error_format: ErrorFormat,
+    #[arg(long = "limit")]
+    limits: Vec<String>,
+    #[arg(long, value_enum)]
+    limits_profile: Option<LimitsProfileArg>,
+    #[arg(long)]
+    limits_file: Option<PathBuf>,
+}
+
+pub(crate) fn run_transform(args: TransformArgs) -> i32 {
+    let (mut rule, yaml) = match load_rule(&args.rules, args.rules_format) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    apply_format_override(&mut rule, args.format);
+
+    if args.validate {
+        if let Err(errors) = validate_rule_file_with_source(&rule, &yaml) {
+            emit_validation_errors(&errors, args.error_format);
+            return 2;
+        }
+    }
+
+    let options = match load_normalization_options(
+        args.limits_profile,
+        args.limits_file.as_ref(),
+        &args.limits,
+    ) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{}", message);
+            return 2;
+        }
+    };
+
+    let input = match load_input_bytes_with_limit(&args.input, options.max_input_bytes) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    let context_value = match load_context(&args.context) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+
+    if args.ndjson {
+        return run_transform_ndjson(
+            &rule,
+            &input,
+            context_value.as_ref(),
+            args.output,
+            args.error_format,
+            &args.rules,
+            &options,
+        );
+    }
+
+    let base_dir = rule_base_dir(&args.rules);
+    let (output, warnings) = match transform_input_with_warnings_with_base_dir_and_options(
+        &rule,
+        InputData::Bytes(&input),
+        context_value.as_ref(),
+        &base_dir,
+        &options,
+    ) {
+        Ok(result) => result,
+        Err(err) => {
+            emit_transform_error(&err, args.error_format);
+            return 3;
+        }
+    };
+
+    let output_text = match serialize_json_output(&output) {
+        Ok(text) => text,
+        Err(()) => return 1,
+    };
+
+    emit_transform_warnings(&warnings, args.error_format);
+
+    if emit_text_output(&output_text, args.output.as_ref()).is_err() {
+        return 1;
+    }
+
+    0
+}
+
+fn run_transform_ndjson(
+    rule: &RuleFile,
+    input: &[u8],
+    context: Option<&serde_json::Value>,
+    output: Option<PathBuf>,
+    error_format: ErrorFormat,
+    rules_path: &PathBuf,
+    options: &NormalizationOptions,
+) -> i32 {
+    let base_dir = rule_base_dir(rules_path);
+    let stream = match transform_stream_input_with_base_dir_and_options(
+        rule,
+        InputData::Bytes(input),
+        context,
+        &base_dir,
+        options,
+    ) {
+        Ok(stream) => stream,
+        Err(err) => {
+            emit_transform_error(&err, error_format);
+            return 3;
+        }
+    };
+
+    let mut writer = match create_output_writer(output.as_ref()) {
+        Ok(writer) => writer,
+        Err(()) => return 1,
+    };
+
+    for item in stream {
+        let item = match item {
+            Ok(item) => item,
+            Err(err) => {
+                emit_transform_error(&err, error_format);
+                return 3;
+            }
+        };
+
+        emit_transform_warnings(&item.warnings, error_format);
+
+        let output = match item.output {
+            Some(output) => output,
+            None => continue,
+        };
+        if write_json_line(&mut writer, &output).is_err() {
+            return 1;
+        }
+    }
+
+    if let Err(err) = writer.flush() {
+        eprintln!("failed to write output: {}", err);
+        return 1;
+    }
+
+    0
+}


### PR DESCRIPTION
## Summary
- Extract CLI transform command args and execution into core_commands/transform.rs.
- Leave core_commands.rs as validate/preflight runner plus transform re-export wiring.
- No CLI behavior, flags, exit codes, output shape, transform semantics, trace schema, public API/export, docs/specs, or server/UI/API-key changes.

## Verification
- cargo fmt
- cargo test -p rulemorph_cli --test cli transform -- --test-threads=1
- cargo test -p rulemorph_cli -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

## Review
- Subagent review PASS: transform command behavior preserved, validate/preflight parent behavior preserved, dependency direction remains core_commands.rs -> core_commands/transform.rs.