### PR TITLE
Refactor MCP sandbox read helpers

### DIFF
--- a/crates/rulemorph_mcp/src/sandbox.rs
+++ b/crates/rulemorph_mcp/src/sandbox.rs
@@ -1,71 +1,9 @@
 use std::fs;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use crate::errors::{CallError, io_error_json};
+mod read;
 
-const MCP_MAX_FILE_BYTES: usize = 64 * 1024 * 1024;
-
-pub(crate) fn read_allowed_to_string(path: &str, label: &str) -> Result<String, CallError> {
-    read_allowed_file(path, label).map(|(_, data)| data)
-}
-
-pub(crate) fn read_allowed_bytes(path: &str, label: &str) -> Result<Vec<u8>, CallError> {
-    read_allowed_file_bytes(path, label).map(|(_, data)| data)
-}
-
-pub(crate) fn read_allowed_file(path: &str, label: &str) -> Result<(PathBuf, String), CallError> {
-    let (path, bytes) = read_allowed_file_bytes(path, label)?;
-    let data = String::from_utf8(bytes).map_err(|err| {
-        let message = format!("failed to read {}: {}", label, err);
-        CallError::Tool {
-            message: message.clone(),
-            errors: Some(vec![io_error_json(
-                &message,
-                Some(path.to_string_lossy().as_ref()),
-            )]),
-        }
-    })?;
-    Ok((path, data))
-}
-
-fn read_allowed_file_bytes(path: &str, label: &str) -> Result<(PathBuf, Vec<u8>), CallError> {
-    let path = allowed_existing_path(path).map_err(|err| {
-        let message = format!("failed to read {}: {}", label, err);
-        CallError::Tool {
-            message: message.clone(),
-            errors: Some(vec![io_error_json(&message, Some(path))]),
-        }
-    })?;
-    let data = read_file_with_limit(&path, MCP_MAX_FILE_BYTES).map_err(|err| {
-        let message = format!("failed to read {}: {}", label, err);
-        CallError::Tool {
-            message: message.clone(),
-            errors: Some(vec![io_error_json(
-                &message,
-                Some(path.to_string_lossy().as_ref()),
-            )]),
-        }
-    })?;
-    Ok((path, data))
-}
-
-fn read_file_with_limit(path: &Path, max_bytes: usize) -> Result<Vec<u8>, String> {
-    let metadata = fs::metadata(path).map_err(|err| err.to_string())?;
-    if metadata.len() > max_bytes as u64 {
-        return Err(format!("file exceeds maximum size ({})", max_bytes));
-    }
-    let mut file = fs::File::open(path).map_err(|err| err.to_string())?;
-    let mut bytes = Vec::new();
-    Read::by_ref(&mut file)
-        .take(max_bytes as u64 + 1)
-        .read_to_end(&mut bytes)
-        .map_err(|err| err.to_string())?;
-    if bytes.len() > max_bytes {
-        return Err(format!("file exceeds maximum size ({})", max_bytes));
-    }
-    Ok(bytes)
-}
+pub(crate) use read::{read_allowed_bytes, read_allowed_file, read_allowed_to_string};
 
 pub(crate) fn write_allowed_output(path: &str, output: &str) -> Result<(), String> {
     let path = Path::new(path);
@@ -79,7 +17,7 @@ pub(crate) fn write_allowed_output(path: &str, output: &str) -> Result<(), Strin
     fs::write(path, output.as_bytes()).map_err(|err| format!("failed to write output: {}", err))
 }
 
-fn allowed_existing_path(path: &str) -> Result<PathBuf, String> {
+pub(super) fn allowed_existing_path(path: &str) -> Result<PathBuf, String> {
     let path = Path::new(path);
     let canonical = path
         .canonicalize()

--- a/crates/rulemorph_mcp/src/sandbox/read.rs
+++ b/crates/rulemorph_mcp/src/sandbox/read.rs
@@ -1,0 +1,70 @@
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use crate::errors::{CallError, io_error_json};
+
+use super::allowed_existing_path;
+
+const MCP_MAX_FILE_BYTES: usize = 64 * 1024 * 1024;
+
+pub(crate) fn read_allowed_to_string(path: &str, label: &str) -> Result<String, CallError> {
+    read_allowed_file(path, label).map(|(_, data)| data)
+}
+
+pub(crate) fn read_allowed_bytes(path: &str, label: &str) -> Result<Vec<u8>, CallError> {
+    read_allowed_file_bytes(path, label).map(|(_, data)| data)
+}
+
+pub(crate) fn read_allowed_file(path: &str, label: &str) -> Result<(PathBuf, String), CallError> {
+    let (path, bytes) = read_allowed_file_bytes(path, label)?;
+    let data = String::from_utf8(bytes).map_err(|err| {
+        let message = format!("failed to read {}: {}", label, err);
+        CallError::Tool {
+            message: message.clone(),
+            errors: Some(vec![io_error_json(
+                &message,
+                Some(path.to_string_lossy().as_ref()),
+            )]),
+        }
+    })?;
+    Ok((path, data))
+}
+
+fn read_allowed_file_bytes(path: &str, label: &str) -> Result<(PathBuf, Vec<u8>), CallError> {
+    let path = allowed_existing_path(path).map_err(|err| {
+        let message = format!("failed to read {}: {}", label, err);
+        CallError::Tool {
+            message: message.clone(),
+            errors: Some(vec![io_error_json(&message, Some(path))]),
+        }
+    })?;
+    let data = read_file_with_limit(&path, MCP_MAX_FILE_BYTES).map_err(|err| {
+        let message = format!("failed to read {}: {}", label, err);
+        CallError::Tool {
+            message: message.clone(),
+            errors: Some(vec![io_error_json(
+                &message,
+                Some(path.to_string_lossy().as_ref()),
+            )]),
+        }
+    })?;
+    Ok((path, data))
+}
+
+fn read_file_with_limit(path: &Path, max_bytes: usize) -> Result<Vec<u8>, String> {
+    let metadata = fs::metadata(path).map_err(|err| err.to_string())?;
+    if metadata.len() > max_bytes as u64 {
+        return Err(format!("file exceeds maximum size ({})", max_bytes));
+    }
+    let mut file = fs::File::open(path).map_err(|err| err.to_string())?;
+    let mut bytes = Vec::new();
+    Read::by_ref(&mut file)
+        .take(max_bytes as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|err| err.to_string())?;
+    if bytes.len() > max_bytes {
+        return Err(format!("file exceeds maximum size ({})", max_bytes));
+    }
+    Ok(bytes)
+}


### PR DESCRIPTION
## Summary
- move MCP sandbox read helpers into a focused internal module
- keep allowed-root validation and output path handling in the parent sandbox module
- preserve MCP tool schemas, JSON-RPC behavior, allowed roots, pathless rules_text boundary, and public contracts

## Tests
- cargo fmt
- cargo test -p rulemorph_mcp sandbox -- --test-threads=1
- cargo test -p rulemorph_mcp transform_rejects_paths_outside_allowed_root -- --test-threads=1
- cargo test -p rulemorph_mcp transform_allows_new_output_directory_inside_allowed_root -- --test-threads=1
- cargo test -p rulemorph_mcp transform_rejects_output_path_traversal_outside_allowed_root -- --test-threads=1
- cargo test -p rulemorph_mcp -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

## Review
- Subagent review: PASS