### PR TITLE
Refactor Excel workbook rewrite

### DIFF
--- a/crates/rulemorph/src/normalization/excel/workbook/rewrite.rs
+++ b/crates/rulemorph/src/normalization/excel/workbook/rewrite.rs
@@ -1,38 +1,16 @@
 use quick_xml::Writer as XmlWriter;
 use quick_xml::events::Event;
-use quick_xml::name::ResolveResult;
 use quick_xml::reader::NsReader;
 
 use crate::error::{TransformError, TransformErrorKind};
 
 use super::super::invalid;
-use super::OFFICE_RELATIONSHIPS_NS;
 
-enum CalamineRelationshipPrefix {
-    R,
-    Relationships,
-}
+mod event;
+mod plan;
 
-impl CalamineRelationshipPrefix {
-    fn attr_name(&self) -> &'static str {
-        match self {
-            Self::R => "r:id",
-            Self::Relationships => "relationships:id",
-        }
-    }
-
-    fn namespace_attr(&self) -> &'static str {
-        match self {
-            Self::R => "xmlns:r",
-            Self::Relationships => "xmlns:relationships",
-        }
-    }
-}
-
-struct WorkbookRewritePlan {
-    prefix: CalamineRelationshipPrefix,
-    add_namespace_attr: bool,
-}
+use self::event::rewrite_workbook_event;
+use self::plan::workbook_rewrite_plan;
 
 pub(in crate::normalization::excel) fn rewrite_workbook_for_calamine(
     workbook_xml: &str,
@@ -88,144 +66,4 @@ pub(in crate::normalization::excel) fn rewrite_workbook_for_calamine(
             err
         ))
     })
-}
-
-fn workbook_rewrite_plan(
-    workbook_xml: &str,
-) -> Result<Option<WorkbookRewritePlan>, TransformError> {
-    let mut reader = NsReader::from_str(workbook_xml);
-    reader.trim_text(false);
-    let mut needs_rewrite = false;
-    let mut r_namespace = None;
-    let mut relationships_namespace = None;
-    loop {
-        match reader.read_event() {
-            Ok(Event::Start(event)) | Ok(Event::Empty(event))
-                if event.local_name().as_ref() == b"workbook" =>
-            {
-                for attr in event.attributes() {
-                    let attr = attr.map_err(|err| {
-                        TransformError::new(
-                            TransformErrorKind::InvalidInput,
-                            format!("failed to parse Excel workbook XML attribute: {}", err),
-                        )
-                    })?;
-                    match attr.key.as_ref() {
-                        b"xmlns:r" => r_namespace = Some(attr.value.as_ref().to_vec()),
-                        b"xmlns:relationships" => {
-                            relationships_namespace = Some(attr.value.as_ref().to_vec())
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Ok(Event::Start(event)) | Ok(Event::Empty(event))
-                if event.local_name().as_ref() == b"sheet" =>
-            {
-                for attr in event.attributes() {
-                    let attr = attr.map_err(|err| {
-                        TransformError::new(
-                            TransformErrorKind::InvalidInput,
-                            format!("failed to parse Excel workbook XML attribute: {}", err),
-                        )
-                    })?;
-                    let (namespace, local_name) = reader.resolve_attribute(attr.key);
-                    if local_name.as_ref() == b"id"
-                        && matches!(
-                            namespace,
-                            ResolveResult::Bound(namespace)
-                                if namespace.as_ref() == OFFICE_RELATIONSHIPS_NS
-                        )
-                        && !is_calamine_relationship_attr(attr.key.as_ref())
-                    {
-                        needs_rewrite = true;
-                    }
-                }
-            }
-            Ok(Event::Eof) => break,
-            Ok(_) => {}
-            Err(err) => {
-                return Err(TransformError::new(
-                    TransformErrorKind::InvalidInput,
-                    format!("failed to parse Excel workbook XML: {}", err),
-                ));
-            }
-        }
-    }
-    if !needs_rewrite {
-        return Ok(None);
-    }
-
-    if r_namespace
-        .as_deref()
-        .is_none_or(|namespace| namespace == OFFICE_RELATIONSHIPS_NS)
-    {
-        return Ok(Some(WorkbookRewritePlan {
-            prefix: CalamineRelationshipPrefix::R,
-            add_namespace_attr: r_namespace.is_none(),
-        }));
-    }
-    if relationships_namespace
-        .as_deref()
-        .is_none_or(|namespace| namespace == OFFICE_RELATIONSHIPS_NS)
-    {
-        return Ok(Some(WorkbookRewritePlan {
-            prefix: CalamineRelationshipPrefix::Relationships,
-            add_namespace_attr: relationships_namespace.is_none(),
-        }));
-    }
-    Err(invalid(
-        "Excel workbook relationship namespace conflicts with supported prefixes",
-    ))
-}
-
-fn rewrite_workbook_event(
-    mut event: quick_xml::events::BytesStart<'static>,
-    reader: &NsReader<&[u8]>,
-    plan: &WorkbookRewritePlan,
-) -> Result<quick_xml::events::BytesStart<'static>, TransformError> {
-    if event.local_name().as_ref() == b"workbook" && plan.add_namespace_attr {
-        event.push_attribute((
-            plan.prefix.namespace_attr().as_bytes(),
-            OFFICE_RELATIONSHIPS_NS,
-        ));
-    }
-    if event.local_name().as_ref() != b"sheet" {
-        return Ok(event);
-    }
-
-    let mut relationship_value = None;
-    let mut has_calamine_relationship_attr = false;
-    for attr in event.attributes() {
-        let attr = attr.map_err(|err| {
-            TransformError::new(
-                TransformErrorKind::InvalidInput,
-                format!("failed to parse Excel workbook XML attribute: {}", err),
-            )
-        })?;
-        let (namespace, local_name) = reader.resolve_attribute(attr.key);
-        let is_office_relationship = matches!(
-            namespace,
-            ResolveResult::Bound(namespace) if namespace.as_ref() == OFFICE_RELATIONSHIPS_NS
-        );
-        if is_calamine_relationship_attr(attr.key.as_ref()) && !is_office_relationship {
-            return Err(invalid(
-                "Excel workbook sheet relationship uses an invalid namespace",
-            ));
-        }
-        if local_name.as_ref() == b"id" && is_office_relationship {
-            if is_calamine_relationship_attr(attr.key.as_ref()) {
-                has_calamine_relationship_attr = true;
-            }
-            relationship_value = Some(attr.value.as_ref().to_vec());
-        }
-    }
-    if !has_calamine_relationship_attr && let Some(value) = relationship_value {
-        event.push_attribute((plan.prefix.attr_name().as_bytes(), value.as_slice()));
-    }
-    Ok(event)
-}
-
-fn is_calamine_relationship_attr(name: &[u8]) -> bool {
-    matches!(name, b"r:id" | b"relationships:id")
 }

--- a/crates/rulemorph/src/normalization/excel/workbook/rewrite/event.rs
+++ b/crates/rulemorph/src/normalization/excel/workbook/rewrite/event.rs
@@ -1,0 +1,56 @@
+use quick_xml::events::BytesStart;
+use quick_xml::name::ResolveResult;
+use quick_xml::reader::NsReader;
+
+use crate::error::{TransformError, TransformErrorKind};
+
+use super::super::super::invalid;
+use super::super::OFFICE_RELATIONSHIPS_NS;
+use super::plan::{WorkbookRewritePlan, is_calamine_relationship_attr};
+
+pub(super) fn rewrite_workbook_event(
+    mut event: BytesStart<'static>,
+    reader: &NsReader<&[u8]>,
+    plan: &WorkbookRewritePlan,
+) -> Result<BytesStart<'static>, TransformError> {
+    if event.local_name().as_ref() == b"workbook" && plan.add_namespace_attr {
+        event.push_attribute((
+            plan.prefix.namespace_attr().as_bytes(),
+            OFFICE_RELATIONSHIPS_NS,
+        ));
+    }
+    if event.local_name().as_ref() != b"sheet" {
+        return Ok(event);
+    }
+
+    let mut relationship_value = None;
+    let mut has_calamine_relationship_attr = false;
+    for attr in event.attributes() {
+        let attr = attr.map_err(|err| {
+            TransformError::new(
+                TransformErrorKind::InvalidInput,
+                format!("failed to parse Excel workbook XML attribute: {}", err),
+            )
+        })?;
+        let (namespace, local_name) = reader.resolve_attribute(attr.key);
+        let is_office_relationship = matches!(
+            namespace,
+            ResolveResult::Bound(namespace) if namespace.as_ref() == OFFICE_RELATIONSHIPS_NS
+        );
+        if is_calamine_relationship_attr(attr.key.as_ref()) && !is_office_relationship {
+            return Err(invalid(
+                "Excel workbook sheet relationship uses an invalid namespace",
+            ));
+        }
+        if local_name.as_ref() == b"id" && is_office_relationship {
+            if is_calamine_relationship_attr(attr.key.as_ref()) {
+                has_calamine_relationship_attr = true;
+            }
+            relationship_value = Some(attr.value.as_ref().to_vec());
+        }
+    }
+    if !has_calamine_relationship_attr && let Some(value) = relationship_value {
+        event.push_attribute((plan.prefix.attr_name().as_bytes(), value.as_slice()));
+    }
+    Ok(event)
+}

--- a/crates/rulemorph/src/normalization/excel/workbook/rewrite/plan.rs
+++ b/crates/rulemorph/src/normalization/excel/workbook/rewrite/plan.rs
@@ -1,0 +1,127 @@
+use quick_xml::events::Event;
+use quick_xml::name::ResolveResult;
+use quick_xml::reader::NsReader;
+
+use crate::error::{TransformError, TransformErrorKind};
+
+use super::super::super::invalid;
+use super::super::OFFICE_RELATIONSHIPS_NS;
+
+pub(super) enum CalamineRelationshipPrefix {
+    R,
+    Relationships,
+}
+
+impl CalamineRelationshipPrefix {
+    pub(super) fn attr_name(&self) -> &'static str {
+        match self {
+            Self::R => "r:id",
+            Self::Relationships => "relationships:id",
+        }
+    }
+
+    pub(super) fn namespace_attr(&self) -> &'static str {
+        match self {
+            Self::R => "xmlns:r",
+            Self::Relationships => "xmlns:relationships",
+        }
+    }
+}
+
+pub(super) struct WorkbookRewritePlan {
+    pub(super) prefix: CalamineRelationshipPrefix,
+    pub(super) add_namespace_attr: bool,
+}
+
+pub(super) fn workbook_rewrite_plan(
+    workbook_xml: &str,
+) -> Result<Option<WorkbookRewritePlan>, TransformError> {
+    let mut reader = NsReader::from_str(workbook_xml);
+    reader.trim_text(false);
+    let mut needs_rewrite = false;
+    let mut r_namespace = None;
+    let mut relationships_namespace = None;
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(event)) | Ok(Event::Empty(event))
+                if event.local_name().as_ref() == b"workbook" =>
+            {
+                for attr in event.attributes() {
+                    let attr = attr.map_err(|err| {
+                        TransformError::new(
+                            TransformErrorKind::InvalidInput,
+                            format!("failed to parse Excel workbook XML attribute: {}", err),
+                        )
+                    })?;
+                    match attr.key.as_ref() {
+                        b"xmlns:r" => r_namespace = Some(attr.value.as_ref().to_vec()),
+                        b"xmlns:relationships" => {
+                            relationships_namespace = Some(attr.value.as_ref().to_vec())
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::Start(event)) | Ok(Event::Empty(event))
+                if event.local_name().as_ref() == b"sheet" =>
+            {
+                for attr in event.attributes() {
+                    let attr = attr.map_err(|err| {
+                        TransformError::new(
+                            TransformErrorKind::InvalidInput,
+                            format!("failed to parse Excel workbook XML attribute: {}", err),
+                        )
+                    })?;
+                    let (namespace, local_name) = reader.resolve_attribute(attr.key);
+                    if local_name.as_ref() == b"id"
+                        && matches!(
+                            namespace,
+                            ResolveResult::Bound(namespace)
+                                if namespace.as_ref() == OFFICE_RELATIONSHIPS_NS
+                        )
+                        && !is_calamine_relationship_attr(attr.key.as_ref())
+                    {
+                        needs_rewrite = true;
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(err) => {
+                return Err(TransformError::new(
+                    TransformErrorKind::InvalidInput,
+                    format!("failed to parse Excel workbook XML: {}", err),
+                ));
+            }
+        }
+    }
+    if !needs_rewrite {
+        return Ok(None);
+    }
+
+    if r_namespace
+        .as_deref()
+        .is_none_or(|namespace| namespace == OFFICE_RELATIONSHIPS_NS)
+    {
+        return Ok(Some(WorkbookRewritePlan {
+            prefix: CalamineRelationshipPrefix::R,
+            add_namespace_attr: r_namespace.is_none(),
+        }));
+    }
+    if relationships_namespace
+        .as_deref()
+        .is_none_or(|namespace| namespace == OFFICE_RELATIONSHIPS_NS)
+    {
+        return Ok(Some(WorkbookRewritePlan {
+            prefix: CalamineRelationshipPrefix::Relationships,
+            add_namespace_attr: relationships_namespace.is_none(),
+        }));
+    }
+    Err(invalid(
+        "Excel workbook relationship namespace conflicts with supported prefixes",
+    ))
+}
+
+pub(super) fn is_calamine_relationship_attr(name: &[u8]) -> bool {
+    matches!(name, b"r:id" | b"relationships:id")
+}


### PR DESCRIPTION
## Summary
- Split Excel workbook rewrite planning into a private plan helper module
- Split XML event rewrite mutation into a private event helper module
- Keep workbook rewrite orchestration and behavior unchanged

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden excel_accepts_sheet_relationship_with_custom_namespace_prefix -- --test-threads=1
- cargo test -p rulemorph --test transform_golden excel_rejects_literal_relationship_id_bound_to_wrong_namespace -- --test-threads=1
- cargo fmt --check
- git diff --check origin/v0.3.1...HEAD