### PR TITLE
Refactor trace store manifest detail state

### DIFF
--- a/crates/rulemorph_trace/src/trace_store/manifest_trace.rs
+++ b/crates/rulemorph_trace/src/trace_store/manifest_trace.rs
@@ -11,7 +11,9 @@ use super::chunk_read::{
 use super::manifest_budget::resolve_max_chunk_bytes;
 use crate::trace_schema::{TRACE_NODE_COUNT_HARD_MAX, TRACE_RECORD_COUNT_HARD_MAX, TraceManifest};
 
+mod detail_state;
 mod nodes;
+use detail_state::{attach_empty_records, downgrade_chunk_error_detail, strip_non_full_detail};
 use nodes::attach_node_chunks;
 
 fn build_trace_from_manifest(manifest: &TraceManifest, base_dir: &Path) -> Result<Value> {
@@ -30,31 +32,18 @@ pub(super) fn build_trace_from_manifest_with_budget(
     let detail = match &manifest.detail {
         Some(detail) => detail,
         None => {
-            if let Some(obj) = trace.as_object_mut() {
-                obj.insert("records".to_string(), Value::Array(Vec::new()));
-            }
+            attach_empty_records(&mut trace);
             return Ok(trace);
         }
     };
 
     if detail.status != "full" {
-        if let Some(obj) = trace.as_object_mut() {
-            obj.insert("records".to_string(), Value::Array(Vec::new()));
-            obj.remove("finalize");
-            if let Some(detail_obj) = obj
-                .get_mut("detail")
-                .and_then(|value| value.as_object_mut())
-            {
-                detail_obj.insert("records".to_string(), Value::Array(Vec::new()));
-                detail_obj.insert("nodes".to_string(), Value::Array(Vec::new()));
-                detail_obj.remove("finalize");
-            }
-        }
+        strip_non_full_detail(&mut trace);
         return Ok(trace);
     }
 
-    let mut detail_status = detail.status.clone();
-    let mut detail_reason = detail.reason.clone();
+    let detail_status = detail.status.clone();
+    let detail_reason = detail.reason.clone();
     let mut chunk_error = false;
     let mut budget_exceeded = false;
     let mut size_exceeded = false;
@@ -181,41 +170,13 @@ pub(super) fn build_trace_from_manifest_with_budget(
             obj.insert("finalize".to_string(), finalize_value);
         }
         if chunk_error {
-            if detail_status == "full" {
-                detail_status = "basic".to_string();
-            }
-            if size_exceeded
-                && !detail_reason
-                    .iter()
-                    .any(|reason| reason == "chunk_too_large")
-            {
-                detail_reason.push("chunk_too_large".to_string());
-            }
-            if budget_exceeded
-                && !detail_reason
-                    .iter()
-                    .any(|reason| reason == "budget_exceeded")
-            {
-                detail_reason.push("budget_exceeded".to_string());
-            }
-            if !detail_reason.iter().any(|reason| reason == "chunk_error") {
-                detail_reason.push("chunk_error".to_string());
-            }
-            obj.insert("records".to_string(), Value::Array(Vec::new()));
-            obj.remove("finalize");
-            if let Some(detail_obj) = obj
-                .get_mut("detail")
-                .and_then(|value| value.as_object_mut())
-            {
-                detail_obj.insert("status".to_string(), Value::String(detail_status));
-                detail_obj.insert(
-                    "reason".to_string(),
-                    Value::Array(detail_reason.into_iter().map(Value::String).collect()),
-                );
-                detail_obj.insert("records".to_string(), Value::Array(Vec::new()));
-                detail_obj.insert("nodes".to_string(), Value::Array(Vec::new()));
-                detail_obj.remove("finalize");
-            }
+            downgrade_chunk_error_detail(
+                &mut trace,
+                detail_status,
+                detail_reason,
+                size_exceeded,
+                budget_exceeded,
+            );
         }
     }
 

--- a/crates/rulemorph_trace/src/trace_store/manifest_trace/detail_state.rs
+++ b/crates/rulemorph_trace/src/trace_store/manifest_trace/detail_state.rs
@@ -1,0 +1,67 @@
+use serde_json::Value;
+
+pub(super) fn attach_empty_records(trace: &mut Value) {
+    if let Some(obj) = trace.as_object_mut() {
+        obj.insert("records".to_string(), Value::Array(Vec::new()));
+    }
+}
+
+pub(super) fn strip_non_full_detail(trace: &mut Value) {
+    if let Some(obj) = trace.as_object_mut() {
+        obj.insert("records".to_string(), Value::Array(Vec::new()));
+        obj.remove("finalize");
+        if let Some(detail_obj) = obj
+            .get_mut("detail")
+            .and_then(|value| value.as_object_mut())
+        {
+            strip_detail_chunks(detail_obj);
+        }
+    }
+}
+
+pub(super) fn downgrade_chunk_error_detail(
+    trace: &mut Value,
+    mut detail_status: String,
+    mut detail_reason: Vec<String>,
+    size_exceeded: bool,
+    budget_exceeded: bool,
+) {
+    if detail_status == "full" {
+        detail_status = "basic".to_string();
+    }
+    if size_exceeded {
+        push_reason_once(&mut detail_reason, "chunk_too_large");
+    }
+    if budget_exceeded {
+        push_reason_once(&mut detail_reason, "budget_exceeded");
+    }
+    push_reason_once(&mut detail_reason, "chunk_error");
+
+    if let Some(obj) = trace.as_object_mut() {
+        obj.insert("records".to_string(), Value::Array(Vec::new()));
+        obj.remove("finalize");
+        if let Some(detail_obj) = obj
+            .get_mut("detail")
+            .and_then(|value| value.as_object_mut())
+        {
+            detail_obj.insert("status".to_string(), Value::String(detail_status));
+            detail_obj.insert(
+                "reason".to_string(),
+                Value::Array(detail_reason.into_iter().map(Value::String).collect()),
+            );
+            strip_detail_chunks(detail_obj);
+        }
+    }
+}
+
+fn strip_detail_chunks(obj: &mut serde_json::Map<String, Value>) {
+    obj.insert("records".to_string(), Value::Array(Vec::new()));
+    obj.insert("nodes".to_string(), Value::Array(Vec::new()));
+    obj.remove("finalize");
+}
+
+fn push_reason_once(reasons: &mut Vec<String>, reason: &str) {
+    if !reasons.iter().any(|current| current == reason) {
+        reasons.push(reason.to_string());
+    }
+}


### PR DESCRIPTION
## Summary
- move manifest detail empty/downgrade JSON mutation into a private helper module
- keep chunk read, budget, path, node attach, and finalize loading order unchanged
- preserve detail status/reason ordering and stripping of records/nodes/finalize on downgrade

## Verification
- cargo fmt
- cargo test -p rulemorph_trace trace_store_downgrades_detail_on_oversized_chunk -- --test-threads=1
- cargo test -p rulemorph_trace trace_store_downgrades_on_total_bytes_budget -- --test-threads=1
- cargo test -p rulemorph_trace --test trace_store trace_store_downgrades_on_invalid_ndjson -- --test-threads=1
- cargo test -p rulemorph_trace --test trace_store trace_store_downgrades_on_node_count_limit -- --test-threads=1
- cargo test -p rulemorph_trace --test trace_store -- --test-threads=1
- cargo test -p rulemorph_trace --test trace_writer write_trace_bundle_masks_rule_source_when_basic -- --test-threads=1
- cargo test -p rulemorph_trace -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD

Note: full rulemorph_trace initially caught a detail.finalize regression during helper extraction; fixed before commit and re-run green.