### PR TITLE
Refactor DTO golden tests

### DIFF
--- a/crates/rulemorph/tests/dto_golden.rs
+++ b/crates/rulemorph/tests/dto_golden.rs
@@ -31,46 +31,5 @@ fn assert_golden_in_fixture(lang: DtoLanguage, fixture: &str, expected: &str) {
     assert_eq!(output, expected);
 }
 
-#[test]
-fn dto01_rust() {
-    assert_golden_in_fixture(DtoLanguage::Rust, "dto01_basic", "expected_rust.rs");
-}
-
-#[test]
-fn dto01_typescript() {
-    assert_golden_in_fixture(
-        DtoLanguage::TypeScript,
-        "dto01_basic",
-        "expected_typescript.ts",
-    );
-}
-
-#[test]
-fn dto01_python() {
-    assert_golden_in_fixture(DtoLanguage::Python, "dto01_basic", "expected_python.py");
-}
-
-#[test]
-fn dto01_go() {
-    assert_golden_in_fixture(DtoLanguage::Go, "dto01_basic", "expected_go.go");
-}
-
-#[test]
-fn dto01_java() {
-    assert_golden_in_fixture(DtoLanguage::Java, "dto01_basic", "expected_java.java");
-}
-
-#[test]
-fn dto01_kotlin() {
-    assert_golden_in_fixture(DtoLanguage::Kotlin, "dto01_basic", "expected_kotlin.kt");
-}
-
-#[test]
-fn dto01_swift() {
-    assert_golden_in_fixture(DtoLanguage::Swift, "dto01_basic", "expected_swift.swift");
-}
-
-#[test]
-fn dto02_steps_rust() {
-    assert_golden_in_fixture(DtoLanguage::Rust, "dto02_steps", "expected_rust.rs");
-}
+include!("dto_golden/basic.rs");
+include!("dto_golden/steps.rs");

--- a/crates/rulemorph/tests/dto_golden/basic.rs
+++ b/crates/rulemorph/tests/dto_golden/basic.rs
@@ -1,0 +1,38 @@
+#[test]
+fn dto01_rust() {
+    assert_golden_in_fixture(DtoLanguage::Rust, "dto01_basic", "expected_rust.rs");
+}
+
+#[test]
+fn dto01_typescript() {
+    assert_golden_in_fixture(
+        DtoLanguage::TypeScript,
+        "dto01_basic",
+        "expected_typescript.ts",
+    );
+}
+
+#[test]
+fn dto01_python() {
+    assert_golden_in_fixture(DtoLanguage::Python, "dto01_basic", "expected_python.py");
+}
+
+#[test]
+fn dto01_go() {
+    assert_golden_in_fixture(DtoLanguage::Go, "dto01_basic", "expected_go.go");
+}
+
+#[test]
+fn dto01_java() {
+    assert_golden_in_fixture(DtoLanguage::Java, "dto01_basic", "expected_java.java");
+}
+
+#[test]
+fn dto01_kotlin() {
+    assert_golden_in_fixture(DtoLanguage::Kotlin, "dto01_basic", "expected_kotlin.kt");
+}
+
+#[test]
+fn dto01_swift() {
+    assert_golden_in_fixture(DtoLanguage::Swift, "dto01_basic", "expected_swift.swift");
+}

--- a/crates/rulemorph/tests/dto_golden/steps.rs
+++ b/crates/rulemorph/tests/dto_golden/steps.rs
@@ -1,0 +1,4 @@
+#[test]
+fn dto02_steps_rust() {
+    assert_golden_in_fixture(DtoLanguage::Rust, "dto02_steps", "expected_rust.rs");
+}


### PR DESCRIPTION
## Summary
- Split DTO golden tests into language matrix and steps fixture include files
- Keep generated output equality assertions, fixture paths, and language coverage unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --test dto_golden dto01 -- --test-threads=1
- cargo test -p rulemorph --test dto_golden dto02 -- --test-threads=1
- cargo test -p rulemorph --test dto_golden -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit: cargo test -p rulemorph --test dto_golden -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD