### PR TITLE
Refactor transform golden input tests

### DIFF
--- a/crates/rulemorph/tests/transform_golden.rs
+++ b/crates/rulemorph/tests/transform_golden.rs
@@ -27,77 +27,9 @@ fn t02_csv_no_header() {
 
 include!("transform_golden/input_limits.rs");
 
-#[test]
-fn t30_json_rule_file_transform_golden() {
-    let base = fixtures_dir().join("t30_json_rule_file");
-    let rule = load_rule_with_format(&base.join("rules.json"), RuleFormat::Json);
-    let input = fs::read_to_string(base.join("input.json")).expect("read input.json");
-    let expected = load_json(&base.join("expected.json"));
-    let output = transform(&rule, &input, None).expect("transform failed");
-    assert_eq!(output, expected);
-}
-
-#[test]
-fn t31_yaml_input_transform_golden() {
-    assert_text_fixture("t31_yaml_input", "input.yaml");
-}
-
-#[test]
-fn t32_toml_input_transform_golden() {
-    assert_text_fixture("t32_toml_input", "input.toml");
-}
-
-#[test]
-fn t33_xml_input_transform_golden() {
-    assert_text_fixture("t33_xml_input", "input.xml");
-}
+include!("transform_golden/input_formats.rs");
 
 include!("transform_golden/excel.rs");
-
-#[test]
-fn t35_html_input_transform_golden() {
-    assert_text_fixture("t35_html_input", "input.html");
-}
-
-#[test]
-fn t36_spreadsheets_plugin_products() {
-    assert_xlsx_fixture("t36_spreadsheets_plugin_products");
-}
-
-#[test]
-fn t37_spreadsheets_plugin_orders() {
-    assert_xlsx_fixture("t37_spreadsheets_plugin_orders");
-}
-
-#[test]
-fn t38_spreadsheets_plugin_survey() {
-    assert_xlsx_fixture("t38_spreadsheets_plugin_survey");
-}
-
-#[test]
-fn t39_pyproject_dependency_inventory() {
-    assert_text_fixture("t39_pyproject_dependency_inventory", "input.toml");
-}
-
-#[test]
-fn t40_cargo_dependency_feature_inventory() {
-    assert_text_fixture("t40_cargo_dependency_feature_inventory", "input.toml");
-}
-
-#[test]
-fn t41_github_actions_matrix() {
-    assert_text_fixture("t41_github_actions_matrix", "input.yaml");
-}
-
-#[test]
-fn t42_openapi_endpoint_catalog() {
-    assert_text_fixture("t42_openapi_endpoint_catalog", "input.yaml");
-}
-
-#[test]
-fn t43_mongodb_schema_summary() {
-    assert_text_fixture("t43_mongodb_schema_summary", "input.json");
-}
 
 include!("transform_golden/xml.rs");
 include!("transform_golden/html.rs");

--- a/crates/rulemorph/tests/transform_golden/input_formats.rs
+++ b/crates/rulemorph/tests/transform_golden/input_formats.rs
@@ -1,0 +1,69 @@
+#[test]
+fn t30_json_rule_file_transform_golden() {
+    let base = fixtures_dir().join("t30_json_rule_file");
+    let rule = load_rule_with_format(&base.join("rules.json"), RuleFormat::Json);
+    let input = fs::read_to_string(base.join("input.json")).expect("read input.json");
+    let expected = load_json(&base.join("expected.json"));
+    let output = transform(&rule, &input, None).expect("transform failed");
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn t31_yaml_input_transform_golden() {
+    assert_text_fixture("t31_yaml_input", "input.yaml");
+}
+
+#[test]
+fn t32_toml_input_transform_golden() {
+    assert_text_fixture("t32_toml_input", "input.toml");
+}
+
+#[test]
+fn t33_xml_input_transform_golden() {
+    assert_text_fixture("t33_xml_input", "input.xml");
+}
+
+#[test]
+fn t35_html_input_transform_golden() {
+    assert_text_fixture("t35_html_input", "input.html");
+}
+
+#[test]
+fn t36_spreadsheets_plugin_products() {
+    assert_xlsx_fixture("t36_spreadsheets_plugin_products");
+}
+
+#[test]
+fn t37_spreadsheets_plugin_orders() {
+    assert_xlsx_fixture("t37_spreadsheets_plugin_orders");
+}
+
+#[test]
+fn t38_spreadsheets_plugin_survey() {
+    assert_xlsx_fixture("t38_spreadsheets_plugin_survey");
+}
+
+#[test]
+fn t39_pyproject_dependency_inventory() {
+    assert_text_fixture("t39_pyproject_dependency_inventory", "input.toml");
+}
+
+#[test]
+fn t40_cargo_dependency_feature_inventory() {
+    assert_text_fixture("t40_cargo_dependency_feature_inventory", "input.toml");
+}
+
+#[test]
+fn t41_github_actions_matrix() {
+    assert_text_fixture("t41_github_actions_matrix", "input.yaml");
+}
+
+#[test]
+fn t42_openapi_endpoint_catalog() {
+    assert_text_fixture("t42_openapi_endpoint_catalog", "input.yaml");
+}
+
+#[test]
+fn t43_mongodb_schema_summary() {
+    assert_text_fixture("t43_mongodb_schema_summary", "input.json");
+}


### PR DESCRIPTION
## Summary
- Move generic input-format transform golden tests from the root integration test file into transform_golden/input_formats.rs
- Keep existing test names, assertions, and fixture coverage unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden t3 -- --test-threads=1
- cargo test -p rulemorph --test transform_golden t4 -- --test-threads=1
- cargo test -p rulemorph --test transform_golden -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-rebase: cargo test -p rulemorph --test transform_golden t3 -- --test-threads=1
- post-rebase: cargo test -p rulemorph_mcp --test stdio validate_rules -- --test-threads=1
- post-rebase: cargo fmt --check
- post-rebase: git diff --check origin/v0.3.1...HEAD