### PR TITLE
Refactor trace collector span stack

### DIFF
--- a/crates/rulemorph/src/trace/collector.rs
+++ b/crates/rulemorph/src/trace/collector.rs
@@ -7,6 +7,11 @@ use super::schema::{
 };
 use super::snapshot::value_size_bytes;
 
+mod span;
+
+pub(super) use span::SpanAction;
+use span::SpanStack;
+
 pub(crate) struct TraceCollector {
     options: TransformTraceOptions,
     next_id: u64,
@@ -16,17 +21,11 @@ pub(crate) struct TraceCollector {
     emitted_bytes: usize,
     frozen: bool,
     structural_truncated: bool,
-    span_stack: Vec<u64>,
+    span_stack: SpanStack,
     records: Vec<RecordTrace>,
     current_record: Option<RecordTrace>,
     finalize_events: Vec<TraceEvent>,
     scope: TraceScope,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum SpanAction {
-    Push(u64),
-    Pop(Option<u64>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,7 +45,7 @@ impl TraceCollector {
             emitted_bytes: 0,
             frozen: false,
             structural_truncated: false,
-            span_stack: Vec::new(),
+            span_stack: SpanStack::new(),
             records: Vec::new(),
             current_record: None,
             finalize_events: Vec::new(),
@@ -94,7 +93,7 @@ impl TraceCollector {
     pub(crate) fn emit(&mut self, kind: TraceEventKind, phase: TracePhase) -> TraceEventBuilder {
         let id = self.next_id;
         self.next_id += 1;
-        TraceEventBuilder::new(id, self.span_stack.last().copied(), kind, phase)
+        TraceEventBuilder::new(id, self.span_stack.current_parent(), kind, phase)
     }
 
     pub(crate) fn start_span(
@@ -104,7 +103,7 @@ impl TraceCollector {
     ) -> TraceEventBuilder {
         let id = self.next_id;
         self.next_id += 1;
-        let parent_id = self.span_stack.last().copied();
+        let parent_id = self.span_stack.current_parent();
         TraceEventBuilder::new(id, parent_id, kind, phase).span_action(SpanAction::Push(id))
     }
 
@@ -113,7 +112,7 @@ impl TraceCollector {
         kind: TraceEventKind,
         phase: TracePhase,
     ) -> TraceEventBuilder {
-        let span_id = self.span_stack.last().copied();
+        let span_id = self.span_stack.current_parent();
         let id = self.next_id;
         self.next_id += 1;
         TraceEventBuilder::new(id, span_id, kind, phase).span_action(SpanAction::Pop(span_id))
@@ -125,7 +124,7 @@ impl TraceCollector {
         code: &'static str,
         message: &'static str,
     ) -> TraceEventBuilder {
-        let span_id = self.span_stack.last().copied();
+        let span_id = self.span_stack.current_parent();
         let id = self.next_id;
         self.next_id += 1;
         TraceEventBuilder::new(id, span_id, kind, TracePhase::Error)
@@ -204,15 +203,7 @@ impl TraceCollector {
     }
 
     pub(super) fn apply_span_action(&mut self, action: Option<SpanAction>) {
-        match action {
-            Some(SpanAction::Push(id)) => self.span_stack.push(id),
-            Some(SpanAction::Pop(Some(expected))) => {
-                if self.span_stack.last().copied() == Some(expected) {
-                    self.span_stack.pop();
-                }
-            }
-            Some(SpanAction::Pop(None)) | None => {}
-        }
+        self.span_stack.apply(action);
     }
 
     fn emitted_events(&self) -> usize {

--- a/crates/rulemorph/src/trace/collector/span.rs
+++ b/crates/rulemorph/src/trace/collector/span.rs
@@ -1,0 +1,36 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::trace) enum SpanAction {
+    Push(u64),
+    Pop(Option<u64>),
+}
+
+#[derive(Debug, Default)]
+pub(super) struct SpanStack {
+    ids: Vec<u64>,
+}
+
+impl SpanStack {
+    pub(super) fn new() -> Self {
+        Self { ids: Vec::new() }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    pub(super) fn current_parent(&self) -> Option<u64> {
+        self.ids.last().copied()
+    }
+
+    pub(super) fn apply(&mut self, action: Option<SpanAction>) {
+        match action {
+            Some(SpanAction::Push(id)) => self.ids.push(id),
+            Some(SpanAction::Pop(Some(expected))) => {
+                if self.ids.last().copied() == Some(expected) {
+                    self.ids.pop();
+                }
+            }
+            Some(SpanAction::Pop(None)) | None => {}
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move trace collector span action and stack handling into trace/collector/span.rs
- Keep collector lifecycle, scope, truncation, raw-value accounting, and record/finalize storage unchanged
- Preserve parent_id behavior, open-span closure, trace schema, public exports, and contracts

## Tests
- cargo fmt
- cargo test -p rulemorph --lib trace::collector::tests::span_stack -- --test-threads=1
- cargo test -p rulemorph --test transform_trace -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check
- post-commit: cargo test -p rulemorph --lib trace::collector::tests::span_stack -- --test-threads=1
- post-commit: git diff --check origin/v0.3.1...HEAD

## Review
- Subagent staged diff review: PASS, no findings