### PR TITLE
Refactor finalize filter and sort

### DIFF
--- a/crates/rulemorph/src/transform/finalize.rs
+++ b/crates/rulemorph/src/transform/finalize.rs
@@ -1,11 +1,14 @@
 use super::*;
 
+mod filter;
 mod pagination;
 mod sort;
 mod wrap;
 
+use filter::{apply_filter, apply_filter_traced};
 use pagination::{apply_limit, apply_limit_traced, apply_offset, apply_offset_traced};
 pub(super) use sort::sort_key_from_value;
+use sort::{apply_sort, apply_sort_traced};
 use wrap::eval_wrap_value;
 
 pub(super) fn apply_finalize(
@@ -25,77 +28,11 @@ pub(super) fn apply_finalize(
     };
 
     if let Some(filter) = &finalize.filter {
-        let raw = expr_to_json_for_v2_condition(filter).ok_or_else(|| {
-            TransformError::new(
-                TransformErrorKind::ExprError,
-                "finalize.filter must be a v2 condition",
-            )
-            .with_path("finalize.filter")
-        })?;
-        let cond = parse_v2_condition(&raw).map_err(|err| {
-            TransformError::new(
-                TransformErrorKind::ExprError,
-                format!("invalid v2 condition: {}", err),
-            )
-            .with_path("finalize.filter")
-        })?;
-        let base_out = JsonValue::Array(records.clone());
-        let mut filtered = Vec::new();
-        for (index, item) in records.iter().enumerate() {
-            let ctx = V2EvalContext::new().with_item(V2EvalItem { value: item, index });
-            let keep = eval_v2_condition(&cond, item, context, &base_out, "finalize.filter", &ctx)?;
-            if keep {
-                filtered.push(item.clone());
-            }
-        }
-        records = filtered;
+        apply_filter(&mut records, filter, context)?;
     }
 
     if let Some(sort) = &finalize.sort {
-        let tokens = parse_path(&sort.by).map_err(|_| {
-            TransformError::new(
-                TransformErrorKind::InvalidRecordsPath,
-                "finalize.sort.by is invalid",
-            )
-            .with_path("finalize.sort.by")
-        })?;
-
-        struct SortItem {
-            key: SortKey,
-            index: usize,
-            value: JsonValue,
-        }
-
-        let mut items = Vec::with_capacity(records.len());
-        for (index, item) in records.iter().enumerate() {
-            let key_value = get_path(item, &tokens).ok_or_else(|| {
-                TransformError::new(
-                    TransformErrorKind::InvalidRef,
-                    "finalize.sort.by path not found",
-                )
-                .with_path("finalize.sort.by")
-            })?;
-            let key = sort_key_from_value(key_value, "finalize.sort.by")?;
-            items.push(SortItem {
-                key,
-                index,
-                value: item.clone(),
-            });
-        }
-
-        items.sort_by(|left, right| {
-            let mut ordering = compare_sort_keys(&left.key, &right.key);
-            if sort.order == "desc" {
-                ordering = ordering.reverse();
-            }
-            if ordering == Ordering::Equal {
-                left.index.cmp(&right.index)
-            } else {
-                ordering
-            }
-        });
-
-        records = items.into_iter().map(|item| item.value).collect();
+        apply_sort(&mut records, sort)?;
     }
 
     if let Some(offset) = finalize.offset {
@@ -133,111 +70,11 @@ pub(super) fn apply_finalize_traced(
     };
 
     if let Some(filter) = &finalize.filter {
-        let raw = expr_to_json_for_v2_condition(filter).ok_or_else(|| {
-            TransformError::new(
-                TransformErrorKind::ExprError,
-                "finalize.filter must be a v2 condition",
-            )
-            .with_path("finalize.filter")
-        })?;
-        let cond = parse_v2_condition(&raw).map_err(|err| {
-            TransformError::new(
-                TransformErrorKind::ExprError,
-                format!("invalid v2 condition: {}", err),
-            )
-            .with_path("finalize.filter")
-        })?;
-        let base_out = JsonValue::Array(records.clone());
-        let before_count = records.len();
-        let mut filtered = Vec::new();
-        for (index, item) in records.iter().enumerate() {
-            let ctx = V2EvalContext::new().with_item(V2EvalItem { value: item, index });
-            let item_path = format!("finalize.filter[{}]", index);
-            let keep = eval_v2_condition_traced(
-                &cond, item, context, &base_out, &item_path, &ctx, collector,
-            )?;
-            collector
-                .emit(TraceEventKind::FinalizeFilter, TracePhase::Instant)
-                .rule_path(&item_path)
-                .input_path(canonical_item_path(""))
-                .attr_index("item_index", index)
-                .attr_bool("kept", keep)
-                .input_value(item, collector.options(), Some("@item"))
-                .finish_with_output(collector, &JsonValue::Bool(keep), None);
-            if keep {
-                filtered.push(item.clone());
-            }
-        }
-        records = filtered;
-        collector
-            .emit(TraceEventKind::FinalizeFilter, TracePhase::Instant)
-            .rule_path("finalize.filter")
-            .attr_count("input_count", before_count)
-            .attr_count("output_count", records.len())
-            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+        apply_filter_traced(&mut records, filter, context, collector)?;
     }
 
     if let Some(sort) = &finalize.sort {
-        let tokens = parse_path(&sort.by).map_err(|_| {
-            TransformError::new(
-                TransformErrorKind::InvalidRecordsPath,
-                "finalize.sort.by is invalid",
-            )
-            .with_path("finalize.sort.by")
-        })?;
-
-        struct SortItem {
-            key: SortKey,
-            index: usize,
-            value: JsonValue,
-        }
-
-        let mut items = Vec::with_capacity(records.len());
-        for (index, item) in records.iter().enumerate() {
-            let key_value = get_path(item, &tokens).ok_or_else(|| {
-                TransformError::new(
-                    TransformErrorKind::InvalidRef,
-                    "finalize.sort.by path not found",
-                )
-                .with_path("finalize.sort.by")
-            })?;
-            let key = sort_key_from_value(key_value, "finalize.sort.by")?;
-            items.push(SortItem {
-                key,
-                index,
-                value: item.clone(),
-            });
-        }
-
-        items.sort_by(|left, right| {
-            let mut ordering = compare_sort_keys(&left.key, &right.key);
-            if sort.order == "desc" {
-                ordering = ordering.reverse();
-            }
-            if ordering == Ordering::Equal {
-                left.index.cmp(&right.index)
-            } else {
-                ordering
-            }
-        });
-
-        for (to_index, item) in items.iter().enumerate() {
-            collector
-                .emit(TraceEventKind::FinalizeSort, TracePhase::Instant)
-                .rule_path(format!("finalize.sort[{}]", item.index))
-                .attr_index("from_index", item.index)
-                .attr_index("to_index", to_index)
-                .attr_enum("order", if sort.order == "desc" { "desc" } else { "asc" })
-                .input_value(&item.value, collector.options(), Some("@item"))
-                .finish_with_output(collector, &sort_key_to_json(&item.key), None);
-        }
-
-        records = items.into_iter().map(|item| item.value).collect();
-        collector
-            .emit(TraceEventKind::FinalizeSort, TracePhase::Instant)
-            .rule_path("finalize.sort")
-            .attr_enum("order", if sort.order == "desc" { "desc" } else { "asc" })
-            .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+        apply_sort_traced(&mut records, sort, collector)?;
     }
 
     if let Some(offset) = finalize.offset {

--- a/crates/rulemorph/src/transform/finalize/filter.rs
+++ b/crates/rulemorph/src/transform/finalize/filter.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+pub(super) fn apply_filter(
+    records: &mut Vec<JsonValue>,
+    filter: &Expr,
+    context: Option<&JsonValue>,
+) -> Result<(), TransformError> {
+    let raw = expr_to_json_for_v2_condition(filter).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "finalize.filter must be a v2 condition",
+        )
+        .with_path("finalize.filter")
+    })?;
+    let cond = parse_v2_condition(&raw).map_err(|err| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            format!("invalid v2 condition: {}", err),
+        )
+        .with_path("finalize.filter")
+    })?;
+    let base_out = JsonValue::Array(records.clone());
+    let mut filtered = Vec::new();
+    for (index, item) in records.iter().enumerate() {
+        let ctx = V2EvalContext::new().with_item(V2EvalItem { value: item, index });
+        let keep = eval_v2_condition(&cond, item, context, &base_out, "finalize.filter", &ctx)?;
+        if keep {
+            filtered.push(item.clone());
+        }
+    }
+    *records = filtered;
+    Ok(())
+}
+
+pub(super) fn apply_filter_traced(
+    records: &mut Vec<JsonValue>,
+    filter: &Expr,
+    context: Option<&JsonValue>,
+    collector: &mut TraceCollector,
+) -> Result<(), TransformError> {
+    let raw = expr_to_json_for_v2_condition(filter).ok_or_else(|| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            "finalize.filter must be a v2 condition",
+        )
+        .with_path("finalize.filter")
+    })?;
+    let cond = parse_v2_condition(&raw).map_err(|err| {
+        TransformError::new(
+            TransformErrorKind::ExprError,
+            format!("invalid v2 condition: {}", err),
+        )
+        .with_path("finalize.filter")
+    })?;
+    let base_out = JsonValue::Array(records.clone());
+    let before_count = records.len();
+    let mut filtered = Vec::new();
+    for (index, item) in records.iter().enumerate() {
+        let ctx = V2EvalContext::new().with_item(V2EvalItem { value: item, index });
+        let item_path = format!("finalize.filter[{}]", index);
+        let keep =
+            eval_v2_condition_traced(&cond, item, context, &base_out, &item_path, &ctx, collector)?;
+        collector
+            .emit(TraceEventKind::FinalizeFilter, TracePhase::Instant)
+            .rule_path(&item_path)
+            .input_path(canonical_item_path(""))
+            .attr_index("item_index", index)
+            .attr_bool("kept", keep)
+            .input_value(item, collector.options(), Some("@item"))
+            .finish_with_output(collector, &JsonValue::Bool(keep), None);
+        if keep {
+            filtered.push(item.clone());
+        }
+    }
+    *records = filtered;
+    collector
+        .emit(TraceEventKind::FinalizeFilter, TracePhase::Instant)
+        .rule_path("finalize.filter")
+        .attr_count("input_count", before_count)
+        .attr_count("output_count", records.len())
+        .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+    Ok(())
+}

--- a/crates/rulemorph/src/transform/finalize/sort.rs
+++ b/crates/rulemorph/src/transform/finalize/sort.rs
@@ -1,4 +1,91 @@
 use super::*;
+use crate::model::FinalizeSort;
+
+struct SortItem {
+    key: SortKey,
+    index: usize,
+    value: JsonValue,
+}
+
+pub(super) fn apply_sort(
+    records: &mut Vec<JsonValue>,
+    sort: &FinalizeSort,
+) -> Result<(), TransformError> {
+    let items = sorted_items(records, sort)?;
+    *records = items.into_iter().map(|item| item.value).collect();
+    Ok(())
+}
+
+pub(super) fn apply_sort_traced(
+    records: &mut Vec<JsonValue>,
+    sort: &FinalizeSort,
+    collector: &mut TraceCollector,
+) -> Result<(), TransformError> {
+    let items = sorted_items(records, sort)?;
+
+    for (to_index, item) in items.iter().enumerate() {
+        collector
+            .emit(TraceEventKind::FinalizeSort, TracePhase::Instant)
+            .rule_path(format!("finalize.sort[{}]", item.index))
+            .attr_index("from_index", item.index)
+            .attr_index("to_index", to_index)
+            .attr_enum("order", if sort.order == "desc" { "desc" } else { "asc" })
+            .input_value(&item.value, collector.options(), Some("@item"))
+            .finish_with_output(collector, &sort_key_to_json(&item.key), None);
+    }
+
+    *records = items.into_iter().map(|item| item.value).collect();
+    collector
+        .emit(TraceEventKind::FinalizeSort, TracePhase::Instant)
+        .rule_path("finalize.sort")
+        .attr_enum("order", if sort.order == "desc" { "desc" } else { "asc" })
+        .finish_with_output(collector, &JsonValue::Array(records.clone()), None);
+    Ok(())
+}
+
+fn sorted_items(
+    records: &[JsonValue],
+    sort: &FinalizeSort,
+) -> Result<Vec<SortItem>, TransformError> {
+    let tokens = parse_path(&sort.by).map_err(|_| {
+        TransformError::new(
+            TransformErrorKind::InvalidRecordsPath,
+            "finalize.sort.by is invalid",
+        )
+        .with_path("finalize.sort.by")
+    })?;
+
+    let mut items = Vec::with_capacity(records.len());
+    for (index, item) in records.iter().enumerate() {
+        let key_value = get_path(item, &tokens).ok_or_else(|| {
+            TransformError::new(
+                TransformErrorKind::InvalidRef,
+                "finalize.sort.by path not found",
+            )
+            .with_path("finalize.sort.by")
+        })?;
+        let key = sort_key_from_value(key_value, "finalize.sort.by")?;
+        items.push(SortItem {
+            key,
+            index,
+            value: item.clone(),
+        });
+    }
+
+    items.sort_by(|left, right| {
+        let mut ordering = compare_sort_keys(&left.key, &right.key);
+        if sort.order == "desc" {
+            ordering = ordering.reverse();
+        }
+        if ordering == Ordering::Equal {
+            left.index.cmp(&right.index)
+        } else {
+            ordering
+        }
+    });
+
+    Ok(items)
+}
 
 pub(in crate::transform) fn sort_key_from_value(
     value: &JsonValue,


### PR DESCRIPTION
## Summary
- Move finalize filter application into a dedicated child module
- Move finalize sort application into the existing finalize sort module
- Keep finalize.rs as array validation plus filter/sort/pagination/wrap orchestration
- No transform semantics, trace JSON schema, public API/export, CLI/MCP/HTTP contract, docs/specs changes

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden finalize -- --test-threads=1
- cargo test -p rulemorph --test preflight finalize -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- cargo test -p rulemorph --test transform_trace -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check
- post-commit: cargo test -p rulemorph --test transform_golden finalize -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD

## Review
- Subagent staged diff review: PASS, no findings