### PR TITLE
Refactor endpoint rule path matcher

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/endpoint_rule.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/endpoint_rule.rs
@@ -10,6 +10,10 @@ use serde_json::Value as JsonValue;
 
 use super::catch::CatchSpec;
 
+mod path;
+
+pub(super) use path::EndpointPath;
+
 #[derive(Debug)]
 pub(super) struct CompiledEndpointRule {
     pub(super) base_dir: PathBuf,
@@ -138,74 +142,6 @@ impl CompiledReply {
             headers,
             body,
         })
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct EndpointPath {
-    pub(super) segments: Vec<PathSegment>,
-}
-
-#[derive(Debug)]
-pub(super) enum PathSegment {
-    Literal(String),
-    Param(String),
-}
-
-impl EndpointPath {
-    pub(super) fn parse(path: &str) -> Result<Self> {
-        if !path.starts_with('/') {
-            return Err(anyhow!("endpoint path must start with /"));
-        }
-        let segments = path
-            .trim_start_matches('/')
-            .split('/')
-            .filter(|seg| !seg.is_empty())
-            .map(|seg| {
-                if let Some(param) = seg.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
-                    if param.is_empty() {
-                        return Err(anyhow!("empty path param"));
-                    }
-                    Ok(PathSegment::Param(param.to_string()))
-                } else {
-                    Ok(PathSegment::Literal(seg.to_string()))
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-        Ok(Self { segments })
-    }
-
-    pub(super) fn matches(&self, path: &str) -> bool {
-        let parts: Vec<&str> = path
-            .trim_start_matches('/')
-            .split('/')
-            .filter(|seg| !seg.is_empty())
-            .collect();
-        if parts.len() != self.segments.len() {
-            return false;
-        }
-        for (seg, part) in self.segments.iter().zip(parts.iter()) {
-            match seg {
-                PathSegment::Literal(lit) if lit != part => return false,
-                _ => {}
-            }
-        }
-        true
-    }
-
-    pub(super) fn capture(&self, path: &str) -> HashMap<String, String> {
-        let parts: Vec<&str> = path
-            .trim_start_matches('/')
-            .split('/')
-            .filter(|seg| !seg.is_empty())
-            .collect();
-        let mut params = HashMap::new();
-        for (seg, part) in self.segments.iter().zip(parts.iter()) {
-            if let PathSegment::Param(name) = seg {
-                params.insert(name.clone(), (*part).to_string());
-            }
-        }
-        params
     }
 }
 

--- a/crates/rulemorph_endpoint/src/endpoint_engine/endpoint_rule/path.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/endpoint_rule/path.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use anyhow::{Result, anyhow};
+
+#[derive(Debug)]
+pub(in crate::endpoint_engine) struct EndpointPath {
+    segments: Vec<PathSegment>,
+}
+
+#[derive(Debug)]
+pub(super) enum PathSegment {
+    Literal(String),
+    Param(String),
+}
+
+impl EndpointPath {
+    pub(in crate::endpoint_engine) fn parse(path: &str) -> Result<Self> {
+        if !path.starts_with('/') {
+            return Err(anyhow!("endpoint path must start with /"));
+        }
+        let segments = path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|seg| !seg.is_empty())
+            .map(|seg| {
+                if let Some(param) = seg.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
+                    if param.is_empty() {
+                        return Err(anyhow!("empty path param"));
+                    }
+                    Ok(PathSegment::Param(param.to_string()))
+                } else {
+                    Ok(PathSegment::Literal(seg.to_string()))
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self { segments })
+    }
+
+    pub(in crate::endpoint_engine) fn matches(&self, path: &str) -> bool {
+        let parts: Vec<&str> = path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|seg| !seg.is_empty())
+            .collect();
+        if parts.len() != self.segments.len() {
+            return false;
+        }
+        for (seg, part) in self.segments.iter().zip(parts.iter()) {
+            match seg {
+                PathSegment::Literal(lit) if lit != part => return false,
+                _ => {}
+            }
+        }
+        true
+    }
+
+    pub(in crate::endpoint_engine) fn capture(&self, path: &str) -> HashMap<String, String> {
+        let parts: Vec<&str> = path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|seg| !seg.is_empty())
+            .collect();
+        let mut params = HashMap::new();
+        for (seg, part) in self.segments.iter().zip(parts.iter()) {
+            if let PathSegment::Param(name) = seg {
+                params.insert(name.clone(), (*part).to_string());
+            }
+        }
+        params
+    }
+}


### PR DESCRIPTION
## Summary
- Move endpoint path parsing/matching/capture helpers into endpoint_rule/path.rs
- Keep endpoint rule compilation, routing order, request params, and DTO structs unchanged
- Preserve HTTP endpoint contract, trace schema, public exports, and docs/specs

## Tests
- cargo fmt
- cargo test -p rulemorph_endpoint endpoint_path -- --test-threads=1
- cargo test -p rulemorph_endpoint endpoint -- --test-threads=1
- cargo test -p rulemorph_endpoint -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check
- post-rebase: cargo test -p rulemorph_endpoint endpoint_path -- --test-threads=1
- post-rebase: git diff --check origin/v0.3.1...HEAD

## Review
- Subagent staged diff review: PASS, no findings