### PR TITLE
Refactor transform value cast

### DIFF
--- a/crates/rulemorph/src/transform/operators/value.rs
+++ b/crates/rulemorph/src/transform/operators/value.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+mod cast;
+
+pub(in crate::transform) use self::cast::cast_value;
+
 pub(in crate::transform) fn value_to_string(
     value: &JsonValue,
     path: &str,
@@ -163,87 +167,4 @@ fn number_to_string(number: &serde_json::Number) -> String {
         return s;
     }
     number.to_string()
-}
-
-pub(in crate::transform) fn cast_value(
-    value: &JsonValue,
-    type_name: &str,
-    path: &str,
-) -> Result<JsonValue, TransformError> {
-    match type_name {
-        "string" => Ok(JsonValue::String(value_to_string(value, path)?)),
-        "int" => cast_to_int(value, path),
-        "float" => cast_to_float(value, path),
-        "bool" => cast_to_bool(value, path),
-        _ => Err(TransformError::new(
-            TransformErrorKind::TypeCastFailed,
-            "type must be string|int|float|bool",
-        )
-        .with_path(path)),
-    }
-}
-
-fn cast_to_int(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
-    match value {
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Ok(JsonValue::Number(i.into()))
-            } else if let Some(f) = n.as_f64() {
-                if (f.fract()).abs() < f64::EPSILON {
-                    Ok(JsonValue::Number((f as i64).into()))
-                } else {
-                    Err(type_cast_error("int", path))
-                }
-            } else {
-                Err(type_cast_error("int", path))
-            }
-        }
-        JsonValue::String(s) => s
-            .parse::<i64>()
-            .map(|i| JsonValue::Number(i.into()))
-            .map_err(|_| type_cast_error("int", path)),
-        _ => Err(type_cast_error("int", path)),
-    }
-}
-
-fn cast_to_float(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
-    match value {
-        JsonValue::Number(n) => n
-            .as_f64()
-            .ok_or_else(|| type_cast_error("float", path))
-            .and_then(|f| {
-                serde_json::Number::from_f64(f)
-                    .map(JsonValue::Number)
-                    .ok_or_else(|| type_cast_error("float", path))
-            }),
-        JsonValue::String(s) => s
-            .parse::<f64>()
-            .map_err(|_| type_cast_error("float", path))
-            .and_then(|f| {
-                serde_json::Number::from_f64(f)
-                    .map(JsonValue::Number)
-                    .ok_or_else(|| type_cast_error("float", path))
-            }),
-        _ => Err(type_cast_error("float", path)),
-    }
-}
-
-fn cast_to_bool(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
-    match value {
-        JsonValue::Bool(b) => Ok(JsonValue::Bool(*b)),
-        JsonValue::String(s) => match s.to_lowercase().as_str() {
-            "true" => Ok(JsonValue::Bool(true)),
-            "false" => Ok(JsonValue::Bool(false)),
-            _ => Err(type_cast_error("bool", path)),
-        },
-        _ => Err(type_cast_error("bool", path)),
-    }
-}
-
-fn type_cast_error(type_name: &str, path: &str) -> TransformError {
-    TransformError::new(
-        TransformErrorKind::TypeCastFailed,
-        format!("failed to cast to {}", type_name),
-    )
-    .with_path(path)
 }

--- a/crates/rulemorph/src/transform/operators/value/cast.rs
+++ b/crates/rulemorph/src/transform/operators/value/cast.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+pub(in crate::transform) fn cast_value(
+    value: &JsonValue,
+    type_name: &str,
+    path: &str,
+) -> Result<JsonValue, TransformError> {
+    match type_name {
+        "string" => Ok(JsonValue::String(value_to_string(value, path)?)),
+        "int" => cast_to_int(value, path),
+        "float" => cast_to_float(value, path),
+        "bool" => cast_to_bool(value, path),
+        _ => Err(TransformError::new(
+            TransformErrorKind::TypeCastFailed,
+            "type must be string|int|float|bool",
+        )
+        .with_path(path)),
+    }
+}
+
+fn cast_to_int(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
+    match value {
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(JsonValue::Number(i.into()))
+            } else if let Some(f) = n.as_f64() {
+                if (f.fract()).abs() < f64::EPSILON {
+                    Ok(JsonValue::Number((f as i64).into()))
+                } else {
+                    Err(type_cast_error("int", path))
+                }
+            } else {
+                Err(type_cast_error("int", path))
+            }
+        }
+        JsonValue::String(s) => s
+            .parse::<i64>()
+            .map(|i| JsonValue::Number(i.into()))
+            .map_err(|_| type_cast_error("int", path)),
+        _ => Err(type_cast_error("int", path)),
+    }
+}
+
+fn cast_to_float(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
+    match value {
+        JsonValue::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| type_cast_error("float", path))
+            .and_then(|f| {
+                serde_json::Number::from_f64(f)
+                    .map(JsonValue::Number)
+                    .ok_or_else(|| type_cast_error("float", path))
+            }),
+        JsonValue::String(s) => s
+            .parse::<f64>()
+            .map_err(|_| type_cast_error("float", path))
+            .and_then(|f| {
+                serde_json::Number::from_f64(f)
+                    .map(JsonValue::Number)
+                    .ok_or_else(|| type_cast_error("float", path))
+            }),
+        _ => Err(type_cast_error("float", path)),
+    }
+}
+
+fn cast_to_bool(value: &JsonValue, path: &str) -> Result<JsonValue, TransformError> {
+    match value {
+        JsonValue::Bool(b) => Ok(JsonValue::Bool(*b)),
+        JsonValue::String(s) => match s.to_lowercase().as_str() {
+            "true" => Ok(JsonValue::Bool(true)),
+            "false" => Ok(JsonValue::Bool(false)),
+            _ => Err(type_cast_error("bool", path)),
+        },
+        _ => Err(type_cast_error("bool", path)),
+    }
+}
+
+fn type_cast_error(type_name: &str, path: &str) -> TransformError {
+    TransformError::new(
+        TransformErrorKind::TypeCastFailed,
+        format!("failed to cast to {}", type_name),
+    )
+    .with_path(path)
+}


### PR DESCRIPTION
## Summary
- move v1 transform value cast helpers into transform/operators/value/cast.rs
- keep value.rs as the common value coercion facade with the same internal cast_value re-export
- preserve cast errors, conversion behavior, trace schema, and public/internal contracts

## Tests
- cargo fmt
- cargo test -p rulemorph --test transform_golden t13_expr_extended -- --test-threads=1
- cargo test -p rulemorph --test transform_golden t26_chain_all_ops -- --test-threads=1
- cargo test -p rulemorph --test validation -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics trace_v2_operator_fixture_table_covers_valid_inventory_representatives -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD