### PR TITLE
Refactor MCP Java DTO parser

### DIFF
--- a/crates/rulemorph_mcp/src/dto_parse/jvm/java.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/jvm/java.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
 use crate::dto_normalize::normalize_java_text;
-use crate::dto_schema::{DtoField, DtoFieldType, DtoType, PrimitiveKind};
+use crate::dto_schema::{DtoField, DtoType};
 
 use super::strip_leading_annotations;
+
+mod declaration;
+mod field;
 
 pub(in crate::dto_parse) fn parse_java_types(
     text: &str,
@@ -23,22 +26,8 @@ pub(in crate::dto_parse) fn parse_java_types(
         }
 
         if line.contains(" class ") || line.starts_with("class ") {
-            let name_part = if let Some(idx) = line.find("class ") {
-                &line[idx + 6..]
-            } else {
-                line
-            };
-            let name = name_part
-                .split(|ch: char| ch.is_whitespace() || ch == '{' || ch == '(')
-                .next()
-                .unwrap_or("")
-                .trim();
-            if !name.is_empty() {
-                current = Some(name.to_string());
-                types
-                    .entry(name.to_string())
-                    .or_insert_with(|| DtoType { fields: Vec::new() });
-                order.push(name.to_string());
+            if let Some(name) = declaration::class_name(line) {
+                begin_java_type(&mut types, &mut order, &mut current, &name);
             }
             record_param_depth = 0;
             pending_json_key = None;
@@ -47,22 +36,8 @@ pub(in crate::dto_parse) fn parse_java_types(
         }
 
         if line.contains(" record ") || line.starts_with("record ") {
-            let name_part = if let Some(idx) = line.find("record ") {
-                &line[idx + 7..]
-            } else {
-                line
-            };
-            let name = name_part
-                .split(|ch: char| ch.is_whitespace() || ch == '{' || ch == '(')
-                .next()
-                .unwrap_or("")
-                .trim();
-            if !name.is_empty() {
-                current = Some(name.to_string());
-                types
-                    .entry(name.to_string())
-                    .or_insert_with(|| DtoType { fields: Vec::new() });
-                order.push(name.to_string());
+            if let Some(name) = declaration::record_name(line) {
+                begin_java_type(&mut types, &mut order, &mut current, &name);
                 if let Some(paren_pos) = line.find('(') {
                     record_param_depth = 1;
                     line = line[paren_pos + 1..].trim();
@@ -135,6 +110,19 @@ pub(in crate::dto_parse) fn parse_java_types(
     Ok((types, order))
 }
 
+fn begin_java_type(
+    types: &mut HashMap<String, DtoType>,
+    order: &mut Vec<String>,
+    current: &mut Option<String>,
+    name: &str,
+) {
+    *current = Some(name.to_string());
+    types
+        .entry(name.to_string())
+        .or_insert_with(|| DtoType { fields: Vec::new() });
+    order.push(name.to_string());
+}
+
 fn parse_java_field_line(
     line: &str,
     current_name: &str,
@@ -142,83 +130,19 @@ fn parse_java_field_line(
     pending_json_key: &mut Option<String>,
     pending_optional: &mut bool,
 ) {
-    let mut cleaned = line;
-    if let Some(comment_pos) = cleaned.find("//") {
-        cleaned = cleaned[..comment_pos].trim();
-    }
-    cleaned = cleaned.split('=').next().unwrap_or(cleaned).trim();
-    cleaned = cleaned.trim_end_matches(';').trim();
-    cleaned = cleaned.trim_end_matches(',').trim();
-    if cleaned.is_empty() {
-        return;
-    }
-
-    let modifiers = [
-        "public",
-        "private",
-        "protected",
-        "static",
-        "final",
-        "transient",
-        "volatile",
-    ];
-    let mut rest = cleaned;
-    loop {
-        let mut stripped = None;
-        for modifier in modifiers {
-            if rest.starts_with(modifier) {
-                let after = rest[modifier.len()..].trim_start();
-                if after.len() != rest.len() {
-                    stripped = Some(after);
-                    break;
-                }
-            }
-        }
-        if let Some(value) = stripped {
-            rest = value;
-            continue;
-        }
-        break;
-    }
-
-    let Some(split_pos) = rest.rfind(|ch: char| ch.is_whitespace()) else {
+    let Some(field) = field::parse_field_line(line, *pending_optional) else {
         return;
     };
-    let type_part = rest[..split_pos].trim();
-    let field_name = rest[split_pos..].trim();
-    if field_name.is_empty() || type_part.is_empty() {
-        return;
-    }
-
-    let optional = *pending_optional || type_part.replace(' ', "").contains("Optional<");
     *pending_optional = false;
-
-    let type_key = type_part
-        .rsplit('.')
-        .next()
-        .unwrap_or(type_part)
-        .trim()
-        .trim_end_matches('>');
-    let type_key = type_key.rsplit('<').next().unwrap_or(type_key).trim();
-    let field_type = match type_key {
-        "String" => DtoFieldType::Primitive(PrimitiveKind::String),
-        "boolean" | "Boolean" => DtoFieldType::Primitive(PrimitiveKind::Bool),
-        "byte" | "short" | "int" | "long" | "Byte" | "Short" | "Integer" | "Long" => {
-            DtoFieldType::Primitive(PrimitiveKind::Int)
-        }
-        "float" | "double" | "Float" | "Double" => DtoFieldType::Primitive(PrimitiveKind::Float),
-        "" => DtoFieldType::Unknown,
-        other => DtoFieldType::Object(other.to_string()),
-    };
 
     let json_key = pending_json_key
         .take()
-        .unwrap_or_else(|| field_name.to_string());
+        .unwrap_or_else(|| field.name.to_string());
     if let Some(dto_type) = types.get_mut(current_name) {
         dto_type.fields.push(DtoField {
             json_key,
-            field_type,
-            optional,
+            field_type: field.field_type,
+            optional: field.optional,
         });
     }
 }

--- a/crates/rulemorph_mcp/src/dto_parse/jvm/java/declaration.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/jvm/java/declaration.rs
@@ -1,0 +1,25 @@
+pub(super) fn class_name(line: &str) -> Option<String> {
+    declaration_name(line, "class ")
+}
+
+pub(super) fn record_name(line: &str) -> Option<String> {
+    declaration_name(line, "record ")
+}
+
+fn declaration_name(line: &str, keyword: &str) -> Option<String> {
+    let name_part = if let Some(idx) = line.find(keyword) {
+        &line[idx + keyword.len()..]
+    } else {
+        line
+    };
+    let name = name_part
+        .split(|ch: char| ch.is_whitespace() || ch == '{' || ch == '(')
+        .next()
+        .unwrap_or("")
+        .trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}

--- a/crates/rulemorph_mcp/src/dto_parse/jvm/java/field.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/jvm/java/field.rs
@@ -1,0 +1,93 @@
+use crate::dto_schema::{DtoFieldType, PrimitiveKind};
+
+pub(super) struct ParsedJavaField {
+    pub(super) name: String,
+    pub(super) field_type: DtoFieldType,
+    pub(super) optional: bool,
+}
+
+pub(super) fn parse_field_line(line: &str, pending_optional: bool) -> Option<ParsedJavaField> {
+    let cleaned = clean_field_line(line)?;
+    let rest = strip_modifiers(cleaned);
+    let (type_part, field_name) = split_type_and_name(rest)?;
+    Some(ParsedJavaField {
+        name: field_name.to_string(),
+        field_type: java_field_type(type_part),
+        optional: pending_optional || type_part.replace(' ', "").contains("Optional<"),
+    })
+}
+
+fn clean_field_line(line: &str) -> Option<&str> {
+    let mut cleaned = line;
+    if let Some(comment_pos) = cleaned.find("//") {
+        cleaned = cleaned[..comment_pos].trim();
+    }
+    cleaned = cleaned.split('=').next().unwrap_or(cleaned).trim();
+    cleaned = cleaned.trim_end_matches(';').trim();
+    cleaned = cleaned.trim_end_matches(',').trim();
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned)
+    }
+}
+
+fn strip_modifiers(mut rest: &str) -> &str {
+    let modifiers = [
+        "public",
+        "private",
+        "protected",
+        "static",
+        "final",
+        "transient",
+        "volatile",
+    ];
+    loop {
+        let mut stripped = None;
+        for modifier in modifiers {
+            if rest.starts_with(modifier) {
+                let after = rest[modifier.len()..].trim_start();
+                if after.len() != rest.len() {
+                    stripped = Some(after);
+                    break;
+                }
+            }
+        }
+        if let Some(value) = stripped {
+            rest = value;
+            continue;
+        }
+        return rest;
+    }
+}
+
+fn split_type_and_name(rest: &str) -> Option<(&str, &str)> {
+    let split_pos = rest.rfind(|ch: char| ch.is_whitespace())?;
+    let type_part = rest[..split_pos].trim();
+    let field_name = rest[split_pos..].trim();
+    if field_name.is_empty() || type_part.is_empty() {
+        None
+    } else {
+        Some((type_part, field_name))
+    }
+}
+
+fn java_field_type(type_part: &str) -> DtoFieldType {
+    let type_key = type_part
+        .rsplit('.')
+        .next()
+        .unwrap_or(type_part)
+        .trim()
+        .trim_end_matches('>');
+    let type_key = type_key.rsplit('<').next().unwrap_or(type_key).trim();
+    match type_key {
+        "String" => DtoFieldType::Primitive(PrimitiveKind::String),
+        "boolean" | "Boolean" => DtoFieldType::Primitive(PrimitiveKind::Bool),
+        "byte" | "short" | "int" | "long" | "Byte" | "Short" | "Integer" | "Long" => {
+            DtoFieldType::Primitive(PrimitiveKind::Int)
+        }
+        "float" | "double" | "Float" | "Double" => DtoFieldType::Primitive(PrimitiveKind::Float),
+        "" => DtoFieldType::Unknown,
+        other => DtoFieldType::Object(other.to_string()),
+    }
+}


### PR DESCRIPTION
## Summary
- split Java DTO class/record declaration extraction into a private helper module
- split Java field cleanup, modifier stripping, type mapping, and optional detection into a private helper module
- keep parse_java_types as the existing internal entrypoint and preserve MCP DTO tool behavior

## Verification
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_java_single_line_annotations -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_jvm_multiline_model_shape -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio -- --test-threads=1
- cargo test -p rulemorph_mcp -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --check origin/v0.3.1...HEAD