### PR TITLE
Refactor validator op arg counts

### DIFF
--- a/crates/rulemorph/src/validator/expr.rs
+++ b/crates/rulemorph/src/validator/expr.rs
@@ -9,6 +9,7 @@ use super::op_inventory::{element_expr_scope, is_valid_op};
 use super::refs::validate_ref;
 use super::scope::LocalScope;
 
+mod arg_count;
 mod chain;
 mod op_args;
 

--- a/crates/rulemorph/src/validator/expr/arg_count.rs
+++ b/crates/rulemorph/src/validator/expr/arg_count.rs
@@ -1,0 +1,68 @@
+use crate::error::ErrorCode;
+
+use super::super::ValidationCtx;
+
+#[derive(Clone, Copy)]
+pub(super) enum ArgCountRule {
+    ExactlyOne,
+    ExactlyTwo,
+    ExactlyThree,
+    OneOrTwo,
+    TwoOrThree,
+    ThreeOrFour,
+    OneToThree,
+    TwoToFour,
+    AtLeastTwo,
+    AtLeastThree,
+}
+
+pub(super) fn require(
+    actual: usize,
+    rule: ArgCountRule,
+    base_path: &str,
+    ctx: &mut ValidationCtx<'_>,
+) {
+    if !rule.accepts(actual) {
+        push_invalid_args(rule.message(), base_path, ctx);
+    }
+}
+
+impl ArgCountRule {
+    fn accepts(self, actual: usize) -> bool {
+        match self {
+            ArgCountRule::ExactlyOne => actual == 1,
+            ArgCountRule::ExactlyTwo => actual == 2,
+            ArgCountRule::ExactlyThree => actual == 3,
+            ArgCountRule::OneOrTwo => (1..=2).contains(&actual),
+            ArgCountRule::TwoOrThree => (2..=3).contains(&actual),
+            ArgCountRule::ThreeOrFour => (3..=4).contains(&actual),
+            ArgCountRule::OneToThree => (1..=3).contains(&actual),
+            ArgCountRule::TwoToFour => (2..=4).contains(&actual),
+            ArgCountRule::AtLeastTwo => actual >= 2,
+            ArgCountRule::AtLeastThree => actual >= 3,
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            ArgCountRule::ExactlyOne => "expr.args must contain exactly one item",
+            ArgCountRule::ExactlyTwo => "expr.args must contain exactly two items",
+            ArgCountRule::ExactlyThree => "expr.args must contain exactly three items",
+            ArgCountRule::OneOrTwo => "expr.args must contain one or two items",
+            ArgCountRule::TwoOrThree => "expr.args must contain two or three items",
+            ArgCountRule::ThreeOrFour => "expr.args must contain three or four items",
+            ArgCountRule::OneToThree => "expr.args must contain one to three items",
+            ArgCountRule::TwoToFour => "expr.args must contain two to four items",
+            ArgCountRule::AtLeastTwo => "expr.args must contain at least two items",
+            ArgCountRule::AtLeastThree => "expr.args must contain at least three items",
+        }
+    }
+}
+
+fn push_invalid_args(message: &'static str, base_path: &str, ctx: &mut ValidationCtx<'_>) {
+    ctx.push(
+        ErrorCode::InvalidArgs,
+        message,
+        format!("{}.args", base_path),
+    );
+}

--- a/crates/rulemorph/src/validator/expr/chain/op_args.rs
+++ b/crates/rulemorph/src/validator/expr/chain/op_args.rs
@@ -1,10 +1,11 @@
-use crate::error::ErrorCode;
 use crate::model::ExprOp;
 
 use super::super::super::ValidationCtx;
 use super::super::super::expr_args::{
     validate_lookup_args_chain, validate_path_arg, validate_path_array_arg,
 };
+use super::super::arg_count::ArgCountRule::*;
+use super::super::arg_count::require;
 
 pub(super) fn validate_chain_op_args(
     expr_op: &ExprOp,
@@ -14,71 +15,33 @@ pub(super) fn validate_chain_op_args(
     let args_len = expr_op.args.len() + 1;
     match expr_op.op.as_str() {
         "trim" | "lowercase" | "uppercase" | "to_string" | "len" | "not" => {
-            if args_len != 1 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly one item",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyOne, base_path, ctx);
         }
         "replace" => {
-            if !(3..=4).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain three or four items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ThreeOrFour, base_path, ctx);
         }
         "split" => {
-            if args_len != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "pad_start" | "pad_end" => {
-            if !(2..=3).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two or three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoOrThree, base_path, ctx);
         }
         "lookup" | "lookup_first" => {
             validate_lookup_args_chain(expr_op, base_path, ctx);
         }
         "merge" | "deep_merge" => {
-            if args_len < 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastTwo, base_path, ctx);
         }
         "get" => {
             if args_len != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
+                require(args_len, ExactlyTwo, base_path, ctx);
             } else {
                 validate_path_arg(&expr_op.args[0], &format!("{}.args[0]", base_path), ctx);
             }
         }
         "pick" | "omit" => {
             if args_len != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
+                require(args_len, ExactlyTwo, base_path, ctx);
             } else {
                 let allow_terminal_index = expr_op.op == "pick";
                 validate_path_array_arg(
@@ -90,149 +53,53 @@ pub(super) fn validate_chain_op_args(
             }
         }
         "keys" | "values" | "entries" | "object_flatten" | "object_unflatten" => {
-            if args_len != 1 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly one item",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyOne, base_path, ctx);
         }
         "from_entries" => {
-            if !(1..=2).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one or two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneOrTwo, base_path, ctx);
         }
         "map" | "filter" | "flat_map" | "group_by" | "key_by" | "partition" | "distinct_by"
         | "find" | "find_index" => {
-            if args_len != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "flatten" => {
-            if !(1..=2).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one or two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneOrTwo, base_path, ctx);
         }
         "take" | "drop" | "chunk" | "index_of" | "contains" | "reduce" => {
-            if args_len != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "slice" => {
-            if !(2..=3).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two or three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoOrThree, base_path, ctx);
         }
         "zip" => {
-            if args_len < 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastTwo, base_path, ctx);
         }
         "zip_with" => {
-            if args_len < 3 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastThree, base_path, ctx);
         }
         "unzip" | "unique" | "sum" | "avg" | "min" | "max" => {
-            if args_len != 1 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly one item",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyOne, base_path, ctx);
         }
         "sort_by" => {
-            if !(2..=3).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two or three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoOrThree, base_path, ctx);
         }
         "fold" => {
-            if args_len != 3 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyThree, base_path, ctx);
         }
         "+" | "*" | "and" | "or" => {
-            if args_len < 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastTwo, base_path, ctx);
         }
         "-" | "/" | "to_base" | "==" | "!=" | "<" | "<=" | ">" | ">=" | "~=" => {
-            if args_len != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "round" => {
-            if !(1..=2).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one or two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneOrTwo, base_path, ctx);
         }
         "date_format" => {
-            if !(2..=4).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two to four items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoToFour, base_path, ctx);
         }
         "to_unixtime" => {
-            if !(1..=3).contains(&args_len) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one to three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneToThree, base_path, ctx);
         }
         _ => {}
     }

--- a/crates/rulemorph/src/validator/expr/op_args.rs
+++ b/crates/rulemorph/src/validator/expr/op_args.rs
@@ -1,77 +1,41 @@
-use crate::error::ErrorCode;
 use crate::model::ExprOp;
 
 use super::super::ValidationCtx;
 use super::super::expr_args::{validate_lookup_args, validate_path_arg, validate_path_array_arg};
+use super::arg_count::ArgCountRule::*;
+use super::arg_count::require;
 
 pub(super) fn validate_op_args(expr_op: &ExprOp, base_path: &str, ctx: &mut ValidationCtx<'_>) {
+    let args_len = expr_op.args.len();
     match expr_op.op.as_str() {
         "trim" | "lowercase" | "uppercase" | "to_string" | "len" => {
-            if expr_op.args.len() != 1 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly one item",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyOne, base_path, ctx);
         }
         "replace" => {
-            if !(3..=4).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain three or four items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ThreeOrFour, base_path, ctx);
         }
         "split" => {
-            if expr_op.args.len() != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "pad_start" | "pad_end" => {
-            if !(2..=3).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two or three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoOrThree, base_path, ctx);
         }
         "lookup" | "lookup_first" => {
             validate_lookup_args(expr_op, base_path, ctx);
         }
         "merge" | "deep_merge" => {
-            if expr_op.args.len() < 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastTwo, base_path, ctx);
         }
         "get" => {
-            if expr_op.args.len() != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
+            if args_len != 2 {
+                require(args_len, ExactlyTwo, base_path, ctx);
             } else {
                 validate_path_arg(&expr_op.args[1], &format!("{}.args[1]", base_path), ctx);
             }
         }
         "pick" | "omit" => {
-            if expr_op.args.len() != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
+            if args_len != 2 {
+                require(args_len, ExactlyTwo, base_path, ctx);
             } else {
                 let allow_terminal_index = expr_op.op == "pick";
                 validate_path_array_arg(
@@ -83,176 +47,62 @@ pub(super) fn validate_op_args(expr_op: &ExprOp, base_path: &str, ctx: &mut Vali
             }
         }
         "keys" | "values" | "entries" | "object_flatten" | "object_unflatten" => {
-            if expr_op.args.len() != 1 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly one item",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyOne, base_path, ctx);
         }
         "from_entries" => {
-            if !(1..=2).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one or two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneOrTwo, base_path, ctx);
         }
         "map" | "filter" | "flat_map" | "group_by" | "key_by" | "partition" | "distinct_by"
         | "find" | "find_index" => {
-            if expr_op.args.len() != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "flatten" => {
-            if !(1..=2).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one or two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneOrTwo, base_path, ctx);
         }
         "take" | "drop" | "chunk" | "index_of" | "contains" | "reduce" => {
-            if expr_op.args.len() != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "slice" => {
-            if !(2..=3).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two or three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoOrThree, base_path, ctx);
         }
         "zip" => {
-            if expr_op.args.len() < 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastTwo, base_path, ctx);
         }
         "zip_with" => {
-            if expr_op.args.len() < 3 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastThree, base_path, ctx);
         }
         "unzip" | "unique" | "sum" | "avg" | "min" | "max" => {
-            if expr_op.args.len() != 1 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly one item",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyOne, base_path, ctx);
         }
         "sort_by" => {
-            if !(2..=3).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two or three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoOrThree, base_path, ctx);
         }
         "fold" => {
-            if expr_op.args.len() != 3 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyThree, base_path, ctx);
         }
         "+" | "*" => {
-            if expr_op.args.len() < 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastTwo, base_path, ctx);
         }
         "-" | "/" | "to_base" => {
-            if expr_op.args.len() != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         "round" => {
-            if !(1..=2).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one or two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneOrTwo, base_path, ctx);
         }
         "date_format" => {
-            if !(2..=4).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain two to four items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, TwoToFour, base_path, ctx);
         }
         "to_unixtime" => {
-            if !(1..=3).contains(&expr_op.args.len()) {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain one to three items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, OneToThree, base_path, ctx);
         }
         "and" | "or" => {
-            if expr_op.args.len() < 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain at least two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, AtLeastTwo, base_path, ctx);
         }
         "not" => {
-            if expr_op.args.len() != 1 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly one item",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyOne, base_path, ctx);
         }
         "==" | "!=" | "<" | "<=" | ">" | ">=" | "~=" => {
-            if expr_op.args.len() != 2 {
-                ctx.push(
-                    ErrorCode::InvalidArgs,
-                    "expr.args must contain exactly two items",
-                    format!("{}.args", base_path),
-                );
-            }
+            require(args_len, ExactlyTwo, base_path, ctx);
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary
- add a private validator arg-count helper for repeated operator arity checks
- use the shared helper from direct and chain operator arg validators
- keep operator groups, error messages/paths/codes, chain injected arg counting, lookup/path validation, public API, transform semantics, trace schema, and docs/specs unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --test validation -- --test-threads=1
- cargo test -p rulemorph --test transform_golden t14_expr_chain -- --test-threads=1
- cargo test -p rulemorph --test transform_golden t26_chain_all_ops -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check
- post-commit: cargo test -p rulemorph --test validation -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD

## Review
- Hegel subagent staged-diff review: PASS, no findings