### PR TITLE
Refactor XML records path handling

### DIFF
--- a/crates/rulemorph/src/normalization/xml.rs
+++ b/crates/rulemorph/src/normalization/xml.rs
@@ -2,14 +2,15 @@ use serde_json::Value as JsonValue;
 
 use crate::error::{TransformError, TransformErrorKind};
 use crate::model::RuleFile;
-use crate::xml_name::is_xml_name;
 
 use super::{NormalizationOptions, enforce_json_limits, enforce_records_limit};
 use parser::parse_xml_tree;
-use shape::{select_xml_records, xml_node_to_json};
+use records_path::{parse_xml_records_path, select_xml_records};
+use shape::xml_node_to_json;
 
 mod names;
 mod parser;
+mod records_path;
 mod shape;
 
 pub fn normalize_xml_records(
@@ -43,21 +44,6 @@ pub fn normalize_xml_records(
         enforce_json_limits(record, options)?;
     }
     Ok(records)
-}
-
-fn parse_xml_records_path(path: &str) -> Result<Vec<&str>, TransformError> {
-    if path.is_empty()
-        || path.contains('[')
-        || path.contains(']')
-        || !path.split('.').all(is_xml_name)
-    {
-        return Err(TransformError::new(
-            TransformErrorKind::InvalidRecordsPath,
-            "xml.records_path must be a dot-separated element path",
-        )
-        .with_path("input.xml.records_path"));
-    }
-    Ok(path.split('.').collect())
 }
 
 fn invalid(message: impl Into<String>) -> TransformError {

--- a/crates/rulemorph/src/normalization/xml/records_path.rs
+++ b/crates/rulemorph/src/normalization/xml/records_path.rs
@@ -1,0 +1,40 @@
+use crate::error::{TransformError, TransformErrorKind};
+use crate::xml_name::is_xml_name;
+
+use super::shape::XmlNode;
+
+pub(super) fn parse_xml_records_path(path: &str) -> Result<Vec<&str>, TransformError> {
+    if path.is_empty()
+        || path.contains('[')
+        || path.contains(']')
+        || !path.split('.').all(is_xml_name)
+    {
+        return Err(TransformError::new(
+            TransformErrorKind::InvalidRecordsPath,
+            "xml.records_path must be a dot-separated element path",
+        )
+        .with_path("input.xml.records_path"));
+    }
+    Ok(path.split('.').collect())
+}
+
+pub(super) fn select_xml_records<'a>(
+    node: &'a XmlNode,
+    path: &[&str],
+    selected: &mut Vec<&'a XmlNode>,
+) {
+    if path.is_empty() {
+        selected.push(node);
+        return;
+    }
+    if node.name != path[0] {
+        return;
+    }
+    if path.len() == 1 {
+        selected.push(node);
+        return;
+    }
+    for child in &node.children {
+        select_xml_records(child, &path[1..], selected);
+    }
+}

--- a/crates/rulemorph/src/normalization/xml/shape.rs
+++ b/crates/rulemorph/src/normalization/xml/shape.rs
@@ -22,27 +22,6 @@ pub(super) struct XmlAttribute {
     pub(super) value: String,
 }
 
-pub(super) fn select_xml_records<'a>(
-    node: &'a XmlNode,
-    path: &[&str],
-    selected: &mut Vec<&'a XmlNode>,
-) {
-    if path.is_empty() {
-        selected.push(node);
-        return;
-    }
-    if node.name != path[0] {
-        return;
-    }
-    if path.len() == 1 {
-        selected.push(node);
-        return;
-    }
-    for child in &node.children {
-        select_xml_records(child, &path[1..], selected);
-    }
-}
-
 pub(super) fn xml_node_to_json(
     node: &XmlNode,
     xml: &XmlInput,


### PR DESCRIPTION
## Summary
- move XML records_path validation and record selection into a focused records_path module
- keep XML parsing and XML node-to-JSON shaping in their existing modules
- preserve XML normalization behavior and security invariants

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden xml -- --test-threads=1
- cargo test -p rulemorph --test validation xml -- --test-threads=1
- cargo test -p rulemorph --test transform_golden -- --test-threads=1
- cargo test -p rulemorph --test validation -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD