### PR TITLE
Refactor input excel model types

### DIFF
--- a/crates/rulemorph/src/model/input.rs
+++ b/crates/rulemorph/src/model/input.rs
@@ -2,6 +2,13 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
+mod excel;
+
+pub use excel::{
+    ExcelCellErrorPolicy, ExcelColumn, ExcelDatePolicy, ExcelEmptyCellPolicy, ExcelFormulaPolicy,
+    ExcelInput, ExcelSheetRef,
+};
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct InputSpec {
@@ -162,91 +169,4 @@ pub enum HtmlValueKind {
     Text,
     Html,
     Attr,
-}
-
-fn default_header_row() -> usize {
-    1
-}
-
-fn default_excel_empty_cell() -> ExcelEmptyCellPolicy {
-    ExcelEmptyCellPolicy::Missing
-}
-
-fn default_excel_formula() -> ExcelFormulaPolicy {
-    ExcelFormulaPolicy::Cached
-}
-
-fn default_excel_date() -> ExcelDatePolicy {
-    ExcelDatePolicy::Iso8601
-}
-
-fn default_excel_cell_error() -> ExcelCellErrorPolicy {
-    ExcelCellErrorPolicy::Error
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct ExcelInput {
-    #[serde(default)]
-    pub sheet: Option<ExcelSheetRef>,
-    #[serde(default = "default_true")]
-    pub has_header: bool,
-    #[serde(default = "default_header_row")]
-    pub header_row: usize,
-    #[serde(default)]
-    pub data_start_row: Option<usize>,
-    #[serde(default)]
-    pub range: Option<String>,
-    #[serde(default)]
-    pub columns: Option<Vec<ExcelColumn>>,
-    #[serde(default = "default_excel_empty_cell")]
-    pub empty_cell: ExcelEmptyCellPolicy,
-    #[serde(default = "default_excel_formula")]
-    pub formula: ExcelFormulaPolicy,
-    #[serde(default = "default_excel_date")]
-    pub date: ExcelDatePolicy,
-    #[serde(default = "default_excel_cell_error")]
-    pub cell_error: ExcelCellErrorPolicy,
-}
-
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum ExcelSheetRef {
-    Name(String),
-    Index(usize),
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct ExcelColumn {
-    pub name: String,
-    pub column: String,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ExcelEmptyCellPolicy {
-    Missing,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ExcelFormulaPolicy {
-    Cached,
-    Formula,
-    Error,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ExcelDatePolicy {
-    Iso8601,
-    Serial,
-    String,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ExcelCellErrorPolicy {
-    Error,
 }

--- a/crates/rulemorph/src/model/input/excel.rs
+++ b/crates/rulemorph/src/model/input/excel.rs
@@ -1,0 +1,92 @@
+use serde::Deserialize;
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_header_row() -> usize {
+    1
+}
+
+fn default_excel_empty_cell() -> ExcelEmptyCellPolicy {
+    ExcelEmptyCellPolicy::Missing
+}
+
+fn default_excel_formula() -> ExcelFormulaPolicy {
+    ExcelFormulaPolicy::Cached
+}
+
+fn default_excel_date() -> ExcelDatePolicy {
+    ExcelDatePolicy::Iso8601
+}
+
+fn default_excel_cell_error() -> ExcelCellErrorPolicy {
+    ExcelCellErrorPolicy::Error
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ExcelInput {
+    #[serde(default)]
+    pub sheet: Option<ExcelSheetRef>,
+    #[serde(default = "default_true")]
+    pub has_header: bool,
+    #[serde(default = "default_header_row")]
+    pub header_row: usize,
+    #[serde(default)]
+    pub data_start_row: Option<usize>,
+    #[serde(default)]
+    pub range: Option<String>,
+    #[serde(default)]
+    pub columns: Option<Vec<ExcelColumn>>,
+    #[serde(default = "default_excel_empty_cell")]
+    pub empty_cell: ExcelEmptyCellPolicy,
+    #[serde(default = "default_excel_formula")]
+    pub formula: ExcelFormulaPolicy,
+    #[serde(default = "default_excel_date")]
+    pub date: ExcelDatePolicy,
+    #[serde(default = "default_excel_cell_error")]
+    pub cell_error: ExcelCellErrorPolicy,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ExcelSheetRef {
+    Name(String),
+    Index(usize),
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ExcelColumn {
+    pub name: String,
+    pub column: String,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExcelEmptyCellPolicy {
+    Missing,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExcelFormulaPolicy {
+    Cached,
+    Formula,
+    Error,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExcelDatePolicy {
+    Iso8601,
+    Serial,
+    String,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExcelCellErrorPolicy {
+    Error,
+}


### PR DESCRIPTION
## Summary
- Move Excel input model types and serde default helpers into model/input/excel.rs
- Keep input.rs as the facade for InputSpec and input model re-exports
- Preserve Excel schema serde behavior, public re-exports, normalization/validation behavior, and contracts

## Tests
- cargo fmt
- cargo test -p rulemorph --test rule_schema_golden -- --test-threads=1
- cargo test -p rulemorph --test transform_golden excel -- --test-threads=1
- cargo test -p rulemorph --test validation excel -- --test-threads=1
- cargo test -p rulemorph --lib -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check
- post-rebase: cargo test -p rulemorph --test rule_schema_golden -- --test-threads=1
- post-rebase: cargo test -p rulemorph --test transform_golden t01_csv_basic -- --test-threads=1
- post-rebase: git diff --check origin/v0.3.1...HEAD

## Review
- Subagent staged diff review: PASS, no findings