### PR TITLE
Refactor v2 eval collection sequence

### DIFF
--- a/crates/rulemorph/src/v2_eval/collection.rs
+++ b/crates/rulemorph/src/v2_eval/collection.rs
@@ -9,11 +9,13 @@ use crate::v2_model::{V2Expr, V2OpStep};
 mod keyed;
 mod predicate;
 mod reduce_fold;
+mod sequence;
 mod sort;
 
 use keyed::eval_keyed_collection;
 use predicate::{eval_filter, eval_find, eval_find_index, eval_partition};
 use reduce_fold::{eval_fold, eval_reduce};
+use sequence::{eval_flat_map, eval_map, eval_zip_with};
 use sort::eval_sort_by;
 
 pub(super) fn eval_collection_op<'a>(
@@ -26,74 +28,9 @@ pub(super) fn eval_collection_op<'a>(
     ctx: &V2EvalContext<'a>,
 ) -> Result<EvalValue, TransformError> {
     match op_step.op.as_str() {
-        "map" => {
-            if op_step.args.len() != 1 {
-                return Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "map requires exactly one argument",
-                )
-                .with_path(path));
-            }
-            let array = match pipe_value {
-                EvalValue::Missing => {
-                    return Ok(EvalValue::Missing);
-                }
-                EvalValue::Value(JsonValue::Array(items)) => items,
-                EvalValue::Value(other) => {
-                    return Err(TransformError::new(
-                        TransformErrorKind::ExprError,
-                        format!("expr arg must be an array, got {:?}", other),
-                    )
-                    .with_path(path));
-                }
-            };
-            let arg_path = format!("{}.args[0]", path);
-            let mut results = Vec::new();
-            for (index, item) in array.iter().enumerate() {
-                let item_ctx = ctx
-                    .clone()
-                    .with_pipe_value(EvalValue::Value(item.clone()))
-                    .with_item(EvalItem { value: item, index });
-                let value =
-                    eval_v2_expr(&op_step.args[0], record, context, out, &arg_path, &item_ctx)?;
-                if let EvalValue::Value(value) = value {
-                    results.push(value);
-                }
-            }
-            Ok(EvalValue::Value(JsonValue::Array(results)))
-        }
+        "map" => eval_map(op_step, pipe_value, record, context, out, path, ctx),
         "filter" => eval_filter(op_step, pipe_value, record, context, out, path, ctx),
-        "flat_map" => {
-            if op_step.args.len() != 1 {
-                return Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "flat_map requires exactly one argument",
-                )
-                .with_path(path));
-            }
-            let array = eval_v2_array_from_eval_value(pipe_value.clone(), path)?;
-            let arg_path = format!("{}.args[0]", path);
-            let mut results = Vec::new();
-            for (index, item) in array.iter().enumerate() {
-                let item_ctx = ctx
-                    .clone()
-                    .with_pipe_value(EvalValue::Value(item.clone()))
-                    .with_item(EvalItem { value: item, index });
-                let value = eval_v2_expr_or_null(
-                    &op_step.args[0],
-                    record,
-                    context,
-                    out,
-                    &arg_path,
-                    &item_ctx,
-                )?;
-                match value {
-                    JsonValue::Array(items) => results.extend(items),
-                    value => results.push(value),
-                }
-            }
-            Ok(EvalValue::Value(JsonValue::Array(results)))
-        }
+        "flat_map" => eval_flat_map(op_step, pipe_value, record, context, out, path, ctx),
         "group_by" | "key_by" | "distinct_by" => {
             eval_keyed_collection(op_step, pipe_value, record, context, out, path, ctx)
         }
@@ -103,46 +40,7 @@ pub(super) fn eval_collection_op<'a>(
         "find_index" => eval_find_index(op_step, pipe_value, record, context, out, path, ctx),
         "reduce" => eval_reduce(op_step, pipe_value, record, context, out, path, ctx),
         "fold" => eval_fold(op_step, pipe_value, record, context, out, path, ctx),
-        "zip_with" => {
-            if op_step.args.len() < 2 {
-                return Err(TransformError::new(
-                    TransformErrorKind::ExprError,
-                    "zip_with requires at least two arguments",
-                )
-                .with_path(path));
-            }
-            let mut arrays = Vec::new();
-            arrays.push(eval_v2_array_from_eval_value(pipe_value.clone(), path)?);
-            for (index, arg) in op_step.args.iter().enumerate().take(op_step.args.len() - 1) {
-                let arg_path = format!("{}.args[{}]", path, index);
-                let value = eval_v2_expr(arg, record, context, out, &arg_path, ctx)?;
-                arrays.push(eval_v2_array_from_eval_value(value, &arg_path)?);
-            }
-
-            let min_len = arrays.iter().map(|items| items.len()).min().unwrap_or(0);
-            let expr_index = op_step.args.len() - 1;
-            let expr_path = format!("{}.args[{}]", path, expr_index);
-            let expr = &op_step.args[expr_index];
-            let mut results = Vec::with_capacity(min_len);
-            for row_index in 0..min_len {
-                let mut row = Vec::with_capacity(arrays.len());
-                for array in &arrays {
-                    row.push(array[row_index].clone());
-                }
-                let row_value = JsonValue::Array(row);
-                let item_ctx = ctx
-                    .clone()
-                    .with_pipe_value(EvalValue::Value(row_value.clone()))
-                    .with_item(EvalItem {
-                        value: &row_value,
-                        index: row_index,
-                    });
-                let value =
-                    eval_v2_expr_or_null(expr, record, context, out, &expr_path, &item_ctx)?;
-                results.push(value);
-            }
-            Ok(EvalValue::Value(JsonValue::Array(results)))
-        }
+        "zip_with" => eval_zip_with(op_step, pipe_value, record, context, out, path, ctx),
         _ => unreachable!("collection dispatcher only calls collection operators"),
     }
 }

--- a/crates/rulemorph/src/v2_eval/collection/sequence.rs
+++ b/crates/rulemorph/src/v2_eval/collection/sequence.rs
@@ -1,0 +1,127 @@
+use super::*;
+
+pub(super) fn eval_map<'a>(
+    op_step: &V2OpStep,
+    pipe_value: EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    if op_step.args.len() != 1 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "map requires exactly one argument",
+        )
+        .with_path(path));
+    }
+    let array = match pipe_value {
+        EvalValue::Missing => {
+            return Ok(EvalValue::Missing);
+        }
+        EvalValue::Value(JsonValue::Array(items)) => items,
+        EvalValue::Value(other) => {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                format!("expr arg must be an array, got {:?}", other),
+            )
+            .with_path(path));
+        }
+    };
+    let arg_path = format!("{}.args[0]", path);
+    let mut results = Vec::new();
+    for (index, item) in array.iter().enumerate() {
+        let item_ctx = ctx
+            .clone()
+            .with_pipe_value(EvalValue::Value(item.clone()))
+            .with_item(EvalItem { value: item, index });
+        let value = eval_v2_expr(&op_step.args[0], record, context, out, &arg_path, &item_ctx)?;
+        if let EvalValue::Value(value) = value {
+            results.push(value);
+        }
+    }
+    Ok(EvalValue::Value(JsonValue::Array(results)))
+}
+
+pub(super) fn eval_flat_map<'a>(
+    op_step: &V2OpStep,
+    pipe_value: EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    if op_step.args.len() != 1 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "flat_map requires exactly one argument",
+        )
+        .with_path(path));
+    }
+    let array = eval_v2_array_from_eval_value(pipe_value.clone(), path)?;
+    let arg_path = format!("{}.args[0]", path);
+    let mut results = Vec::new();
+    for (index, item) in array.iter().enumerate() {
+        let item_ctx = ctx
+            .clone()
+            .with_pipe_value(EvalValue::Value(item.clone()))
+            .with_item(EvalItem { value: item, index });
+        let value =
+            eval_v2_expr_or_null(&op_step.args[0], record, context, out, &arg_path, &item_ctx)?;
+        match value {
+            JsonValue::Array(items) => results.extend(items),
+            value => results.push(value),
+        }
+    }
+    Ok(EvalValue::Value(JsonValue::Array(results)))
+}
+
+pub(super) fn eval_zip_with<'a>(
+    op_step: &V2OpStep,
+    pipe_value: EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    if op_step.args.len() < 2 {
+        return Err(TransformError::new(
+            TransformErrorKind::ExprError,
+            "zip_with requires at least two arguments",
+        )
+        .with_path(path));
+    }
+    let mut arrays = Vec::new();
+    arrays.push(eval_v2_array_from_eval_value(pipe_value.clone(), path)?);
+    for (index, arg) in op_step.args.iter().enumerate().take(op_step.args.len() - 1) {
+        let arg_path = format!("{}.args[{}]", path, index);
+        let value = eval_v2_expr(arg, record, context, out, &arg_path, ctx)?;
+        arrays.push(eval_v2_array_from_eval_value(value, &arg_path)?);
+    }
+
+    let min_len = arrays.iter().map(|items| items.len()).min().unwrap_or(0);
+    let expr_index = op_step.args.len() - 1;
+    let expr_path = format!("{}.args[{}]", path, expr_index);
+    let expr = &op_step.args[expr_index];
+    let mut results = Vec::with_capacity(min_len);
+    for row_index in 0..min_len {
+        let mut row = Vec::with_capacity(arrays.len());
+        for array in &arrays {
+            row.push(array[row_index].clone());
+        }
+        let row_value = JsonValue::Array(row);
+        let item_ctx = ctx
+            .clone()
+            .with_pipe_value(EvalValue::Value(row_value.clone()))
+            .with_item(EvalItem {
+                value: &row_value,
+                index: row_index,
+            });
+        let value = eval_v2_expr_or_null(expr, record, context, out, &expr_path, &item_ctx)?;
+        results.push(value);
+    }
+    Ok(EvalValue::Value(JsonValue::Array(results)))
+}


### PR DESCRIPTION
## 概要
- v2 collection evaluator の map / flat_map / zip_with を collection/sequence.rs に分割
- dispatcher order と shared collection helpers は維持
- collection semantics / trace schema / public API / CLI-MCP-HTTP / docs-specs は変更なし

## 検証
- cargo fmt
- cargo test -p rulemorph --lib v2_eval::tests::v2_op_step_eval_tests::test_eval_op_array_map_and_reduce -- --test-threads=1
- cargo test -p rulemorph --test v2_collection_ops -- --test-threads=1
- cargo test -p rulemorph --test v2_transform -- --test-threads=1
- cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- cargo test -p rulemorph -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-rebase: cargo test -p rulemorph --lib v2_eval::tests::v2_op_step_eval_tests::test_eval_op_array_map_and_reduce -- --test-threads=1
- post-rebase: cargo test -p rulemorph --test v2_collection_ops -- --test-threads=1
- post-rebase: cargo test -p rulemorph --test transform_trace_semantics -- --test-threads=1
- post-rebase: cargo fmt --check
- post-rebase: git diff --check origin/v0.3.1...HEAD