### PR TITLE
Refactor UI app stage composition

### DIFF
--- a/crates/rulemorph_ui/ui/src/App.tsx
+++ b/crates/rulemorph_ui/ui/src/App.tsx
@@ -21,17 +21,13 @@ import {
   type TracePayload,
   type TraceRecord
 } from "./trace_payload";
-import { InspectorDrawer } from "./inspector_drawer";
-import { RecordPanel } from "./record_panel";
 import { Topbar } from "./topbar";
-import { TraceCanvas } from "./trace_canvas";
 import {
   buildOverviewGraph,
   type ApiGraphNode,
   type ApiGraphOp,
   type ApiGraphResponse
 } from "./trace_graph";
-import { TraceListPanel, ZipImportModal } from "./trace_list_panel";
 import { runZipImport } from "./zip_import";
 import {
   loadTraceList,
@@ -42,6 +38,7 @@ import { loadApiGraph, resetApiGraphSelection } from "./app_api_graph_state";
 import { loadTraceDetailForSelection } from "./app_trace_detail_state";
 import { useAuthSecretCapture, useStoredDurationUnit } from "./app_runtime";
 import { useAppGraphViewState } from "./app_graph_view_state";
+import { AppStage } from "./app_stage";
 
 export { getApiKey, getInternalKey } from "./auth";
 export { __getTenantIdFromQueryOrStorageForTest, resolveTenantId } from "./tenant";
@@ -232,110 +229,78 @@ export default function App() {
         apiEdgeCount={apiGraph?.edges.length ?? 0}
       />
 
-      <main className="stage">
-        <TraceCanvas
-          viewMode={viewMode}
-          trace={trace}
-          traceResetKey={selectedId}
-          activeGraph={activeGraph}
-          hasDetail={hasDetail}
-          apiHasDetail={apiHasDetail}
-          overviewGraph={overviewGraph}
-          expandedRuleIds={expandedRuleIds}
-          setExpandedRuleIds={setExpandedRuleIds}
-          setFocusedRuleId={setFocusedRuleId}
-          setRecordIndex={setRecordIndex}
-          setSelectedNode={setSelectedNode}
-          setSelectedOp={setSelectedOp}
-          setInspectorOpen={setInspectorOpen}
-          setTraceInspectorSections={setTraceInspectorSections}
-          detailNodeMap={detailNodeMap}
-          apiGraphNodeMap={apiGraphLayout.nodeMap}
-          apiDetailNodeMap={apiDetailNodeMap}
-          apiExpandedRuleIds={apiExpandedRuleIds}
-          setApiExpandedRuleIds={setApiExpandedRuleIds}
-          setApiFocusedRuleId={setApiFocusedRuleId}
-          setSelectedApiNode={setSelectedApiNode}
-          setSelectedApiOp={setSelectedApiOp}
-          pinnedPositions={pinnedPositions}
-          setPinnedPositions={setPinnedPositions}
-          apiPinnedPositions={apiPinnedPositions}
-          setApiPinnedPositions={setApiPinnedPositions}
-        />
-
-        {viewMode === "trace" && (
-          <TraceListPanel
-            traceListOpen={traceListOpen}
-            setTraceListOpen={setTraceListOpen}
-            internalKey={internalKey}
-            durationUnit={durationUnit}
-            setDurationUnit={setDurationUnit}
-            traceFilterQuery={traceFilterQuery}
-            setTraceFilterQuery={setTraceFilterQuery}
-            traceFilterStatus={traceFilterStatus}
-            setTraceFilterStatus={setTraceFilterStatus}
-            traceFilterRule={traceFilterRule}
-            setTraceFilterRule={setTraceFilterRule}
-            traceFilterRange={traceFilterRange}
-            setTraceFilterRange={setTraceFilterRange}
-            statusOptions={statusOptions}
-            ruleOptions={ruleOptions}
-            filteredTraces={filteredTraces}
-            traces={traces}
-            selectedId={selectedId}
-            setSelectedId={setSelectedId}
-            detailStatus={detailStatus}
-            detailError={detailError}
-            detailReason={detailReason}
-            setZipMessage={setZipMessage}
-            setZipModalOpen={setZipModalOpen}
-          />
-        )}
-
-        {hasDetail && viewMode === "trace" && (
-          <RecordPanel
-            currentTrace={currentTrace}
-            recordIndex={recordIndex}
-            setRecordIndex={setRecordIndex}
-            setSelectedNode={setSelectedNode}
-            setSelectedOp={setSelectedOp}
-            setInspectorOpen={setInspectorOpen}
-            finalizePayload={finalizePayload}
-            isFinalizeSelected={isFinalizeSelected}
-            durationUnit={durationUnit}
-          />
-        )}
-
-        <InspectorDrawer
-          inspectorOpen={inspectorOpen}
-          setInspectorOpen={setInspectorOpen}
-          viewMode={viewMode}
-          selectedNode={selectedNode}
-          selectedOp={selectedOp}
-          setSelectedOp={setSelectedOp}
-          selectedApiNode={selectedApiNode}
-          selectedApiOp={selectedApiOp}
-          traceInspectorSections={traceInspectorSections}
-          setTraceInspectorSections={setTraceInspectorSections}
-          apiInspectorSections={apiInspectorSections}
-          setApiInspectorSections={setApiInspectorSections}
-          isFinalizeSelected={isFinalizeSelected}
-          finalizePayload={finalizePayload}
-          durationUnit={durationUnit}
-        />
-        {zipModalOpen && (
-          <ZipImportModal
-            tenantId={tenantId}
-            zipMessage={zipMessage}
-            zipUploading={zipUploading}
-            zipFile={zipFile}
-            setZipFile={setZipFile}
-            setZipMessage={setZipMessage}
-            setZipModalOpen={setZipModalOpen}
-            handleZipImport={handleZipImport}
-          />
-        )}
-      </main>
+      <AppStage
+        viewMode={viewMode}
+        trace={trace}
+        traceResetKey={selectedId}
+        activeGraph={activeGraph}
+        hasDetail={hasDetail}
+        apiHasDetail={apiHasDetail}
+        overviewGraph={overviewGraph}
+        expandedRuleIds={expandedRuleIds}
+        setExpandedRuleIds={setExpandedRuleIds}
+        setFocusedRuleId={setFocusedRuleId}
+        recordIndex={recordIndex}
+        setRecordIndex={setRecordIndex}
+        selectedNode={selectedNode}
+        setSelectedNode={setSelectedNode}
+        selectedOp={selectedOp}
+        setSelectedOp={setSelectedOp}
+        inspectorOpen={inspectorOpen}
+        setInspectorOpen={setInspectorOpen}
+        traceInspectorSections={traceInspectorSections}
+        setTraceInspectorSections={setTraceInspectorSections}
+        detailNodeMap={detailNodeMap}
+        apiGraphNodeMap={apiGraphLayout.nodeMap}
+        apiDetailNodeMap={apiDetailNodeMap}
+        apiExpandedRuleIds={apiExpandedRuleIds}
+        setApiExpandedRuleIds={setApiExpandedRuleIds}
+        setApiFocusedRuleId={setApiFocusedRuleId}
+        selectedApiNode={selectedApiNode}
+        setSelectedApiNode={setSelectedApiNode}
+        selectedApiOp={selectedApiOp}
+        setSelectedApiOp={setSelectedApiOp}
+        pinnedPositions={pinnedPositions}
+        setPinnedPositions={setPinnedPositions}
+        apiPinnedPositions={apiPinnedPositions}
+        setApiPinnedPositions={setApiPinnedPositions}
+        traceListOpen={traceListOpen}
+        setTraceListOpen={setTraceListOpen}
+        internalKey={internalKey}
+        durationUnit={durationUnit}
+        setDurationUnit={setDurationUnit}
+        traceFilterQuery={traceFilterQuery}
+        setTraceFilterQuery={setTraceFilterQuery}
+        traceFilterStatus={traceFilterStatus}
+        setTraceFilterStatus={setTraceFilterStatus}
+        traceFilterRule={traceFilterRule}
+        setTraceFilterRule={setTraceFilterRule}
+        traceFilterRange={traceFilterRange}
+        setTraceFilterRange={setTraceFilterRange}
+        statusOptions={statusOptions}
+        ruleOptions={ruleOptions}
+        filteredTraces={filteredTraces}
+        traces={traces}
+        selectedId={selectedId}
+        setSelectedId={setSelectedId}
+        detailStatus={detailStatus}
+        detailError={detailError}
+        detailReason={detailReason}
+        setZipMessage={setZipMessage}
+        setZipModalOpen={setZipModalOpen}
+        currentTrace={currentTrace}
+        finalizePayload={finalizePayload}
+        isFinalizeSelected={isFinalizeSelected}
+        apiInspectorSections={apiInspectorSections}
+        setApiInspectorSections={setApiInspectorSections}
+        zipModalOpen={zipModalOpen}
+        tenantId={tenantId}
+        zipMessage={zipMessage}
+        zipUploading={zipUploading}
+        zipFile={zipFile}
+        setZipFile={setZipFile}
+        handleZipImport={handleZipImport}
+      />
     </div>
   );
 }

--- a/crates/rulemorph_ui/ui/src/app_stage.tsx
+++ b/crates/rulemorph_ui/ui/src/app_stage.tsx
@@ -1,0 +1,271 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { Edge, Node } from "reactflow";
+import { InspectorDrawer } from "./inspector_drawer";
+import type { ApiInspectorSections, TraceInspectorSections } from "./inspector_section_types";
+import { RecordPanel } from "./record_panel";
+import { TraceCanvas } from "./trace_canvas";
+import type { DurationUnit, TimeRange, TraceListItem } from "./trace_list_helpers";
+import { TraceListPanel, ZipImportModal } from "./trace_list_panel";
+import type { TraceNode, TracePayload } from "./trace_payload";
+import type {
+  ApiDetailEntry,
+  ApiGraphNode,
+  ApiGraphOp,
+  DetailEntry,
+  OverviewGraph
+} from "./trace_graph";
+
+type NodePositions = Record<string, { x: number; y: number }>;
+
+type AppStageProps = {
+  viewMode: "trace" | "api";
+  trace: TracePayload | null;
+  traceResetKey: string | null;
+  activeGraph: { nodes: Node[]; edges: Edge[] };
+  hasDetail: boolean;
+  apiHasDetail: boolean;
+  overviewGraph: OverviewGraph;
+  expandedRuleIds: string[];
+  setExpandedRuleIds: Dispatch<SetStateAction<string[]>>;
+  setFocusedRuleId: Dispatch<SetStateAction<string | null>>;
+  recordIndex: number;
+  setRecordIndex: Dispatch<SetStateAction<number>>;
+  selectedNode: TraceNode | null;
+  setSelectedNode: Dispatch<SetStateAction<TraceNode | null>>;
+  selectedOp: TraceNode | null;
+  setSelectedOp: Dispatch<SetStateAction<TraceNode | null>>;
+  inspectorOpen: boolean;
+  setInspectorOpen: Dispatch<SetStateAction<boolean>>;
+  traceInspectorSections: TraceInspectorSections;
+  setTraceInspectorSections: Dispatch<SetStateAction<TraceInspectorSections>>;
+  detailNodeMap: Map<string, DetailEntry>;
+  apiGraphNodeMap: Map<string, ApiGraphNode>;
+  apiDetailNodeMap: Map<string, ApiDetailEntry>;
+  apiExpandedRuleIds: string[];
+  setApiExpandedRuleIds: Dispatch<SetStateAction<string[]>>;
+  setApiFocusedRuleId: Dispatch<SetStateAction<string | null>>;
+  selectedApiNode: ApiGraphNode | null;
+  setSelectedApiNode: Dispatch<SetStateAction<ApiGraphNode | null>>;
+  selectedApiOp: ApiGraphOp | null;
+  setSelectedApiOp: Dispatch<SetStateAction<ApiGraphOp | null>>;
+  pinnedPositions: NodePositions;
+  setPinnedPositions: Dispatch<SetStateAction<NodePositions>>;
+  apiPinnedPositions: NodePositions;
+  setApiPinnedPositions: Dispatch<SetStateAction<NodePositions>>;
+  traceListOpen: boolean;
+  setTraceListOpen: Dispatch<SetStateAction<boolean>>;
+  internalKey: string | null;
+  durationUnit: DurationUnit;
+  setDurationUnit: Dispatch<SetStateAction<DurationUnit>>;
+  traceFilterQuery: string;
+  setTraceFilterQuery: Dispatch<SetStateAction<string>>;
+  traceFilterStatus: string;
+  setTraceFilterStatus: Dispatch<SetStateAction<string>>;
+  traceFilterRule: string;
+  setTraceFilterRule: Dispatch<SetStateAction<string>>;
+  traceFilterRange: TimeRange;
+  setTraceFilterRange: Dispatch<SetStateAction<TimeRange>>;
+  statusOptions: string[];
+  ruleOptions: string[];
+  filteredTraces: TraceListItem[];
+  traces: TraceListItem[];
+  selectedId: string | null;
+  setSelectedId: Dispatch<SetStateAction<string | null>>;
+  detailStatus?: string;
+  detailError: string | null;
+  detailReason: string[];
+  setZipMessage: Dispatch<SetStateAction<string | null>>;
+  setZipModalOpen: Dispatch<SetStateAction<boolean>>;
+  currentTrace: TracePayload | null;
+  finalizePayload: TracePayload["finalize"] | null;
+  isFinalizeSelected: boolean;
+  apiInspectorSections: ApiInspectorSections;
+  setApiInspectorSections: Dispatch<SetStateAction<ApiInspectorSections>>;
+  zipModalOpen: boolean;
+  tenantId: string | null;
+  zipMessage: string | null;
+  zipUploading: boolean;
+  zipFile: File | null;
+  setZipFile: Dispatch<SetStateAction<File | null>>;
+  handleZipImport: () => void;
+};
+
+export function AppStage({
+  viewMode,
+  trace,
+  traceResetKey,
+  activeGraph,
+  hasDetail,
+  apiHasDetail,
+  overviewGraph,
+  expandedRuleIds,
+  setExpandedRuleIds,
+  setFocusedRuleId,
+  recordIndex,
+  setRecordIndex,
+  selectedNode,
+  setSelectedNode,
+  selectedOp,
+  setSelectedOp,
+  inspectorOpen,
+  setInspectorOpen,
+  traceInspectorSections,
+  setTraceInspectorSections,
+  detailNodeMap,
+  apiGraphNodeMap,
+  apiDetailNodeMap,
+  apiExpandedRuleIds,
+  setApiExpandedRuleIds,
+  setApiFocusedRuleId,
+  selectedApiNode,
+  setSelectedApiNode,
+  selectedApiOp,
+  setSelectedApiOp,
+  pinnedPositions,
+  setPinnedPositions,
+  apiPinnedPositions,
+  setApiPinnedPositions,
+  traceListOpen,
+  setTraceListOpen,
+  internalKey,
+  durationUnit,
+  setDurationUnit,
+  traceFilterQuery,
+  setTraceFilterQuery,
+  traceFilterStatus,
+  setTraceFilterStatus,
+  traceFilterRule,
+  setTraceFilterRule,
+  traceFilterRange,
+  setTraceFilterRange,
+  statusOptions,
+  ruleOptions,
+  filteredTraces,
+  traces,
+  selectedId,
+  setSelectedId,
+  detailStatus,
+  detailError,
+  detailReason,
+  setZipMessage,
+  setZipModalOpen,
+  currentTrace,
+  finalizePayload,
+  isFinalizeSelected,
+  apiInspectorSections,
+  setApiInspectorSections,
+  zipModalOpen,
+  tenantId,
+  zipMessage,
+  zipUploading,
+  zipFile,
+  setZipFile,
+  handleZipImport
+}: AppStageProps) {
+  return (
+    <main className="stage">
+      <TraceCanvas
+        viewMode={viewMode}
+        trace={trace}
+        traceResetKey={traceResetKey}
+        activeGraph={activeGraph}
+        hasDetail={hasDetail}
+        apiHasDetail={apiHasDetail}
+        overviewGraph={overviewGraph}
+        expandedRuleIds={expandedRuleIds}
+        setExpandedRuleIds={setExpandedRuleIds}
+        setFocusedRuleId={setFocusedRuleId}
+        setRecordIndex={setRecordIndex}
+        setSelectedNode={setSelectedNode}
+        setSelectedOp={setSelectedOp}
+        setInspectorOpen={setInspectorOpen}
+        setTraceInspectorSections={setTraceInspectorSections}
+        detailNodeMap={detailNodeMap}
+        apiGraphNodeMap={apiGraphNodeMap}
+        apiDetailNodeMap={apiDetailNodeMap}
+        apiExpandedRuleIds={apiExpandedRuleIds}
+        setApiExpandedRuleIds={setApiExpandedRuleIds}
+        setApiFocusedRuleId={setApiFocusedRuleId}
+        setSelectedApiNode={setSelectedApiNode}
+        setSelectedApiOp={setSelectedApiOp}
+        pinnedPositions={pinnedPositions}
+        setPinnedPositions={setPinnedPositions}
+        apiPinnedPositions={apiPinnedPositions}
+        setApiPinnedPositions={setApiPinnedPositions}
+      />
+
+      {viewMode === "trace" && (
+        <TraceListPanel
+          traceListOpen={traceListOpen}
+          setTraceListOpen={setTraceListOpen}
+          internalKey={internalKey}
+          durationUnit={durationUnit}
+          setDurationUnit={setDurationUnit}
+          traceFilterQuery={traceFilterQuery}
+          setTraceFilterQuery={setTraceFilterQuery}
+          traceFilterStatus={traceFilterStatus}
+          setTraceFilterStatus={setTraceFilterStatus}
+          traceFilterRule={traceFilterRule}
+          setTraceFilterRule={setTraceFilterRule}
+          traceFilterRange={traceFilterRange}
+          setTraceFilterRange={setTraceFilterRange}
+          statusOptions={statusOptions}
+          ruleOptions={ruleOptions}
+          filteredTraces={filteredTraces}
+          traces={traces}
+          selectedId={selectedId}
+          setSelectedId={setSelectedId}
+          detailStatus={detailStatus}
+          detailError={detailError}
+          detailReason={detailReason}
+          setZipMessage={setZipMessage}
+          setZipModalOpen={setZipModalOpen}
+        />
+      )}
+
+      {hasDetail && viewMode === "trace" && (
+        <RecordPanel
+          currentTrace={currentTrace}
+          recordIndex={recordIndex}
+          setRecordIndex={setRecordIndex}
+          setSelectedNode={setSelectedNode}
+          setSelectedOp={setSelectedOp}
+          setInspectorOpen={setInspectorOpen}
+          finalizePayload={finalizePayload}
+          isFinalizeSelected={isFinalizeSelected}
+          durationUnit={durationUnit}
+        />
+      )}
+
+      <InspectorDrawer
+        inspectorOpen={inspectorOpen}
+        setInspectorOpen={setInspectorOpen}
+        viewMode={viewMode}
+        selectedNode={selectedNode}
+        selectedOp={selectedOp}
+        setSelectedOp={setSelectedOp}
+        selectedApiNode={selectedApiNode}
+        selectedApiOp={selectedApiOp}
+        traceInspectorSections={traceInspectorSections}
+        setTraceInspectorSections={setTraceInspectorSections}
+        apiInspectorSections={apiInspectorSections}
+        setApiInspectorSections={setApiInspectorSections}
+        isFinalizeSelected={isFinalizeSelected}
+        finalizePayload={finalizePayload}
+        durationUnit={durationUnit}
+      />
+      {zipModalOpen && (
+        <ZipImportModal
+          tenantId={tenantId}
+          zipMessage={zipMessage}
+          zipUploading={zipUploading}
+          zipFile={zipFile}
+          setZipFile={setZipFile}
+          setZipMessage={setZipMessage}
+          setZipModalOpen={setZipModalOpen}
+          handleZipImport={handleZipImport}
+        />
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## 概要
- App.tsx の stage composition を internal AppStage component に分割
- state/effects/API loading/auth/tenant/ZIP import callback は App.tsx に維持
- Trace Console/API graph/ZIP import behavior と public exports は変更なし

## 検証
- npm --prefix crates/rulemorph_ui/ui run test
- npm --prefix crates/rulemorph_ui/ui run build
- npm --prefix crates/rulemorph_ui/ui run test:e2e (sandbox 外で実行)
- browser smoke: topbar 1 / React Flow canvas 1 / ZIP import button 1 / screenshot /private/tmp/rulemorph-stage631-smoke.png
- cargo fmt --check
- git diff --check
- post-rebase: npm --prefix crates/rulemorph_ui/ui run test
- post-rebase: npm --prefix crates/rulemorph_ui/ui run build
- post-rebase: npm --prefix crates/rulemorph_ui/ui run test:e2e (sandbox 外で実行)
- post-rebase: cargo fmt --check
- post-rebase: git diff --check origin/v0.3.1...HEAD