### PR TITLE
Refactor CLI API key commands

### DIFF
--- a/crates/rulemorph_cli/src/api_keys.rs
+++ b/crates/rulemorph_cli/src/api_keys.rs
@@ -1,11 +1,16 @@
-use std::path::PathBuf;
-
 use clap::{Args, Subcommand};
-use rulemorph_server::{ApiKeyStore, ServerConfig, TenantLayout};
 
+mod issue;
+mod layout;
+mod list;
 mod output;
+mod revoke;
+mod rotate;
 
-use self::output::{emit_api_key_issue, emit_api_key_list};
+use self::issue::{ApiKeysIssueArgs, run_issue};
+use self::list::{ApiKeysListArgs, run_list};
+use self::revoke::{ApiKeysRevokeArgs, run_revoke};
+use self::rotate::{ApiKeysRotateArgs, run_rotate};
 
 #[derive(Args)]
 pub(super) struct ApiKeysArgs {
@@ -21,54 +26,6 @@ enum ApiKeysCommand {
     Rotate(ApiKeysRotateArgs),
 }
 
-#[derive(Args)]
-struct ApiKeysIssueArgs {
-    #[arg(long)]
-    tenant_id: String,
-    #[arg(long)]
-    data_dir: Option<PathBuf>,
-    #[arg(long)]
-    label: Option<String>,
-    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
-    json: bool,
-}
-
-#[derive(Args)]
-struct ApiKeysListArgs {
-    #[arg(long)]
-    tenant_id: String,
-    #[arg(long)]
-    data_dir: Option<PathBuf>,
-    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
-    json: bool,
-}
-
-#[derive(Args)]
-struct ApiKeysRevokeArgs {
-    #[arg(long)]
-    tenant_id: String,
-    #[arg(long)]
-    data_dir: Option<PathBuf>,
-    #[arg(long)]
-    id: String,
-    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
-    json: bool,
-}
-
-#[derive(Args)]
-struct ApiKeysRotateArgs {
-    #[arg(long)]
-    tenant_id: String,
-    #[arg(long)]
-    data_dir: Option<PathBuf>,
-    #[arg(long)]
-    id: String,
-    #[arg(long)]
-    label: Option<String>,
-    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
-    json: bool,
-}
-
 pub(super) fn run(args: ApiKeysArgs) -> i32 {
     match args.command {
         ApiKeysCommand::Issue(args) => run_issue(args),
@@ -76,126 +33,4 @@ pub(super) fn run(args: ApiKeysArgs) -> i32 {
         ApiKeysCommand::Revoke(args) => run_revoke(args),
         ApiKeysCommand::Rotate(args) => run_rotate(args),
     }
-}
-
-fn run_issue(args: ApiKeysIssueArgs) -> i32 {
-    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
-        Ok(layout) => layout,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let path = layout.api_keys_path();
-    let mut store = match ApiKeyStore::load_or_init(path, layout.tenant_id()) {
-        Ok(store) => store,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let issued = match store.issue(args.label) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    emit_api_key_issue(&issued, args.json);
-    0
-}
-
-fn run_list(args: ApiKeysListArgs) -> i32 {
-    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
-        Ok(layout) => layout,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let path = layout.api_keys_path();
-    let store = match ApiKeyStore::load(path, layout.tenant_id()) {
-        Ok(store) => store,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let keys = store.map(|store| store.list()).unwrap_or_default();
-    emit_api_key_list(&keys, args.json);
-    0
-}
-
-fn run_revoke(args: ApiKeysRevokeArgs) -> i32 {
-    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
-        Ok(layout) => layout,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let path = layout.api_keys_path();
-    let mut store = match ApiKeyStore::load(path, layout.tenant_id()) {
-        Ok(Some(store)) => store,
-        Ok(None) => {
-            eprintln!("api key store not found");
-            return 2;
-        }
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let revoked = match store.revoke(&args.id) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    if args.json {
-        println!("{}", serde_json::json!({ "revoked": revoked }));
-    } else {
-        println!("revoked: {}", revoked);
-    }
-    if revoked { 0 } else { 2 }
-}
-
-fn run_rotate(args: ApiKeysRotateArgs) -> i32 {
-    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
-        Ok(layout) => layout,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let path = layout.api_keys_path();
-    let mut store = match ApiKeyStore::load_or_init(path, layout.tenant_id()) {
-        Ok(store) => store,
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    let issued = match store.rotate(&args.id, args.label) {
-        Ok(Some(issued)) => issued,
-        Ok(None) => {
-            eprintln!("api key not found");
-            return 2;
-        }
-        Err(err) => {
-            eprintln!("{err}");
-            return 2;
-        }
-    };
-    emit_api_key_issue(&issued, args.json);
-    0
-}
-
-fn resolve_tenant_layout(
-    tenant_id: &str,
-    data_dir: Option<PathBuf>,
-) -> Result<TenantLayout, String> {
-    let base_dir = data_dir.unwrap_or_else(ServerConfig::default_data_dir);
-    TenantLayout::new(base_dir, tenant_id).map_err(|err| err.to_string())
 }

--- a/crates/rulemorph_cli/src/api_keys/issue.rs
+++ b/crates/rulemorph_cli/src/api_keys/issue.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use rulemorph_server::ApiKeyStore;
+
+use super::layout::resolve_tenant_layout;
+use super::output::emit_api_key_issue;
+
+#[derive(Args)]
+pub(crate) struct ApiKeysIssueArgs {
+    #[arg(long)]
+    tenant_id: String,
+    #[arg(long)]
+    data_dir: Option<PathBuf>,
+    #[arg(long)]
+    label: Option<String>,
+    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
+    json: bool,
+}
+
+pub(crate) fn run_issue(args: ApiKeysIssueArgs) -> i32 {
+    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
+        Ok(layout) => layout,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let path = layout.api_keys_path();
+    let mut store = match ApiKeyStore::load_or_init(path, layout.tenant_id()) {
+        Ok(store) => store,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let issued = match store.issue(args.label) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    emit_api_key_issue(&issued, args.json);
+    0
+}

--- a/crates/rulemorph_cli/src/api_keys/layout.rs
+++ b/crates/rulemorph_cli/src/api_keys/layout.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use rulemorph_server::{ServerConfig, TenantLayout};
+
+pub(crate) fn resolve_tenant_layout(
+    tenant_id: &str,
+    data_dir: Option<PathBuf>,
+) -> Result<TenantLayout, String> {
+    let base_dir = data_dir.unwrap_or_else(ServerConfig::default_data_dir);
+    TenantLayout::new(base_dir, tenant_id).map_err(|err| err.to_string())
+}

--- a/crates/rulemorph_cli/src/api_keys/list.rs
+++ b/crates/rulemorph_cli/src/api_keys/list.rs
@@ -1,0 +1,38 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use rulemorph_server::ApiKeyStore;
+
+use super::layout::resolve_tenant_layout;
+use super::output::emit_api_key_list;
+
+#[derive(Args)]
+pub(crate) struct ApiKeysListArgs {
+    #[arg(long)]
+    tenant_id: String,
+    #[arg(long)]
+    data_dir: Option<PathBuf>,
+    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
+    json: bool,
+}
+
+pub(crate) fn run_list(args: ApiKeysListArgs) -> i32 {
+    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
+        Ok(layout) => layout,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let path = layout.api_keys_path();
+    let store = match ApiKeyStore::load(path, layout.tenant_id()) {
+        Ok(store) => store,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let keys = store.map(|store| store.list()).unwrap_or_default();
+    emit_api_key_list(&keys, args.json);
+    0
+}

--- a/crates/rulemorph_cli/src/api_keys/revoke.rs
+++ b/crates/rulemorph_cli/src/api_keys/revoke.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use rulemorph_server::ApiKeyStore;
+
+use super::layout::resolve_tenant_layout;
+
+#[derive(Args)]
+pub(crate) struct ApiKeysRevokeArgs {
+    #[arg(long)]
+    tenant_id: String,
+    #[arg(long)]
+    data_dir: Option<PathBuf>,
+    #[arg(long)]
+    id: String,
+    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
+    json: bool,
+}
+
+pub(crate) fn run_revoke(args: ApiKeysRevokeArgs) -> i32 {
+    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
+        Ok(layout) => layout,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let path = layout.api_keys_path();
+    let mut store = match ApiKeyStore::load(path, layout.tenant_id()) {
+        Ok(Some(store)) => store,
+        Ok(None) => {
+            eprintln!("api key store not found");
+            return 2;
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let revoked = match store.revoke(&args.id) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    if args.json {
+        println!("{}", serde_json::json!({ "revoked": revoked }));
+    } else {
+        println!("revoked: {}", revoked);
+    }
+    if revoked { 0 } else { 2 }
+}

--- a/crates/rulemorph_cli/src/api_keys/rotate.rs
+++ b/crates/rulemorph_cli/src/api_keys/rotate.rs
@@ -1,0 +1,52 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use rulemorph_server::ApiKeyStore;
+
+use super::layout::resolve_tenant_layout;
+use super::output::emit_api_key_issue;
+
+#[derive(Args)]
+pub(crate) struct ApiKeysRotateArgs {
+    #[arg(long)]
+    tenant_id: String,
+    #[arg(long)]
+    data_dir: Option<PathBuf>,
+    #[arg(long)]
+    id: String,
+    #[arg(long)]
+    label: Option<String>,
+    #[arg(long, action = clap::ArgAction::SetTrue, default_value_t = false)]
+    json: bool,
+}
+
+pub(crate) fn run_rotate(args: ApiKeysRotateArgs) -> i32 {
+    let layout = match resolve_tenant_layout(&args.tenant_id, args.data_dir) {
+        Ok(layout) => layout,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let path = layout.api_keys_path();
+    let mut store = match ApiKeyStore::load_or_init(path, layout.tenant_id()) {
+        Ok(store) => store,
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    let issued = match store.rotate(&args.id, args.label) {
+        Ok(Some(issued)) => issued,
+        Ok(None) => {
+            eprintln!("api key not found");
+            return 2;
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            return 2;
+        }
+    };
+    emit_api_key_issue(&issued, args.json);
+    0
+}

--- a/crates/rulemorph_cli/tests/cli/api_keys.rs
+++ b/crates/rulemorph_cli/tests/cli/api_keys.rs
@@ -60,3 +60,78 @@ fn api_keys_issue_list_and_revoke_json() {
     let revoked = stdout_json(revoke);
     assert_eq!(revoked["revoked"], true);
 }
+
+#[cfg(feature = "server")]
+#[test]
+fn api_keys_rotate_json_revokes_and_issues_replacement() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let mut issue_cmd = cargo_bin_cmd!("rulemorph");
+    let issue = issue_cmd
+        .arg("api-keys")
+        .arg("issue")
+        .arg("--tenant-id")
+        .arg("tenant-a")
+        .arg("--data-dir")
+        .arg(temp_dir.path())
+        .arg("--label")
+        .arg("alpha")
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert_eq!(issue.status.code(), Some(0));
+
+    let issued = stdout_json(issue);
+    let old_id = issued["id"].as_str().expect("issued id").to_string();
+
+    let mut rotate_cmd = cargo_bin_cmd!("rulemorph");
+    let rotate = rotate_cmd
+        .arg("api-keys")
+        .arg("rotate")
+        .arg("--tenant-id")
+        .arg("tenant-a")
+        .arg("--data-dir")
+        .arg(temp_dir.path())
+        .arg("--id")
+        .arg(&old_id)
+        .arg("--label")
+        .arg("beta")
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert_eq!(rotate.status.code(), Some(0));
+
+    let rotated = stdout_json(rotate);
+    let new_id = rotated["id"].as_str().expect("rotated id").to_string();
+    assert_ne!(new_id, old_id);
+    assert_eq!(rotated["label"], "beta");
+    assert!(rotated["key"].as_str().is_some_and(|key| !key.is_empty()));
+
+    let mut list_cmd = cargo_bin_cmd!("rulemorph");
+    let list = list_cmd
+        .arg("api-keys")
+        .arg("list")
+        .arg("--tenant-id")
+        .arg("tenant-a")
+        .arg("--data-dir")
+        .arg(temp_dir.path())
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert_eq!(list.status.code(), Some(0));
+
+    let keys = stdout_json(list);
+    let keys = keys.as_array().expect("api key array");
+    assert_eq!(keys.len(), 2);
+    let old_key = keys
+        .iter()
+        .find(|key| key["id"] == old_id)
+        .expect("old key should remain listed");
+    assert!(old_key["revoked_at"].as_str().is_some());
+    let new_key = keys
+        .iter()
+        .find(|key| key["id"] == new_id)
+        .expect("new key should be listed");
+    assert!(new_key["revoked_at"].is_null());
+    assert_eq!(new_key["label"], "beta");
+}


### PR DESCRIPTION
## Summary
- split CLI api-keys subcommands into issue/list/revoke/rotate child modules
- move tenant layout resolution into a dedicated internal helper module
- add rotate JSON characterization coverage for revoked and replacement key state

## Verification
- cargo fmt
- cargo test -p rulemorph_cli --features server --test cli api_keys_rotate_json_revokes_and_issues_replacement -- --test-threads=1
- cargo test -p rulemorph_cli --features server --test cli api_keys_issue_list_and_revoke_json -- --test-threads=1
- cargo test -p rulemorph_cli --features server
- cargo test -p rulemorph_cli
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD