### PR TITLE
Refactor MCP Swift DTO parser

### DIFF
--- a/crates/rulemorph_mcp/src/dto_parse/swift.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/swift.rs
@@ -1,9 +1,15 @@
 use std::collections::HashMap;
 
 use crate::dto_normalize::normalize_swift_text;
-use crate::dto_schema::{DtoField, DtoFieldType, DtoType, PrimitiveKind};
+use crate::dto_schema::DtoType;
 
-use super::parse_first_quoted_value;
+mod coding_keys;
+mod declaration;
+mod field;
+
+use self::coding_keys::{apply_coding_key, parse_swift_cases};
+use self::declaration::parse_swift_type_name;
+use self::field::parse_swift_field;
 
 pub(in crate::dto_parse) fn parse_swift_types(
     text: &str,
@@ -23,35 +29,16 @@ pub(in crate::dto_parse) fn parse_swift_types(
             continue;
         }
 
-        if line.contains(" struct ")
-            || line.starts_with("struct ")
-            || line.contains(" class ")
-            || line.starts_with("class ")
-        {
-            let keyword_pos = if let Some(pos) = line.find("struct ") {
-                pos + 7
-            } else if let Some(pos) = line.find("class ") {
-                pos + 6
-            } else {
-                0
-            };
-            let name_part = line[keyword_pos..].split_whitespace().next().unwrap_or("");
-            let name = name_part
-                .split(|ch: char| ch == ':' || ch == '{')
-                .next()
-                .unwrap_or("")
-                .trim();
-            if !name.is_empty() {
-                current = Some(name.to_string());
-                types
-                    .entry(name.to_string())
-                    .or_insert_with(|| DtoType { fields: Vec::new() });
-                order.push(name.to_string());
-                coding_keys.clear();
-                in_coding_keys = false;
-                coding_depth = 0;
-                type_depth = 0;
-            }
+        if let Some(name) = parse_swift_type_name(line) {
+            current = Some(name.to_string());
+            types
+                .entry(name.to_string())
+                .or_insert_with(|| DtoType { fields: Vec::new() });
+            order.push(name.to_string());
+            coding_keys.clear();
+            in_coding_keys = false;
+            coding_depth = 0;
+            type_depth = 0;
         }
 
         let open_braces = line.matches('{').count() as i32;
@@ -79,12 +66,7 @@ pub(in crate::dto_parse) fn parse_swift_types(
                 let cases = parse_swift_cases(line);
                 if let Some(dto_type) = types.get_mut(&current_name) {
                     for (field, rename) in cases {
-                        coding_keys.insert(field.clone(), rename.clone());
-                        for existing in &mut dto_type.fields {
-                            if existing.json_key == field {
-                                existing.json_key = rename.clone();
-                            }
-                        }
+                        apply_coding_key(&mut coding_keys, dto_type, field, rename);
                     }
                 }
             }
@@ -100,116 +82,12 @@ pub(in crate::dto_parse) fn parse_swift_types(
             continue;
         }
 
-        if !(line.starts_with("let ") || line.starts_with("var ")) {
-            continue;
-        }
-
-        let rest = line.trim_end_matches(';').trim_end_matches(',').trim();
-        let rest = rest
-            .strip_prefix("let ")
-            .or_else(|| rest.strip_prefix("var "));
-        let Some(rest) = rest else { continue };
-        let mut parts = rest.splitn(2, ':');
-        let field_name = parts.next().unwrap_or("").trim();
-        let mut type_part = parts.next().unwrap_or("").trim();
-        if field_name.is_empty() || type_part.is_empty() {
-            continue;
-        }
-        if let Some(eq_pos) = type_part.find('=') {
-            type_part = type_part[..eq_pos].trim();
-        }
-
-        let mut optional = type_part.contains('?');
-        let type_token = type_part.trim_end_matches('?');
-        let field_type = if type_token.contains('<') {
-            DtoFieldType::Unknown
-        } else {
-            match type_token {
-                "String" => DtoFieldType::Primitive(PrimitiveKind::String),
-                "Bool" => DtoFieldType::Primitive(PrimitiveKind::Bool),
-                "Int" | "Int8" | "Int16" | "Int32" | "Int64" | "UInt" | "UInt8" | "UInt16"
-                | "UInt32" | "UInt64" => DtoFieldType::Primitive(PrimitiveKind::Int),
-                "Float" | "Double" => DtoFieldType::Primitive(PrimitiveKind::Float),
-                "" => DtoFieldType::Unknown,
-                other => DtoFieldType::Object(other.to_string()),
+        if let Some(field) = parse_swift_field(line, &coding_keys) {
+            if let Some(dto_type) = types.get_mut(&current_name) {
+                dto_type.fields.push(field);
             }
-        };
-
-        if type_part.contains("Optional<") {
-            optional = true;
-        }
-
-        let json_key = coding_keys
-            .get(field_name)
-            .cloned()
-            .unwrap_or_else(|| field_name.to_string());
-        if let Some(dto_type) = types.get_mut(&current_name) {
-            dto_type.fields.push(DtoField {
-                json_key,
-                field_type,
-                optional,
-            });
         }
     }
 
     Ok((types, order))
-}
-
-fn parse_swift_cases(line: &str) -> Vec<(String, String)> {
-    let mut cases = Vec::new();
-    let rest = line.strip_prefix("case ").unwrap_or(line).trim();
-    let mut current = String::new();
-    let mut in_string = false;
-    let mut escape = false;
-
-    for ch in rest.chars() {
-        if in_string {
-            current.push(ch);
-            if escape {
-                escape = false;
-                continue;
-            }
-            if ch == '\\' {
-                escape = true;
-                continue;
-            }
-            if ch == '"' {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if ch == '"' {
-            in_string = true;
-            current.push(ch);
-            continue;
-        }
-
-        if ch == ',' {
-            push_swift_case(&mut cases, &current);
-            current.clear();
-            continue;
-        }
-
-        current.push(ch);
-    }
-    push_swift_case(&mut cases, &current);
-    cases
-}
-
-fn push_swift_case(cases: &mut Vec<(String, String)>, text: &str) {
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return;
-    }
-    let mut parts = trimmed.splitn(2, '=');
-    let name = parts.next().unwrap_or("").trim();
-    if name.is_empty() {
-        return;
-    }
-    let rename = parts
-        .next()
-        .and_then(|value| parse_first_quoted_value(value))
-        .unwrap_or_else(|| name.to_string());
-    cases.push((name.to_string(), rename));
 }

--- a/crates/rulemorph_mcp/src/dto_parse/swift/coding_keys.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/swift/coding_keys.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use crate::dto_schema::DtoType;
+
+use super::super::parse_first_quoted_value;
+
+pub(super) fn parse_swift_cases(line: &str) -> Vec<(String, String)> {
+    let mut cases = Vec::new();
+    let rest = line.strip_prefix("case ").unwrap_or(line).trim();
+    let mut current = String::new();
+    let mut in_string = false;
+    let mut escape = false;
+
+    for ch in rest.chars() {
+        if in_string {
+            current.push(ch);
+            if escape {
+                escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                escape = true;
+                continue;
+            }
+            if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            current.push(ch);
+            continue;
+        }
+
+        if ch == ',' {
+            push_swift_case(&mut cases, &current);
+            current.clear();
+            continue;
+        }
+
+        current.push(ch);
+    }
+    push_swift_case(&mut cases, &current);
+    cases
+}
+
+pub(super) fn apply_coding_key(
+    coding_keys: &mut HashMap<String, String>,
+    dto_type: &mut DtoType,
+    field: String,
+    rename: String,
+) {
+    coding_keys.insert(field.clone(), rename.clone());
+    for existing in &mut dto_type.fields {
+        if existing.json_key == field {
+            existing.json_key = rename.clone();
+        }
+    }
+}
+
+fn push_swift_case(cases: &mut Vec<(String, String)>, text: &str) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    let mut parts = trimmed.splitn(2, '=');
+    let name = parts.next().unwrap_or("").trim();
+    if name.is_empty() {
+        return;
+    }
+    let rename = parts
+        .next()
+        .and_then(parse_first_quoted_value)
+        .unwrap_or_else(|| name.to_string());
+    cases.push((name.to_string(), rename));
+}

--- a/crates/rulemorph_mcp/src/dto_parse/swift/declaration.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/swift/declaration.rs
@@ -1,0 +1,24 @@
+pub(super) fn parse_swift_type_name(line: &str) -> Option<&str> {
+    if !(line.contains(" struct ")
+        || line.starts_with("struct ")
+        || line.contains(" class ")
+        || line.starts_with("class "))
+    {
+        return None;
+    }
+
+    let keyword_pos = if let Some(pos) = line.find("struct ") {
+        pos + 7
+    } else if let Some(pos) = line.find("class ") {
+        pos + 6
+    } else {
+        0
+    };
+    let name_part = line[keyword_pos..].split_whitespace().next().unwrap_or("");
+    let name = name_part
+        .split(|ch: char| ch == ':' || ch == '{')
+        .next()
+        .unwrap_or("")
+        .trim();
+    if name.is_empty() { None } else { Some(name) }
+}

--- a/crates/rulemorph_mcp/src/dto_parse/swift/field.rs
+++ b/crates/rulemorph_mcp/src/dto_parse/swift/field.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+
+use crate::dto_schema::{DtoField, DtoFieldType, PrimitiveKind};
+
+pub(super) fn parse_swift_field(
+    line: &str,
+    coding_keys: &HashMap<String, String>,
+) -> Option<DtoField> {
+    if !(line.starts_with("let ") || line.starts_with("var ")) {
+        return None;
+    }
+
+    let rest = line.trim_end_matches(';').trim_end_matches(',').trim();
+    let rest = rest
+        .strip_prefix("let ")
+        .or_else(|| rest.strip_prefix("var "))?;
+    let mut parts = rest.splitn(2, ':');
+    let field_name = parts.next().unwrap_or("").trim();
+    let mut type_part = parts.next().unwrap_or("").trim();
+    if field_name.is_empty() || type_part.is_empty() {
+        return None;
+    }
+    if let Some(eq_pos) = type_part.find('=') {
+        type_part = type_part[..eq_pos].trim();
+    }
+
+    let mut optional = type_part.contains('?');
+    let type_token = type_part.trim_end_matches('?');
+    let field_type = swift_field_type(type_token);
+
+    if type_part.contains("Optional<") {
+        optional = true;
+    }
+
+    let json_key = coding_keys
+        .get(field_name)
+        .cloned()
+        .unwrap_or_else(|| field_name.to_string());
+    Some(DtoField {
+        json_key,
+        field_type,
+        optional,
+    })
+}
+
+fn swift_field_type(type_token: &str) -> DtoFieldType {
+    if type_token.contains('<') {
+        return DtoFieldType::Unknown;
+    }
+
+    match type_token {
+        "String" => DtoFieldType::Primitive(PrimitiveKind::String),
+        "Bool" => DtoFieldType::Primitive(PrimitiveKind::Bool),
+        "Int" | "Int8" | "Int16" | "Int32" | "Int64" | "UInt" | "UInt8" | "UInt16" | "UInt32"
+        | "UInt64" => DtoFieldType::Primitive(PrimitiveKind::Int),
+        "Float" | "Double" => DtoFieldType::Primitive(PrimitiveKind::Float),
+        "" => DtoFieldType::Unknown,
+        other => DtoFieldType::Object(other.to_string()),
+    }
+}

--- a/crates/rulemorph_mcp/tests/stdio/dto/multiline_languages.rs
+++ b/crates/rulemorph_mcp/tests/stdio/dto/multiline_languages.rs
@@ -5,3 +5,5 @@ include!("multiline_languages/python.rs");
 include!("multiline_languages/go.rs");
 
 include!("multiline_languages/jvm.rs");
+
+include!("multiline_languages/swift.rs");

--- a/crates/rulemorph_mcp/tests/stdio/dto/multiline_languages/swift.rs
+++ b/crates/rulemorph_mcp/tests/stdio/dto/multiline_languages/swift.rs
@@ -1,0 +1,71 @@
+#[test]
+fn generate_rules_from_dto_swift_multiline_class_and_optional_object() {
+    let mut server = McpServer::start();
+    initialize(&mut server);
+
+    let dto_text = r#"
+class Record: Codable {
+    let id: String
+    let name: Optional<String>
+    let profile: Profile
+    let active: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id = "user_id"
+        case name
+        case profile
+        case active
+    }
+}
+
+struct Profile: Codable {
+    let city: String
+
+    enum CodingKeys: String, CodingKey {
+        case city = "city_name"
+    }
+}
+"#;
+
+    let rule = call_tool_rule(
+        &mut server,
+        2102,
+        "generate_rules_from_dto",
+        json!({
+            "dto_text": dto_text,
+            "dto_language": "swift",
+            "input_json": {
+                "user_id": "001",
+                "name": "Ada",
+                "profile": {
+                    "city_name": "Tokyo"
+                },
+                "active": true
+            }
+        }),
+    );
+
+    let id_mapping = mapping_by_target(&rule, "user_id");
+    assert_eq!(id_mapping.source.as_deref(), Some("user_id"));
+    assert_eq!(id_mapping.value_type.as_deref(), Some("string"));
+    assert!(id_mapping.required);
+
+    let name_mapping = mapping_by_target(&rule, "name");
+    assert_eq!(name_mapping.source.as_deref(), Some("name"));
+    assert!(!name_mapping.required);
+
+    let profile_city_mapping = mapping_by_target(&rule, "profile.city_name");
+    assert_eq!(
+        profile_city_mapping.source.as_deref(),
+        Some("profile.city_name")
+    );
+    assert_eq!(profile_city_mapping.value_type.as_deref(), Some("string"));
+    assert!(profile_city_mapping.required);
+
+    let active_mapping = mapping_by_target(&rule, "active");
+    assert_eq!(active_mapping.source.as_deref(), Some("active"));
+    assert_eq!(active_mapping.value_type.as_deref(), Some("bool"));
+    assert!(active_mapping.required);
+
+    server.shutdown();
+}


### PR DESCRIPTION
## 概要
- Swift DTO parser の declaration / field / CodingKeys helper を private child modules に分割
- Swift multiline class/struct + Optional + object reference の characterization test を追加
- MCP tool schema / public API / CLI-MCP-HTTP / trace schema / transform semantics / docs-specs は変更なし

## 検証
- cargo fmt
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_swift_multiline_class_and_optional_object -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_swift_single_line_coding_keys -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio dto -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio -- --test-threads=1
- cargo test -p rulemorph_mcp -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-rebase: cargo test -p rulemorph_mcp --test stdio generate_rules_from_dto_swift_multiline_class_and_optional_object -- --test-threads=1
- post-rebase: cargo test -p rulemorph_mcp --test stdio dto -- --test-threads=1
- post-rebase: cargo fmt --check
- post-rebase: git diff --check origin/v0.3.1...HEAD