### PR TITLE
Refactor endpoint trace step nodes

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/tests/trace_graph/endpoint.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/tests/trace_graph/endpoint.rs
@@ -1,2 +1,3 @@
 include!("endpoint/status_path.rs");
 include!("endpoint/branch.rs");
+include!("endpoint/steps.rs");

--- a/crates/rulemorph_endpoint/src/endpoint_engine/tests/trace_graph/endpoint/steps.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/tests/trace_graph/endpoint/steps.rs
@@ -1,0 +1,71 @@
+#[test]
+fn trace_step_record_when_false_is_skipped_with_meta() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+steps:
+  - record_when:
+      eq: ["@input.kind", "allowed"]
+  - mappings:
+      - target: result
+        value: "kept"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let record = json!({ "kind": "blocked" });
+    let trace = build_rule_nodes_from_rule(&rule, &record, None, Path::new("."));
+    let node = trace.nodes.first().expect("record_when node");
+
+    assert_eq!(node.get("kind"), Some(&json!("record_when")));
+    assert_eq!(node.get("status"), Some(&json!("skipped")));
+    assert_eq!(node.get("output"), Some(&json!(null)));
+    assert_eq!(
+        node.get("meta")
+            .and_then(|meta| meta.get("record_when"))
+            .and_then(|value| value.as_bool()),
+        Some(false)
+    );
+}
+
+#[test]
+fn trace_step_assert_failure_records_error_and_asserts_meta() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+steps:
+  - asserts:
+      - when:
+          eq: ["@input.kind", "allowed"]
+        error:
+          code: NOT_ALLOWED
+          message: blocked kind
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let record = json!({ "kind": "blocked" });
+    let trace = build_rule_nodes_from_rule(&rule, &record, None, Path::new("."));
+    let node = trace.nodes.first().expect("assert node");
+
+    assert_eq!(node.get("kind"), Some(&json!("asserts")));
+    assert_eq!(node.get("status"), Some(&json!("error")));
+    assert_eq!(
+        node.get("meta")
+            .and_then(|meta| meta.get("asserts_ok"))
+            .and_then(|value| value.as_bool()),
+        Some(false)
+    );
+    assert_eq!(
+        node.get("error").and_then(|error| error.get("code")),
+        Some(&json!("AssertionFailed"))
+    );
+    assert_eq!(
+        node.get("error").and_then(|error| error.get("message")),
+        Some(&json!("assert failed: NOT_ALLOWED: blocked kind"))
+    );
+    assert_eq!(
+        node.get("error").and_then(|error| error.get("path")),
+        Some(&json!("steps[0].asserts[0]"))
+    );
+}

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/steps.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/steps.rs
@@ -1,13 +1,16 @@
 use std::path::Path;
 
 use rulemorph::{RuleFile, TransformError, TransformErrorKind};
-use serde_json::{Map as JsonMap, Value as JsonValue, json};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
-use super::branch_trace::apply_branch_trace_meta;
+use self::conditions::{apply_asserts_meta, apply_branch_meta, apply_record_when_meta};
+use self::node::{build_step_node, step_kind, step_label};
 use super::step_outputs::collect_step_outputs;
 use super::transform_error_to_trace;
-use crate::endpoint_engine::trace_graph::condition::eval_trace_condition;
 use crate::endpoint_engine::trace_graph::mapping_ops::build_mapping_ops_with_values;
+
+mod conditions;
+mod node;
 
 pub(super) fn build_step_nodes(
     rule: &RuleFile,
@@ -25,27 +28,13 @@ pub(super) fn build_step_nodes(
     let mut halted = false;
     let mut prev_elapsed = 0u64;
     for (index, step) in steps.iter().enumerate() {
-        let label = step
-            .name
-            .clone()
-            .unwrap_or_else(|| format!("step-{}", index + 1));
-        let kind = if step.branch.is_some() {
-            "branch"
-        } else if step.record_when.is_some() {
-            "record_when"
-        } else if step.asserts.is_some() {
-            "asserts"
-        } else if step.mappings.is_some() {
-            "mappings"
-        } else {
-            "step"
-        };
+        let label = step_label(rule, index);
+        let kind = step_kind(rule, index);
 
         let step_input = prev_output.clone();
         let mut status = "ok".to_string();
         let mut output_value: Option<JsonValue> = None;
         let mut error: Option<JsonValue> = None;
-        let mut child_trace: Option<JsonValue> = None;
         let mut meta = JsonMap::new();
 
         let step_active = !halted;
@@ -83,112 +72,43 @@ pub(super) fn build_step_nodes(
             }
         }
 
-        if step_active && status != "error" {
-            if let Some(expr) = step.record_when.as_ref() {
-                match eval_trace_condition(
-                    expr,
-                    record,
-                    context,
-                    &step_input,
-                    "record_when",
-                    rule.version,
-                ) {
-                    Ok(flag) => {
-                        meta.insert("record_when".to_string(), JsonValue::Bool(flag));
-                    }
-                    Err(err) => {
-                        status = "error".to_string();
-                        error = Some(transform_error_to_trace(&err));
-                        halted = true;
-                    }
-                }
-            }
-        }
-
-        if step_active && status != "error" {
-            if let Some(asserts) = step.asserts.as_ref() {
-                let mut asserts_ok = true;
-                for (assert_index, assert) in asserts.iter().enumerate() {
-                    let assert_path = format!("steps[{}].asserts[{}].when", index, assert_index);
-                    match eval_trace_condition(
-                        &assert.when,
-                        record,
-                        context,
-                        &step_input,
-                        &assert_path,
-                        rule.version,
-                    ) {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            asserts_ok = false;
-                            let err = TransformError::new(
-                                TransformErrorKind::AssertionFailed,
-                                format!(
-                                    "assert failed: {}: {}",
-                                    assert.error.code, assert.error.message
-                                ),
-                            )
-                            .with_path(format!("steps[{}].asserts[{}]", index, assert_index));
-                            status = "error".to_string();
-                            error = Some(transform_error_to_trace(&err));
-                            halted = true;
-                            break;
-                        }
-                        Err(err) => {
-                            asserts_ok = false;
-                            status = "error".to_string();
-                            error = Some(transform_error_to_trace(&err));
-                            halted = true;
-                            break;
-                        }
-                    }
-                }
-                meta.insert("asserts_ok".to_string(), JsonValue::Bool(asserts_ok));
-            }
-        }
-        if step.asserts.is_some() && !meta.contains_key("asserts_ok") {
-            meta.insert("asserts_ok".to_string(), JsonValue::Bool(false));
-        }
-
-        if step_active && status != "error" {
-            if let Some(branch) = step.branch.as_ref() {
-                let branch_taken = match eval_trace_condition(
-                    &branch.when,
-                    record,
-                    context,
-                    &step_input,
-                    "branch.when",
-                    rule.version,
-                ) {
-                    Ok(true) => "then",
-                    Ok(false) => {
-                        if branch.r#else.is_some() {
-                            "else"
-                        } else {
-                            "none"
-                        }
-                    }
-                    Err(err) => {
-                        status = "error".to_string();
-                        error = Some(transform_error_to_trace(&err));
-                        halted = true;
-                        "none"
-                    }
-                };
-                if branch.return_ && branch_taken != "none" {
-                    halted = true;
-                }
-                child_trace = apply_branch_trace_meta(
-                    &branch.then,
-                    branch.r#else.as_deref(),
-                    branch_taken,
-                    base_dir,
-                    &step_input,
-                    context,
-                    &mut meta,
-                );
-            }
-        }
+        apply_record_when_meta(
+            rule,
+            index,
+            record,
+            context,
+            &step_input,
+            step_active,
+            &mut status,
+            &mut error,
+            &mut halted,
+            &mut meta,
+        );
+        apply_asserts_meta(
+            rule,
+            index,
+            record,
+            context,
+            &step_input,
+            step_active,
+            &mut status,
+            &mut error,
+            &mut halted,
+            &mut meta,
+        );
+        let child_trace = apply_branch_meta(
+            rule,
+            index,
+            record,
+            context,
+            base_dir,
+            &step_input,
+            step_active,
+            &mut status,
+            &mut error,
+            &mut halted,
+            &mut meta,
+        );
 
         let children = if status == "ok" {
             if let Some(mappings) = step.mappings.as_deref() {
@@ -208,36 +128,19 @@ pub(super) fn build_step_nodes(
             Vec::new()
         };
 
-        let mut node = json!({
-            "id": format!("step-{}", index),
-            "kind": kind,
-            "label": label,
-            "status": status,
-            "input": step_input,
-            "output": output_value,
-            "duration_us": step_duration_us,
-        });
-        if let Some(err) = error {
-            if let Some(obj) = node.as_object_mut() {
-                obj.insert("error".to_string(), err);
-            }
-        }
-        if let Some(trace) = child_trace {
-            if let Some(obj) = node.as_object_mut() {
-                obj.insert("child_trace".to_string(), trace);
-            }
-        }
-        if !meta.is_empty() {
-            if let Some(obj) = node.as_object_mut() {
-                obj.insert("meta".to_string(), JsonValue::Object(meta));
-            }
-        }
-        if !children.is_empty() {
-            if let Some(obj) = node.as_object_mut() {
-                obj.insert("children".to_string(), JsonValue::Array(children));
-            }
-        }
-        nodes.push(node);
+        nodes.push(build_step_node(
+            index,
+            kind,
+            label,
+            status,
+            step_input,
+            output_value,
+            step_duration_us,
+            error,
+            child_trace,
+            meta,
+            children,
+        ));
     }
     nodes
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/steps/conditions.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/steps/conditions.rs
@@ -1,0 +1,179 @@
+use std::path::Path;
+
+use rulemorph::{RuleFile, TransformError, TransformErrorKind};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use super::super::branch_trace::apply_branch_trace_meta;
+use super::super::transform_error_to_trace;
+use crate::endpoint_engine::trace_graph::condition::eval_trace_condition;
+
+pub(super) fn apply_record_when_meta(
+    rule: &RuleFile,
+    step_index: usize,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    step_input: &JsonValue,
+    step_active: bool,
+    status: &mut String,
+    error: &mut Option<JsonValue>,
+    halted: &mut bool,
+    meta: &mut JsonMap<String, JsonValue>,
+) {
+    if !step_active || status == "error" {
+        return;
+    }
+    let Some(expr) = rule
+        .steps
+        .as_deref()
+        .and_then(|steps| steps.get(step_index))
+        .and_then(|step| step.record_when.as_ref())
+    else {
+        return;
+    };
+
+    match eval_trace_condition(
+        expr,
+        record,
+        context,
+        step_input,
+        "record_when",
+        rule.version,
+    ) {
+        Ok(flag) => {
+            meta.insert("record_when".to_string(), JsonValue::Bool(flag));
+        }
+        Err(err) => {
+            *status = "error".to_string();
+            *error = Some(transform_error_to_trace(&err));
+            *halted = true;
+        }
+    }
+}
+
+pub(super) fn apply_asserts_meta(
+    rule: &RuleFile,
+    step_index: usize,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    step_input: &JsonValue,
+    step_active: bool,
+    status: &mut String,
+    error: &mut Option<JsonValue>,
+    halted: &mut bool,
+    meta: &mut JsonMap<String, JsonValue>,
+) {
+    let Some(asserts) = rule
+        .steps
+        .as_deref()
+        .and_then(|steps| steps.get(step_index))
+        .and_then(|step| step.asserts.as_ref())
+    else {
+        return;
+    };
+
+    if !step_active || status == "error" {
+        meta.entry("asserts_ok".to_string())
+            .or_insert(JsonValue::Bool(false));
+        return;
+    }
+
+    let mut asserts_ok = true;
+    for (assert_index, assert) in asserts.iter().enumerate() {
+        let assert_path = format!("steps[{}].asserts[{}].when", step_index, assert_index);
+        match eval_trace_condition(
+            &assert.when,
+            record,
+            context,
+            step_input,
+            &assert_path,
+            rule.version,
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                asserts_ok = false;
+                let err = TransformError::new(
+                    TransformErrorKind::AssertionFailed,
+                    format!(
+                        "assert failed: {}: {}",
+                        assert.error.code, assert.error.message
+                    ),
+                )
+                .with_path(format!("steps[{}].asserts[{}]", step_index, assert_index));
+                *status = "error".to_string();
+                *error = Some(transform_error_to_trace(&err));
+                *halted = true;
+                break;
+            }
+            Err(err) => {
+                asserts_ok = false;
+                *status = "error".to_string();
+                *error = Some(transform_error_to_trace(&err));
+                *halted = true;
+                break;
+            }
+        }
+    }
+    meta.insert("asserts_ok".to_string(), JsonValue::Bool(asserts_ok));
+}
+
+pub(super) fn apply_branch_meta(
+    rule: &RuleFile,
+    step_index: usize,
+    record: &JsonValue,
+    context: Option<&JsonValue>,
+    base_dir: &Path,
+    step_input: &JsonValue,
+    step_active: bool,
+    status: &mut String,
+    error: &mut Option<JsonValue>,
+    halted: &mut bool,
+    meta: &mut JsonMap<String, JsonValue>,
+) -> Option<JsonValue> {
+    if !step_active || status == "error" {
+        return None;
+    }
+    let Some(branch) = rule
+        .steps
+        .as_deref()
+        .and_then(|steps| steps.get(step_index))
+        .and_then(|step| step.branch.as_ref())
+    else {
+        return None;
+    };
+
+    let branch_taken = match eval_trace_condition(
+        &branch.when,
+        record,
+        context,
+        step_input,
+        "branch.when",
+        rule.version,
+    ) {
+        Ok(true) => "then",
+        Ok(false) => {
+            if branch.r#else.is_some() {
+                "else"
+            } else {
+                "none"
+            }
+        }
+        Err(err) => {
+            *status = "error".to_string();
+            *error = Some(transform_error_to_trace(&err));
+            *halted = true;
+            "none"
+        }
+    };
+    if branch.return_ && branch_taken != "none" {
+        *halted = true;
+    }
+    apply_branch_trace_meta(
+        &branch.then,
+        branch.r#else.as_deref(),
+        branch_taken,
+        base_dir,
+        step_input,
+        context,
+        meta,
+    )
+}

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/steps/node.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/rule_nodes/steps/node.rs
@@ -1,0 +1,76 @@
+use rulemorph::RuleFile;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+
+pub(super) fn step_label(rule: &RuleFile, step_index: usize) -> String {
+    rule.steps
+        .as_deref()
+        .and_then(|steps| steps.get(step_index))
+        .and_then(|step| step.name.clone())
+        .unwrap_or_else(|| format!("step-{}", step_index + 1))
+}
+
+pub(super) fn step_kind(rule: &RuleFile, step_index: usize) -> &'static str {
+    let Some(step) = rule
+        .steps
+        .as_deref()
+        .and_then(|steps| steps.get(step_index))
+    else {
+        return "step";
+    };
+    if step.branch.is_some() {
+        "branch"
+    } else if step.record_when.is_some() {
+        "record_when"
+    } else if step.asserts.is_some() {
+        "asserts"
+    } else if step.mappings.is_some() {
+        "mappings"
+    } else {
+        "step"
+    }
+}
+
+pub(super) fn build_step_node(
+    step_index: usize,
+    kind: &'static str,
+    label: String,
+    status: String,
+    input: JsonValue,
+    output: Option<JsonValue>,
+    duration_us: u64,
+    error: Option<JsonValue>,
+    child_trace: Option<JsonValue>,
+    meta: JsonMap<String, JsonValue>,
+    children: Vec<JsonValue>,
+) -> JsonValue {
+    let mut node = json!({
+        "id": format!("step-{}", step_index),
+        "kind": kind,
+        "label": label,
+        "status": status,
+        "input": input,
+        "output": output,
+        "duration_us": duration_us,
+    });
+    if let Some(err) = error
+        && let Some(obj) = node.as_object_mut()
+    {
+        obj.insert("error".to_string(), err);
+    }
+    if let Some(trace) = child_trace
+        && let Some(obj) = node.as_object_mut()
+    {
+        obj.insert("child_trace".to_string(), trace);
+    }
+    if !meta.is_empty()
+        && let Some(obj) = node.as_object_mut()
+    {
+        obj.insert("meta".to_string(), JsonValue::Object(meta));
+    }
+    if !children.is_empty()
+        && let Some(obj) = node.as_object_mut()
+    {
+        obj.insert("children".to_string(), JsonValue::Array(children));
+    }
+    node
+}


### PR DESCRIPTION
## Summary
- add characterization coverage for endpoint trace record_when skip metadata and assert failure error metadata
- split endpoint trace step condition/meta handling into private helpers
- split step node label/kind and JSON assembly into a private helper module

## Verification
- cargo fmt
- cargo test -p rulemorph_endpoint trace_step_record_when_false_is_skipped_with_meta -- --test-threads=1
- cargo test -p rulemorph_endpoint trace_step_assert_failure_records_error_and_asserts_meta -- --test-threads=1
- cargo test -p rulemorph_endpoint rule_nodes_include_step_duration_us -- --test-threads=1
- cargo test -p rulemorph_endpoint endpoint_trace_branch_step_includes_rule_refs_and_child_trace -- --test-threads=1
- cargo test -p rulemorph_endpoint mapping_ops_include_duration_us -- --test-threads=1
- cargo test -p rulemorph_endpoint finalize_trace_includes_operation_nodes_in_order -- --test-threads=1
- cargo test -p rulemorph_endpoint -- --test-threads=1
- cargo test -p rulemorph_server --test cloud_scenarios -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD