### PR TITLE
Refactor UI App graph state

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -12,19 +12,8 @@ import {
   type TraceListItem
 } from "./trace_list_helpers";
 import {
-  buildApiDetailBundles,
-  buildTraceDetailBundles,
-  collectApiDetailNodeMap,
-  collectDetailNodeMap,
   deriveRuleOptions,
-  deriveStatusOptions,
-  emptyOverviewGraph,
-  resolveCurrentTrace,
-  resolveDetailLabel,
-  resolveDetailReason,
-  resolveDetailStatus,
-  resolveEffectiveFocusedRuleId,
-  resolveRecordLabel
+  deriveStatusOptions
 } from "./app_derived_state";
 import {
   type TraceManifest,
@@ -37,9 +26,6 @@ import { RecordPanel } from "./record_panel";
 import { Topbar } from "./topbar";
 import { TraceCanvas } from "./trace_canvas";
 import {
-  buildApiGraph,
-  buildMergedApiGraph,
-  buildMergedGraph,
   buildOverviewGraph,
   type ApiGraphNode,
   type ApiGraphOp,
@@ -55,6 +41,7 @@ import {
 import { loadApiGraph, resetApiGraphSelection } from "./app_api_graph_state";
 import { loadTraceDetailForSelection } from "./app_trace_detail_state";
 import { useAuthSecretCapture, useStoredDurationUnit } from "./app_runtime";
+import { useAppGraphViewState } from "./app_graph_view_state";
 
 export { getApiKey, getInternalKey } from "./auth";
 export { __getTenantIdFromQueryOrStorageForTest, resolveTenantId } from "./tenant";
@@ -200,62 +187,34 @@ export default function App() {
     });
   }, [selectedId]);
 
-  const overviewGraph = useMemo(
-    () => (trace ? buildOverviewGraph(trace) : emptyOverviewGraph()),
-    [trace]
-  );
-  const effectiveFocusedRuleId = resolveEffectiveFocusedRuleId(focusedRuleId, expandedRuleIds);
-  const currentTrace = resolveCurrentTrace(effectiveFocusedRuleId, overviewGraph, trace);
-  const isFinalizeSelected = recordIndex < 0;
-  const currentRecord = recordIndex >= 0 ? currentTrace?.records?.[recordIndex] : undefined;
-  const finalizePayload = currentTrace?.finalize ?? null;
-  const bundles = useMemo(
-    () => buildTraceDetailBundles(expandedRuleIds, overviewGraph, recordIndex, effectiveFocusedRuleId),
-    [expandedRuleIds, overviewGraph, recordIndex, effectiveFocusedRuleId]
-  );
-  const apiGraphLayout = useMemo(() => {
-    if (!apiGraph) {
-      return { nodes: [], edges: [], nodeMap: new Map<string, ApiGraphNode>(), edgeLabelMap: new Map<string, string>() };
-    }
-    return buildApiGraph(apiGraph);
-  }, [apiGraph]);
-  const apiBundles = useMemo(
-    () => buildApiDetailBundles(apiExpandedRuleIds, apiGraphLayout),
-    [apiExpandedRuleIds, apiGraphLayout]
-  );
-  const mergedGraph = useMemo(
-    () =>
-      buildMergedGraph(
-        overviewGraph,
-        bundles,
-        expandedRuleIds,
-        pinnedPositions,
-        overviewGraph.endpointEdgeLabels
-      ),
-    [overviewGraph, bundles, expandedRuleIds, pinnedPositions]
-  );
-  const apiMergedGraph = useMemo(
-    () =>
-      buildMergedApiGraph(
-        { nodes: apiGraphLayout.nodes, edges: apiGraphLayout.edges },
-        apiBundles,
-        apiExpandedRuleIds,
-        apiPinnedPositions,
-        apiGraphLayout.edgeLabelMap
-      ),
-    [apiGraphLayout, apiBundles, apiExpandedRuleIds, apiPinnedPositions]
-  );
-  const activeGraph = viewMode === "api" ? apiMergedGraph : mergedGraph;
-
-  const detailNodeMap = useMemo(() => collectDetailNodeMap(bundles), [bundles]);
-  const apiDetailNodeMap = useMemo(() => collectApiDetailNodeMap(apiBundles), [apiBundles]);
-  const detailStatus = resolveDetailStatus(traceManifest, trace);
-  const detailReason = resolveDetailReason(traceManifest, trace);
-  const detailAvailable = detailStatus ? detailStatus === "full" : true;
-  const hasDetail = viewMode === "trace" && expandedRuleIds.length > 0 && detailAvailable;
-  const apiHasDetail = viewMode === "api" && apiExpandedRuleIds.length > 0;
-  const recordLabel = resolveRecordLabel(isFinalizeSelected, currentRecord);
-  const detailLabel = resolveDetailLabel(detailStatus, detailLoading, hasDetail);
+  const {
+    overviewGraph,
+    currentTrace,
+    isFinalizeSelected,
+    finalizePayload,
+    activeGraph,
+    detailNodeMap,
+    apiGraphLayout,
+    apiDetailNodeMap,
+    detailStatus,
+    detailReason,
+    hasDetail,
+    apiHasDetail,
+    recordLabel,
+    detailLabel
+  } = useAppGraphViewState({
+    viewMode,
+    trace,
+    traceManifest,
+    detailLoading,
+    expandedRuleIds,
+    focusedRuleId,
+    recordIndex,
+    apiGraph,
+    apiExpandedRuleIds,
+    pinnedPositions,
+    apiPinnedPositions
+  });
 
   return (
     <div className="app">

--- a/crates/rulemorph_ui/ui/src/app_graph_view_state.ts
+++ b/crates/rulemorph_ui/ui/src/app_graph_view_state.ts
@@ -1,0 +1,135 @@
+import { useMemo } from "react";
+import {
+  buildApiDetailBundles,
+  buildTraceDetailBundles,
+  collectApiDetailNodeMap,
+  collectDetailNodeMap,
+  emptyOverviewGraph,
+  resolveCurrentTrace,
+  resolveDetailLabel,
+  resolveDetailReason,
+  resolveDetailStatus,
+  resolveEffectiveFocusedRuleId,
+  resolveRecordLabel
+} from "./app_derived_state";
+import {
+  buildApiGraph,
+  buildMergedApiGraph,
+  buildMergedGraph,
+  buildOverviewGraph,
+  type ApiGraphNode,
+  type ApiGraphResponse
+} from "./trace_graph";
+import type { TraceManifest, TracePayload } from "./trace_payload";
+
+type ViewMode = "trace" | "api";
+type PinnedPositions = Record<string, { x: number; y: number }>;
+type ApiGraphLayout = ReturnType<typeof buildApiGraph>;
+
+type AppGraphViewStateArgs = {
+  viewMode: ViewMode;
+  trace: TracePayload | null;
+  traceManifest: TraceManifest | null;
+  detailLoading: boolean;
+  expandedRuleIds: string[];
+  focusedRuleId: string | null;
+  recordIndex: number;
+  apiGraph: ApiGraphResponse | null;
+  apiExpandedRuleIds: string[];
+  pinnedPositions: PinnedPositions;
+  apiPinnedPositions: PinnedPositions;
+};
+
+function emptyApiGraphLayout(): ApiGraphLayout {
+  return {
+    nodes: [],
+    edges: [],
+    nodeMap: new Map<string, ApiGraphNode>(),
+    edgeLabelMap: new Map<string, string>()
+  };
+}
+
+export function useAppGraphViewState({
+  viewMode,
+  trace,
+  traceManifest,
+  detailLoading,
+  expandedRuleIds,
+  focusedRuleId,
+  recordIndex,
+  apiGraph,
+  apiExpandedRuleIds,
+  pinnedPositions,
+  apiPinnedPositions
+}: AppGraphViewStateArgs) {
+  const overviewGraph = useMemo(
+    () => (trace ? buildOverviewGraph(trace) : emptyOverviewGraph()),
+    [trace]
+  );
+  const effectiveFocusedRuleId = resolveEffectiveFocusedRuleId(focusedRuleId, expandedRuleIds);
+  const currentTrace = resolveCurrentTrace(effectiveFocusedRuleId, overviewGraph, trace);
+  const isFinalizeSelected = recordIndex < 0;
+  const currentRecord = recordIndex >= 0 ? currentTrace?.records?.[recordIndex] : undefined;
+  const finalizePayload = currentTrace?.finalize ?? null;
+  const bundles = useMemo(
+    () => buildTraceDetailBundles(expandedRuleIds, overviewGraph, recordIndex, effectiveFocusedRuleId),
+    [expandedRuleIds, overviewGraph, recordIndex, effectiveFocusedRuleId]
+  );
+  const apiGraphLayout = useMemo(
+    () => (apiGraph ? buildApiGraph(apiGraph) : emptyApiGraphLayout()),
+    [apiGraph]
+  );
+  const apiBundles = useMemo(
+    () => buildApiDetailBundles(apiExpandedRuleIds, apiGraphLayout),
+    [apiExpandedRuleIds, apiGraphLayout]
+  );
+  const mergedGraph = useMemo(
+    () =>
+      buildMergedGraph(
+        overviewGraph,
+        bundles,
+        expandedRuleIds,
+        pinnedPositions,
+        overviewGraph.endpointEdgeLabels
+      ),
+    [overviewGraph, bundles, expandedRuleIds, pinnedPositions]
+  );
+  const apiMergedGraph = useMemo(
+    () =>
+      buildMergedApiGraph(
+        { nodes: apiGraphLayout.nodes, edges: apiGraphLayout.edges },
+        apiBundles,
+        apiExpandedRuleIds,
+        apiPinnedPositions,
+        apiGraphLayout.edgeLabelMap
+      ),
+    [apiGraphLayout, apiBundles, apiExpandedRuleIds, apiPinnedPositions]
+  );
+  const activeGraph = viewMode === "api" ? apiMergedGraph : mergedGraph;
+  const detailNodeMap = useMemo(() => collectDetailNodeMap(bundles), [bundles]);
+  const apiDetailNodeMap = useMemo(() => collectApiDetailNodeMap(apiBundles), [apiBundles]);
+  const detailStatus = resolveDetailStatus(traceManifest, trace);
+  const detailReason = resolveDetailReason(traceManifest, trace);
+  const detailAvailable = detailStatus ? detailStatus === "full" : true;
+  const hasDetail = viewMode === "trace" && expandedRuleIds.length > 0 && detailAvailable;
+  const apiHasDetail = viewMode === "api" && apiExpandedRuleIds.length > 0;
+  const recordLabel = resolveRecordLabel(isFinalizeSelected, currentRecord);
+  const detailLabel = resolveDetailLabel(detailStatus, detailLoading, hasDetail);
+
+  return {
+    overviewGraph,
+    currentTrace,
+    isFinalizeSelected,
+    finalizePayload,
+    activeGraph,
+    detailNodeMap,
+    apiGraphLayout,
+    apiDetailNodeMap,
+    detailStatus,
+    detailReason,
+    hasDetail,
+    apiHasDetail,
+    recordLabel,
+    detailLabel
+  };
+}


### PR DESCRIPTION
## Summary
- move App.tsx trace/API graph derived state into useAppGraphViewState
- keep App.tsx focused on state/effects and component composition
- preserve public test exports and UI/API/trace contracts

## Verification
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e
- browser smoke at http://127.0.0.1:5176/ (topbar 1, React Flow canvas 1, ZIP import button 1, no-traces message true; screenshot /private/tmp/rulemorph-stage617-smoke.png)
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD

## Contract
- No behavior changes
- No trace JSON schema changes
- No public API/export changes
- No transform semantics changes
- No CLI/MCP/HTTP contract changes
- No docs/specs changes