### PR TITLE
Refactor XLSX fixture worksheet helpers

### DIFF
--- a/crates/rulemorph/tests/common/xlsx/fixture.rs
+++ b/crates/rulemorph/tests/common/xlsx/fixture.rs
@@ -4,6 +4,10 @@ use zip::{CompressionMethod, ZipWriter, write::FileOptions};
 
 use super::write_zip_file;
 
+mod worksheet;
+
+use self::worksheet::{build_sheet1_xml, build_sheet2_xml};
+
 #[derive(Default)]
 pub(crate) struct XlsxFixtureOptions {
     pub(crate) duplicate_header: bool,
@@ -156,59 +160,7 @@ pub(crate) fn build_test_xlsx(options: XlsxFixtureOptions) -> Vec<u8> {
 <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs></styleSheet>"#,
         file_options,
     );
-    let sheet = if options.empty_sheet {
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData></sheetData>
-</worksheet>"#
-            .to_string()
-    } else if options.formula_without_cache {
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="1"><c r="A1" t="s"><v>0</v></c></row>
-    <row r="2"><c r="A2"><f>1+1</f></c></row>
-  </sheetData>
-</worksheet>"#
-            .to_string()
-    } else if options.far_formula_without_cache {
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="200"><c r="A200"><f>1+1</f></c></row>
-  </sheetData>
-</worksheet>"#
-            .to_string()
-    } else if options.shared_formula {
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="1"><c r="A1" t="s"><v>0</v></c></row>
-    <row r="2"><c r="A2"><f t="shared" si="1000000000" ref="A2:A1048576">1+1</f><v>2</v></c></row>
-  </sheetData>
-</worksheet>"#
-            .to_string()
-    } else if options.sparse_far_cell {
-        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="1"><c r="A1" t="s"><v>0</v></c></row>
-    <row r="1048576"><c r="XFD1048576"><v>1</v></c></row>
-  </sheetData>
-</worksheet>"#
-            .to_string()
-    } else {
-        let second_header = if options.duplicate_header { 0 } else { 1 };
-        format!(
-            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>{second_header}</v></c></row>
-    <row r="2"><c r="A2"><v>1</v></c><c r="B2" t="s"><v>2</v></c></row>
-  </sheetData>
-</worksheet>"#
-        )
-    };
+    let sheet = build_sheet1_xml(&options);
     write_zip_file(&mut zip, "xl/worksheets/sheet1.xml", &sheet, file_options);
     if options.case_variant_duplicate_sheet {
         write_zip_file(
@@ -225,24 +177,7 @@ pub(crate) fn build_test_xlsx(options: XlsxFixtureOptions) -> Vec<u8> {
         );
     }
     if include_second_sheet {
-        let sheet2 = if options.conflicting_sheet_relationship {
-            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="1"><c r="A1"><v>1</v></c></row>
-    <row r="1048576"><c r="XFD1048576"><v>1</v></c></row>
-  </sheetData>
-</worksheet>"#
-        } else {
-            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <sheetData>
-    <row r="1"><c r="A1"><v>1</v></c><c r="B1"><v>2</v></c></row>
-    <row r="2"><c r="A2"><v>3</v></c><c r="B2"><v>4</v></c></row>
-    <row r="3"><c r="A3"><v>5</v></c><c r="B3"><v>6</v></c></row>
-  </sheetData>
-</worksheet>"#
-        };
+        let sheet2 = build_sheet2_xml(&options);
         write_zip_file(&mut zip, "xl/worksheets/sheet2.xml", sheet2, file_options);
     }
     if options.macro_enabled {

--- a/crates/rulemorph/tests/common/xlsx/fixture/worksheet.rs
+++ b/crates/rulemorph/tests/common/xlsx/fixture/worksheet.rs
@@ -1,0 +1,78 @@
+use super::XlsxFixtureOptions;
+
+pub(super) fn build_sheet1_xml(options: &XlsxFixtureOptions) -> String {
+    if options.empty_sheet {
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData></sheetData>
+</worksheet>"#
+            .to_string()
+    } else if options.formula_without_cache {
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c></row>
+    <row r="2"><c r="A2"><f>1+1</f></c></row>
+  </sheetData>
+</worksheet>"#
+            .to_string()
+    } else if options.far_formula_without_cache {
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="200"><c r="A200"><f>1+1</f></c></row>
+  </sheetData>
+</worksheet>"#
+            .to_string()
+    } else if options.shared_formula {
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c></row>
+    <row r="2"><c r="A2"><f t="shared" si="1000000000" ref="A2:A1048576">1+1</f><v>2</v></c></row>
+  </sheetData>
+</worksheet>"#
+            .to_string()
+    } else if options.sparse_far_cell {
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c></row>
+    <row r="1048576"><c r="XFD1048576"><v>1</v></c></row>
+  </sheetData>
+</worksheet>"#
+            .to_string()
+    } else {
+        let second_header = if options.duplicate_header { 0 } else { 1 };
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>{second_header}</v></c></row>
+    <row r="2"><c r="A2"><v>1</v></c><c r="B2" t="s"><v>2</v></c></row>
+  </sheetData>
+</worksheet>"#
+        )
+    }
+}
+
+pub(super) fn build_sheet2_xml(options: &XlsxFixtureOptions) -> &'static str {
+    if options.conflicting_sheet_relationship {
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1"><v>1</v></c></row>
+    <row r="1048576"><c r="XFD1048576"><v>1</v></c></row>
+  </sheetData>
+</worksheet>"#
+    } else {
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1"><v>1</v></c><c r="B1"><v>2</v></c></row>
+    <row r="2"><c r="A2"><v>3</v></c><c r="B2"><v>4</v></c></row>
+    <row r="3"><c r="A3"><v>5</v></c><c r="B3"><v>6</v></c></row>
+  </sheetData>
+</worksheet>"#
+    }
+}


### PR DESCRIPTION
## Summary
- Move generated worksheet XML helpers out of the shared XLSX fixture builder
- Keep build_test_xlsx ZIP assembly, options, and generated fixture contents unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden excel -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio initialize_and_list_tools -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio list_ops_success -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD

Note: an intermediate checkpoint command using two Cargo test filters failed with a Cargo usage error, then the two filters were run separately and passed.