### PR TITLE
Refactor network rule retry

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_rule.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_rule.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
@@ -11,6 +10,11 @@ use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
 use super::{catch::CatchSpec, resolve_rule_path, rule_loader::LoadedRule, rule_ref_from_path};
+
+mod retry;
+
+use retry::NetworkRetry;
+pub(super) use retry::{RetryConfig, compile_retry, parse_duration};
 
 #[derive(Debug)]
 pub(super) struct CompiledNetworkRule {
@@ -57,30 +61,6 @@ pub(super) struct NetworkRequest {
     pub(super) url: JsonValue,
     #[serde(default)]
     pub(super) headers: Option<HashMap<String, JsonValue>>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(super) struct NetworkRetry {
-    #[serde(default)]
-    max: Option<u32>,
-    #[serde(default)]
-    backoff: Option<String>,
-    #[serde(default)]
-    initial_delay: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub(super) struct RetryConfig {
-    pub(super) max: u32,
-    pub(super) backoff: RetryBackoff,
-    pub(super) initial_delay: Duration,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(super) enum RetryBackoff {
-    Fixed,
-    Linear,
-    Exponential,
 }
 
 #[derive(Debug)]
@@ -181,59 +161,4 @@ pub(super) fn compile_network_rule(
             .unwrap_or_else(|| Path::new("."))
             .to_path_buf(),
     })
-}
-
-pub(super) fn parse_duration(value: &str) -> Result<Duration> {
-    let trimmed = value.trim();
-    if let Some(ms) = trimmed.strip_suffix("ms") {
-        let amount = u64::from_str(ms.trim()).context("invalid ms")?;
-        return Ok(Duration::from_millis(amount));
-    }
-    if let Some(sec) = trimmed.strip_suffix('s') {
-        let amount = u64::from_str(sec.trim()).context("invalid s")?;
-        return Ok(Duration::from_secs(amount));
-    }
-    Err(anyhow!("invalid duration: {}", value))
-}
-
-pub(super) fn compile_retry(raw: Option<&NetworkRetry>) -> Result<Option<RetryConfig>> {
-    let Some(raw) = raw else {
-        return Ok(None);
-    };
-    let max = raw.max.unwrap_or(0);
-    if max == 0 {
-        return Ok(None);
-    }
-    let backoff = match raw.backoff.as_deref().unwrap_or("fixed") {
-        "fixed" => RetryBackoff::Fixed,
-        "linear" => RetryBackoff::Linear,
-        "exponential" => RetryBackoff::Exponential,
-        other => return Err(anyhow!("invalid retry backoff: {}", other)),
-    };
-    let initial_delay = match raw.initial_delay.as_deref() {
-        Some(value) => parse_duration(value)?,
-        None => Duration::from_millis(100),
-    };
-    Ok(Some(RetryConfig {
-        max,
-        backoff,
-        initial_delay,
-    }))
-}
-
-impl RetryConfig {
-    pub(super) fn delay_for(&self, attempt: u32) -> Duration {
-        let factor = attempt.saturating_add(1);
-        match self.backoff {
-            RetryBackoff::Fixed => self.initial_delay,
-            RetryBackoff::Linear => self
-                .initial_delay
-                .checked_mul(factor)
-                .unwrap_or(Duration::MAX),
-            RetryBackoff::Exponential => {
-                let exp = 2u32.saturating_pow(attempt);
-                self.initial_delay.checked_mul(exp).unwrap_or(Duration::MAX)
-            }
-        }
-    }
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/network_rule/retry.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/network_rule/retry.rs
@@ -1,0 +1,86 @@
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(in crate::endpoint_engine) struct NetworkRetry {
+    #[serde(default)]
+    max: Option<u32>,
+    #[serde(default)]
+    backoff: Option<String>,
+    #[serde(default)]
+    initial_delay: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::endpoint_engine) struct RetryConfig {
+    pub(in crate::endpoint_engine) max: u32,
+    pub(in crate::endpoint_engine) backoff: RetryBackoff,
+    pub(in crate::endpoint_engine) initial_delay: Duration,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(in crate::endpoint_engine) enum RetryBackoff {
+    Fixed,
+    Linear,
+    Exponential,
+}
+
+pub(in crate::endpoint_engine) fn parse_duration(value: &str) -> Result<Duration> {
+    let trimmed = value.trim();
+    if let Some(ms) = trimmed.strip_suffix("ms") {
+        let amount = u64::from_str(ms.trim()).context("invalid ms")?;
+        return Ok(Duration::from_millis(amount));
+    }
+    if let Some(sec) = trimmed.strip_suffix('s') {
+        let amount = u64::from_str(sec.trim()).context("invalid s")?;
+        return Ok(Duration::from_secs(amount));
+    }
+    Err(anyhow!("invalid duration: {}", value))
+}
+
+pub(in crate::endpoint_engine) fn compile_retry(
+    raw: Option<&NetworkRetry>,
+) -> Result<Option<RetryConfig>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let max = raw.max.unwrap_or(0);
+    if max == 0 {
+        return Ok(None);
+    }
+    let backoff = match raw.backoff.as_deref().unwrap_or("fixed") {
+        "fixed" => RetryBackoff::Fixed,
+        "linear" => RetryBackoff::Linear,
+        "exponential" => RetryBackoff::Exponential,
+        other => return Err(anyhow!("invalid retry backoff: {}", other)),
+    };
+    let initial_delay = match raw.initial_delay.as_deref() {
+        Some(value) => parse_duration(value)?,
+        None => Duration::from_millis(100),
+    };
+    Ok(Some(RetryConfig {
+        max,
+        backoff,
+        initial_delay,
+    }))
+}
+
+impl RetryConfig {
+    pub(in crate::endpoint_engine) fn delay_for(&self, attempt: u32) -> Duration {
+        let factor = attempt.saturating_add(1);
+        match self.backoff {
+            RetryBackoff::Fixed => self.initial_delay,
+            RetryBackoff::Linear => self
+                .initial_delay
+                .checked_mul(factor)
+                .unwrap_or(Duration::MAX),
+            RetryBackoff::Exponential => {
+                let exp = 2u32.saturating_pow(attempt);
+                self.initial_delay.checked_mul(exp).unwrap_or(Duration::MAX)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move network retry DTO/config, duration parsing, and retry compile helpers into network_rule/retry.rs
- keep network_rule.rs focused on network rule DTOs and compile orchestration
- preserve retry defaults, delay semantics, validation access, runtime retry behavior, and trace metadata

## Verification
- cargo fmt
- cargo test -p rulemorph_endpoint compile_retry -- --test-threads=1
- cargo test -p rulemorph_endpoint compile_network_rule_rejects_zero_timeout -- --test-threads=1
- cargo test -p rulemorph_endpoint validate_rules_dir_network_header_expr_error -- --test-threads=1
- cargo test -p rulemorph_endpoint network -- --test-threads=1
- cargo test -p rulemorph_endpoint -- --test-threads=1
- cargo test -p rulemorph_server --test cloud_scenarios -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD

## Contract
- No behavior changes
- No trace JSON schema changes
- No public API/export changes
- No transform semantics changes
- No CLI/MCP/HTTP contract changes
- No docs/specs changes