### PR TITLE
Refactor CLI API key output

### DIFF
--- a/crates/rulemorph_cli/src/api_keys.rs
+++ b/crates/rulemorph_cli/src/api_keys.rs
@@ -1,7 +1,11 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
-use rulemorph_server::{ApiKeyInfo, ApiKeyIssueResult, ApiKeyStore, ServerConfig, TenantLayout};
+use rulemorph_server::{ApiKeyStore, ServerConfig, TenantLayout};
+
+mod output;
+
+use self::output::{emit_api_key_issue, emit_api_key_list};
 
 #[derive(Args)]
 pub(super) struct ApiKeysArgs {
@@ -194,47 +198,4 @@ fn resolve_tenant_layout(
 ) -> Result<TenantLayout, String> {
     let base_dir = data_dir.unwrap_or_else(ServerConfig::default_data_dir);
     TenantLayout::new(base_dir, tenant_id).map_err(|err| err.to_string())
-}
-
-fn emit_api_key_issue(issued: &ApiKeyIssueResult, json: bool) {
-    if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(issued).unwrap_or_default()
-        );
-        return;
-    }
-    println!("id: {}", issued.id);
-    println!("prefix: {}", issued.prefix);
-    println!("key: {}", issued.key);
-    if let Some(label) = issued.label.as_ref() {
-        println!("label: {}", label);
-    }
-    println!("created_at: {}", issued.created_at);
-}
-
-fn emit_api_key_list(keys: &[ApiKeyInfo], json: bool) {
-    if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(keys).unwrap_or_else(|_| "[]".to_string())
-        );
-        return;
-    }
-    if keys.is_empty() {
-        println!("no api keys");
-        return;
-    }
-    for key in keys {
-        println!("id: {}", key.id);
-        println!("prefix: {}", key.prefix);
-        println!("created_at: {}", key.created_at);
-        if let Some(revoked) = key.revoked_at.as_ref() {
-            println!("revoked_at: {}", revoked);
-        }
-        if let Some(label) = key.label.as_ref() {
-            println!("label: {}", label);
-        }
-        println!("---");
-    }
 }

--- a/crates/rulemorph_cli/src/api_keys/output.rs
+++ b/crates/rulemorph_cli/src/api_keys/output.rs
@@ -1,0 +1,44 @@
+use rulemorph_server::{ApiKeyInfo, ApiKeyIssueResult};
+
+pub(super) fn emit_api_key_issue(issued: &ApiKeyIssueResult, json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(issued).unwrap_or_default()
+        );
+        return;
+    }
+    println!("id: {}", issued.id);
+    println!("prefix: {}", issued.prefix);
+    println!("key: {}", issued.key);
+    if let Some(label) = issued.label.as_ref() {
+        println!("label: {}", label);
+    }
+    println!("created_at: {}", issued.created_at);
+}
+
+pub(super) fn emit_api_key_list(keys: &[ApiKeyInfo], json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(keys).unwrap_or_else(|_| "[]".to_string())
+        );
+        return;
+    }
+    if keys.is_empty() {
+        println!("no api keys");
+        return;
+    }
+    for key in keys {
+        println!("id: {}", key.id);
+        println!("prefix: {}", key.prefix);
+        println!("created_at: {}", key.created_at);
+        if let Some(revoked) = key.revoked_at.as_ref() {
+            println!("revoked_at: {}", revoked);
+        }
+        if let Some(label) = key.label.as_ref() {
+            println!("label: {}", label);
+        }
+        println!("---");
+    }
+}


### PR DESCRIPTION
## Summary
- move CLI api-keys output formatting helpers into a private child module
- keep command handling, store operations, JSON/text output shape, and exit codes unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph_cli --test cli api_keys --features server -- --test-threads=1
- cargo test -p rulemorph_cli --features server api_keys -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD