### PR TITLE
Refactor endpoint network request send

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec.rs
@@ -1,22 +1,18 @@
 use std::time::Instant;
 
 use anyhow::Result;
-use axum::http::{HeaderMap, HeaderName, HeaderValue};
-use reqwest::Client;
 use rulemorph::{get_path, parse_path};
 use serde_json::Value as JsonValue;
 
-use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
-
 mod body;
 mod internal_auth;
+mod request;
 mod response;
 
 use super::config::RequestContext;
 use super::error::{EndpointError, EndpointErrorKind};
 use super::expr::{build_headers, eval_expr_string};
 use super::network_rule::CompiledNetworkRule;
-use super::ssrf_audit::build_ssrf_audit_log;
 use super::{EndpointEngine, NetworkExecution, empty_object};
 
 impl EndpointEngine {
@@ -155,104 +151,5 @@ impl EndpointEngine {
                 }
             }
         }
-    }
-
-    fn build_resolved_client(&self, target: &ResolvedSsrfTarget) -> Result<Client, EndpointError> {
-        Client::builder()
-            .no_proxy()
-            .redirect(reqwest::redirect::Policy::none())
-            .resolve(&target.host, target.addr)
-            .build()
-            .map_err(|err| EndpointError::network(err.to_string()))
-    }
-
-    pub(super) async fn send_network_request(
-        &self,
-        rule: &CompiledNetworkRule,
-        url: &str,
-        headers: &HeaderMap,
-        body: Option<&JsonValue>,
-        request_context: Option<&RequestContext>,
-    ) -> Result<JsonValue, EndpointError> {
-        if rule.internal_auth && !self.config.allow_internal_auth {
-            return Err(EndpointError::invalid("internal_auth is not allowed"));
-        }
-        let value = tokio::time::timeout(rule.timeout, async {
-            let internal_auth_allowed = rule.internal_auth && self.config.allow_internal_auth;
-            let is_internal = internal_auth_allowed && self.is_internal_target(url);
-            if rule.internal_auth && self.config.allow_internal_auth && !is_internal {
-                return Err(EndpointError::invalid(
-                    "internal_auth requires internal_base",
-                ));
-            }
-            let allow_private_hosts: &[String] = if is_internal {
-                &self.config.ssrf_private_allowlist
-            } else {
-                &[]
-            };
-            if is_internal {
-                self.ensure_internal_auth_path_allowed(url)?;
-            }
-            let target = match resolve_ssrf_target(
-                url,
-                &self.config.ssrf_allowlist,
-                self.config.ssrf_allow_private,
-                allow_private_hosts,
-            )
-            .await
-            {
-                Ok(target) => target,
-                Err(reason) => {
-                    self.log_ssrf_block(rule, url, &reason, request_context);
-                    return Err(EndpointError::invalid(reason));
-                }
-            };
-            let client = self.build_resolved_client(&target)?;
-            let mut req = client.request(rule.request.method.clone(), url);
-            let mut headers = headers.clone();
-            if is_internal {
-                self.apply_internal_auth_headers(&mut headers, request_context)?;
-            }
-            if body.is_some() && !headers.contains_key("content-type") {
-                headers.insert(
-                    HeaderName::from_static("content-type"),
-                    HeaderValue::from_static("application/json"),
-                );
-            }
-            req = req.headers(headers);
-            if let Some(body) = body {
-                req = req.json(body);
-            }
-
-            let response = req
-                .send()
-                .await
-                .map_err(|err| EndpointError::network(err.to_string()))?;
-
-            response::read_network_response(response, self.config.max_response_bytes).await
-        })
-        .await
-        .map_err(|_| EndpointError::timeout())??;
-
-        Ok(value)
-    }
-
-    fn log_ssrf_block(
-        &self,
-        rule: &CompiledNetworkRule,
-        url: &str,
-        reason: &str,
-        request_context: Option<&RequestContext>,
-    ) {
-        let log = build_ssrf_audit_log(rule, url, reason, request_context);
-        tracing::warn!(
-            target: "rulemorph_endpoint::ssrf",
-            tenant_id = log.tenant_id,
-            rule_ref = log.rule_ref,
-            method = %log.method,
-            url = log.url,
-            reason = log.reason,
-            "blocked ssrf request"
-        );
     }
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/request.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_exec/request.rs
@@ -1,0 +1,114 @@
+use anyhow::Result;
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::Client;
+use serde_json::Value as JsonValue;
+
+use crate::ssrf::{ResolvedSsrfTarget, resolve_ssrf_target};
+
+use super::response;
+use crate::endpoint_engine::EndpointEngine;
+use crate::endpoint_engine::config::RequestContext;
+use crate::endpoint_engine::error::EndpointError;
+use crate::endpoint_engine::network_rule::CompiledNetworkRule;
+use crate::endpoint_engine::ssrf_audit::build_ssrf_audit_log;
+
+impl EndpointEngine {
+    fn build_resolved_client(&self, target: &ResolvedSsrfTarget) -> Result<Client, EndpointError> {
+        Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .resolve(&target.host, target.addr)
+            .build()
+            .map_err(|err| EndpointError::network(err.to_string()))
+    }
+
+    pub(in crate::endpoint_engine) async fn send_network_request(
+        &self,
+        rule: &CompiledNetworkRule,
+        url: &str,
+        headers: &HeaderMap,
+        body: Option<&JsonValue>,
+        request_context: Option<&RequestContext>,
+    ) -> Result<JsonValue, EndpointError> {
+        if rule.internal_auth && !self.config.allow_internal_auth {
+            return Err(EndpointError::invalid("internal_auth is not allowed"));
+        }
+        let value = tokio::time::timeout(rule.timeout, async {
+            let internal_auth_allowed = rule.internal_auth && self.config.allow_internal_auth;
+            let is_internal = internal_auth_allowed && self.is_internal_target(url);
+            if rule.internal_auth && self.config.allow_internal_auth && !is_internal {
+                return Err(EndpointError::invalid(
+                    "internal_auth requires internal_base",
+                ));
+            }
+            let allow_private_hosts: &[String] = if is_internal {
+                &self.config.ssrf_private_allowlist
+            } else {
+                &[]
+            };
+            if is_internal {
+                self.ensure_internal_auth_path_allowed(url)?;
+            }
+            let target = match resolve_ssrf_target(
+                url,
+                &self.config.ssrf_allowlist,
+                self.config.ssrf_allow_private,
+                allow_private_hosts,
+            )
+            .await
+            {
+                Ok(target) => target,
+                Err(reason) => {
+                    self.log_ssrf_block(rule, url, &reason, request_context);
+                    return Err(EndpointError::invalid(reason));
+                }
+            };
+            let client = self.build_resolved_client(&target)?;
+            let mut req = client.request(rule.request.method.clone(), url);
+            let mut headers = headers.clone();
+            if is_internal {
+                self.apply_internal_auth_headers(&mut headers, request_context)?;
+            }
+            if body.is_some() && !headers.contains_key("content-type") {
+                headers.insert(
+                    HeaderName::from_static("content-type"),
+                    HeaderValue::from_static("application/json"),
+                );
+            }
+            req = req.headers(headers);
+            if let Some(body) = body {
+                req = req.json(body);
+            }
+
+            let response = req
+                .send()
+                .await
+                .map_err(|err| EndpointError::network(err.to_string()))?;
+
+            response::read_network_response(response, self.config.max_response_bytes).await
+        })
+        .await
+        .map_err(|_| EndpointError::timeout())??;
+
+        Ok(value)
+    }
+
+    fn log_ssrf_block(
+        &self,
+        rule: &CompiledNetworkRule,
+        url: &str,
+        reason: &str,
+        request_context: Option<&RequestContext>,
+    ) {
+        let log = build_ssrf_audit_log(rule, url, reason, request_context);
+        tracing::warn!(
+            target: "rulemorph_endpoint::ssrf",
+            tenant_id = log.tenant_id,
+            rule_ref = log.rule_ref,
+            method = %log.method,
+            url = log.url,
+            reason = log.reason,
+            "blocked ssrf request"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- move endpoint network request send helpers into a focused internal module
- keep execute_network retry/catch/select orchestration in the parent module
- preserve internal auth, SSRF resolution/audit logging, response limits, trace schema, and public contracts

## Tests
- cargo fmt
- cargo check -p rulemorph_endpoint
- cargo test -p rulemorph_endpoint internal_auth -- --test-threads=1
- cargo test -p rulemorph_endpoint network_response -- --test-threads=1
- cargo test -p rulemorph_endpoint network_chunked_response -- --test-threads=1
- cargo test -p rulemorph_endpoint network_timeout_on_slow_body_runs_catch -- --test-threads=1
- cargo test -p rulemorph_endpoint network_select_error_runs_catch -- --test-threads=1
- cargo test -p rulemorph_endpoint network_body_build_error_runs_catch -- --test-threads=1
- cargo test -p rulemorph_endpoint -- --test-threads=1
- cargo test -p rulemorph_endpoint ssrf -- --test-threads=1
- cargo test -p rulemorph_endpoint network_ -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

## Review
- Subagent review: PASS