### PR TITLE
Refactor trace collector budget

### DIFF
--- a/crates/rulemorph/src/trace/collector.rs
+++ b/crates/rulemorph/src/trace/collector.rs
@@ -5,8 +5,8 @@ use super::schema::{
     RecordTrace, TraceEvent, TraceEventKind, TracePhase, TraceTruncation, TransformTrace,
     TransformTraceOptions,
 };
-use super::snapshot::value_size_bytes;
 
+mod budget;
 mod span;
 
 pub(super) use span::SpanAction;
@@ -132,91 +132,8 @@ impl TraceCollector {
             .span_action(SpanAction::Pop(span_id))
     }
 
-    pub(crate) fn push(&mut self, event: TraceEvent) -> bool {
-        if self.frozen {
-            return false;
-        }
-        let snapshot_truncated = event.output.as_ref().is_some_and(|snapshot| {
-            snapshot.redaction_reason.as_deref() == Some("max_snapshot_bytes")
-        }) || event
-            .inputs
-            .iter()
-            .any(|snapshot| snapshot.redaction_reason.as_deref() == Some("max_snapshot_bytes"));
-        if let Some(max_events) = self.options.max_events {
-            let emitted = self.emitted_events();
-            if emitted >= max_events {
-                self.complete = false;
-                self.truncation = Some(TraceTruncation {
-                    reason: "max_events".to_string(),
-                    emitted_events: emitted,
-                    emitted_bytes: self.emitted_bytes,
-                });
-                self.frozen = true;
-                self.structural_truncated = true;
-                return false;
-            }
-        }
-        let event_bytes =
-            value_size_bytes(&serde_json::to_value(&event).unwrap_or(JsonValue::Null));
-        if let Some(max_trace_bytes) = self.options.max_trace_bytes
-            && self.emitted_bytes.saturating_add(event_bytes) > max_trace_bytes
-        {
-            self.complete = false;
-            self.truncation = Some(TraceTruncation {
-                reason: "max_trace_bytes".to_string(),
-                emitted_events: self.emitted_events(),
-                emitted_bytes: self.emitted_bytes,
-            });
-            self.frozen = true;
-            self.structural_truncated = true;
-            return false;
-        }
-        self.emitted_bytes = self.emitted_bytes.saturating_add(event_bytes);
-        if snapshot_truncated {
-            self.complete = false;
-            let emitted_events = self.emitted_events();
-            self.truncation.get_or_insert_with(|| TraceTruncation {
-                reason: "max_snapshot_bytes".to_string(),
-                emitted_events,
-                emitted_bytes: self.emitted_bytes,
-            });
-        }
-        self.contains_raw_values |= event
-            .output
-            .as_ref()
-            .is_some_and(|snapshot| snapshot.contains_raw_value)
-            || event
-                .inputs
-                .iter()
-                .any(|snapshot| snapshot.contains_raw_value);
-        match self.scope {
-            TraceScope::Record => {
-                if let Some(record) = &mut self.current_record {
-                    record.events.push(event);
-                }
-            }
-            TraceScope::Finalize => {
-                self.finalize_events.push(event);
-            }
-        }
-        true
-    }
-
     pub(super) fn apply_span_action(&mut self, action: Option<SpanAction>) {
         self.span_stack.apply(action);
-    }
-
-    fn emitted_events(&self) -> usize {
-        self.records
-            .iter()
-            .map(|record| record.events.len())
-            .sum::<usize>()
-            + self
-                .current_record
-                .as_ref()
-                .map(|record| record.events.len())
-                .unwrap_or(0)
-            + self.finalize_events.len()
     }
 
     pub(crate) fn finish(mut self) -> TransformTrace {

--- a/crates/rulemorph/src/trace/collector/budget.rs
+++ b/crates/rulemorph/src/trace/collector/budget.rs
@@ -1,0 +1,90 @@
+use serde_json::Value as JsonValue;
+
+use super::TraceCollector;
+use crate::trace::schema::{TraceEvent, TraceTruncation};
+use crate::trace::snapshot::value_size_bytes;
+
+impl TraceCollector {
+    pub(crate) fn push(&mut self, event: TraceEvent) -> bool {
+        if self.frozen {
+            return false;
+        }
+        let snapshot_truncated = event.output.as_ref().is_some_and(|snapshot| {
+            snapshot.redaction_reason.as_deref() == Some("max_snapshot_bytes")
+        }) || event
+            .inputs
+            .iter()
+            .any(|snapshot| snapshot.redaction_reason.as_deref() == Some("max_snapshot_bytes"));
+        if let Some(max_events) = self.options.max_events {
+            let emitted = self.emitted_events();
+            if emitted >= max_events {
+                self.complete = false;
+                self.truncation = Some(TraceTruncation {
+                    reason: "max_events".to_string(),
+                    emitted_events: emitted,
+                    emitted_bytes: self.emitted_bytes,
+                });
+                self.frozen = true;
+                self.structural_truncated = true;
+                return false;
+            }
+        }
+        let event_bytes =
+            value_size_bytes(&serde_json::to_value(&event).unwrap_or(JsonValue::Null));
+        if let Some(max_trace_bytes) = self.options.max_trace_bytes
+            && self.emitted_bytes.saturating_add(event_bytes) > max_trace_bytes
+        {
+            self.complete = false;
+            self.truncation = Some(TraceTruncation {
+                reason: "max_trace_bytes".to_string(),
+                emitted_events: self.emitted_events(),
+                emitted_bytes: self.emitted_bytes,
+            });
+            self.frozen = true;
+            self.structural_truncated = true;
+            return false;
+        }
+        self.emitted_bytes = self.emitted_bytes.saturating_add(event_bytes);
+        if snapshot_truncated {
+            self.complete = false;
+            let emitted_events = self.emitted_events();
+            self.truncation.get_or_insert_with(|| TraceTruncation {
+                reason: "max_snapshot_bytes".to_string(),
+                emitted_events,
+                emitted_bytes: self.emitted_bytes,
+            });
+        }
+        self.contains_raw_values |= event
+            .output
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.contains_raw_value)
+            || event
+                .inputs
+                .iter()
+                .any(|snapshot| snapshot.contains_raw_value);
+        match self.scope {
+            super::TraceScope::Record => {
+                if let Some(record) = &mut self.current_record {
+                    record.events.push(event);
+                }
+            }
+            super::TraceScope::Finalize => {
+                self.finalize_events.push(event);
+            }
+        }
+        true
+    }
+
+    fn emitted_events(&self) -> usize {
+        self.records
+            .iter()
+            .map(|record| record.events.len())
+            .sum::<usize>()
+            + self
+                .current_record
+                .as_ref()
+                .map(|record| record.events.len())
+                .unwrap_or(0)
+            + self.finalize_events.len()
+    }
+}


### PR DESCRIPTION
## Summary
- move TraceCollector event budget/truncation bookkeeping into a focused collector/budget module
- keep collector.rs focused on lifecycle, span facade, finish, and options
- leave trace semantics and trace JSON schema unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --lib trace::collector -- --test-threads=1
- cargo test -p rulemorph --test transform_trace trace_max -- --test-threads=1
- cargo test -p rulemorph --test transform_trace -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD