### PR TITLE
Refactor normalization core records

### DIFF
--- a/crates/rulemorph/src/normalization/input.rs
+++ b/crates/rulemorph/src/normalization/input.rs
@@ -1,0 +1,32 @@
+use crate::error::{TransformError, TransformErrorKind};
+
+use super::NormalizationOptions;
+
+#[derive(Clone, Copy)]
+pub enum InputData<'a> {
+    Text(&'a str),
+    Bytes(&'a [u8]),
+}
+
+pub(super) fn text_input<'a>(
+    input: InputData<'a>,
+    options: &NormalizationOptions,
+) -> Result<&'a str, TransformError> {
+    let bytes = match input {
+        InputData::Text(value) => value.as_bytes(),
+        InputData::Bytes(bytes) => bytes,
+    };
+    if bytes.len() > options.max_input_bytes {
+        return Err(TransformError::new(
+            TransformErrorKind::InvalidInput,
+            "input exceeds max_input_bytes",
+        ));
+    }
+    let bytes = bytes.strip_prefix(b"\xef\xbb\xbf").unwrap_or(bytes);
+    std::str::from_utf8(bytes).map_err(|err| {
+        TransformError::new(
+            TransformErrorKind::InvalidInput,
+            format!("input must be valid UTF-8: {}", err),
+        )
+    })
+}

--- a/crates/rulemorph/src/normalization/limits.rs
+++ b/crates/rulemorph/src/normalization/limits.rs
@@ -1,0 +1,106 @@
+use serde_json::Value as JsonValue;
+
+use crate::error::{TransformError, TransformErrorKind};
+use crate::path::{get_path, parse_path};
+
+use super::NormalizationOptions;
+
+pub(crate) fn enforce_records_limit(
+    count: usize,
+    options: &NormalizationOptions,
+) -> Result<(), TransformError> {
+    if count > options.max_records {
+        return Err(TransformError::new(
+            TransformErrorKind::InvalidInput,
+            "input exceeds max_records",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn enforce_json_limits(
+    value: &JsonValue,
+    options: &NormalizationOptions,
+) -> Result<(), TransformError> {
+    fn walk(
+        value: &JsonValue,
+        depth: usize,
+        options: &NormalizationOptions,
+    ) -> Result<(), TransformError> {
+        if depth > options.max_depth {
+            return Err(TransformError::new(
+                TransformErrorKind::InvalidInput,
+                "input exceeds max_depth",
+            ));
+        }
+        match value {
+            JsonValue::Array(items) => {
+                if items.len() > options.max_array_len {
+                    return Err(TransformError::new(
+                        TransformErrorKind::InvalidInput,
+                        "input exceeds max_array_len",
+                    ));
+                }
+                for item in items {
+                    walk(item, depth + 1, options)?;
+                }
+            }
+            JsonValue::Object(map) => {
+                for value in map.values() {
+                    walk(value, depth + 1, options)?;
+                }
+            }
+            JsonValue::String(value) => {
+                if value.len() > options.max_text_bytes {
+                    return Err(TransformError::new(
+                        TransformErrorKind::InvalidInput,
+                        "input exceeds max_text_bytes",
+                    ));
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    walk(value, 0, options)
+}
+
+pub(crate) fn select_records_from_document(
+    value: &JsonValue,
+    records_path: Option<&str>,
+    path_for_error: &'static str,
+    options: &NormalizationOptions,
+) -> Result<Vec<JsonValue>, TransformError> {
+    let records_value = match records_path {
+        Some(path) => {
+            let tokens = parse_path(path).map_err(|err| {
+                TransformError::new(TransformErrorKind::InvalidRecordsPath, err.message())
+                    .with_path(path_for_error)
+            })?;
+            get_path(value, &tokens).ok_or_else(|| {
+                TransformError::new(
+                    TransformErrorKind::InvalidRecordsPath,
+                    "records_path does not exist",
+                )
+                .with_path(path_for_error)
+            })?
+        }
+        None => value,
+    };
+
+    match records_value {
+        JsonValue::Array(items) => {
+            enforce_records_limit(items.len(), options)?;
+            Ok(items.clone())
+        }
+        JsonValue::Object(_) => {
+            enforce_records_limit(1, options)?;
+            Ok(vec![records_value.clone()])
+        }
+        _ => Err(TransformError::new(
+            TransformErrorKind::InvalidInput,
+            "records_path must point to an array or object",
+        )),
+    }
+}

--- a/crates/rulemorph/src/normalization/mod.rs
+++ b/crates/rulemorph/src/normalization/mod.rs
@@ -1,57 +1,24 @@
 mod csv;
 mod excel;
 mod html;
+mod input;
 mod json;
+mod limits;
 mod options;
+mod records;
 mod toml;
 mod xml;
 mod yaml;
 
+pub use input::InputData;
 pub use options::NormalizationOptions;
+pub use records::NormalizedRecords;
 
-use std::fmt;
-
-use serde_json::Value as JsonValue;
-
-use crate::error::{TransformError, TransformErrorKind};
+use crate::error::TransformError;
 use crate::model::{InputFormat, RuleFile};
-use crate::path::{get_path, parse_path};
 
-#[derive(Clone, Copy)]
-pub enum InputData<'a> {
-    Text(&'a str),
-    Bytes(&'a [u8]),
-}
-
-/// Normalized input records.
-///
-/// Streaming formats can report record-level parse or limit errors while the
-/// iterator is consumed, so callers must drain or collect the iterator when
-/// they need full input validation.
-pub enum NormalizedRecords<'a> {
-    Materialized(std::vec::IntoIter<JsonValue>),
-    Streaming(Box<dyn Iterator<Item = Result<JsonValue, TransformError>> + 'a>),
-}
-
-impl fmt::Debug for NormalizedRecords<'_> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            NormalizedRecords::Materialized(_) => formatter.write_str("Materialized(..)"),
-            NormalizedRecords::Streaming(_) => formatter.write_str("Streaming(..)"),
-        }
-    }
-}
-
-impl Iterator for NormalizedRecords<'_> {
-    type Item = Result<JsonValue, TransformError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            NormalizedRecords::Materialized(iter) => iter.next().map(Ok),
-            NormalizedRecords::Streaming(iter) => iter.next(),
-        }
-    }
-}
+use input::text_input;
+pub(crate) use limits::{enforce_json_limits, enforce_records_limit, select_records_from_document};
 
 pub fn normalize_records<'a>(
     rule: &RuleFile,
@@ -89,127 +56,4 @@ pub fn normalize_records_with_options<'a>(
         InputFormat::Excel => excel::normalize_excel_records(rule, input, options)?,
     };
     Ok(NormalizedRecords::Materialized(records.into_iter()))
-}
-
-fn text_input<'a>(
-    input: InputData<'a>,
-    options: &NormalizationOptions,
-) -> Result<&'a str, TransformError> {
-    let bytes = match input {
-        InputData::Text(value) => value.as_bytes(),
-        InputData::Bytes(bytes) => bytes,
-    };
-    if bytes.len() > options.max_input_bytes {
-        return Err(TransformError::new(
-            TransformErrorKind::InvalidInput,
-            "input exceeds max_input_bytes",
-        ));
-    }
-    let bytes = bytes.strip_prefix(b"\xef\xbb\xbf").unwrap_or(bytes);
-    std::str::from_utf8(bytes).map_err(|err| {
-        TransformError::new(
-            TransformErrorKind::InvalidInput,
-            format!("input must be valid UTF-8: {}", err),
-        )
-    })
-}
-
-pub(crate) fn enforce_records_limit(
-    count: usize,
-    options: &NormalizationOptions,
-) -> Result<(), TransformError> {
-    if count > options.max_records {
-        return Err(TransformError::new(
-            TransformErrorKind::InvalidInput,
-            "input exceeds max_records",
-        ));
-    }
-    Ok(())
-}
-
-pub(crate) fn enforce_json_limits(
-    value: &JsonValue,
-    options: &NormalizationOptions,
-) -> Result<(), TransformError> {
-    fn walk(
-        value: &JsonValue,
-        depth: usize,
-        options: &NormalizationOptions,
-    ) -> Result<(), TransformError> {
-        if depth > options.max_depth {
-            return Err(TransformError::new(
-                TransformErrorKind::InvalidInput,
-                "input exceeds max_depth",
-            ));
-        }
-        match value {
-            JsonValue::Array(items) => {
-                if items.len() > options.max_array_len {
-                    return Err(TransformError::new(
-                        TransformErrorKind::InvalidInput,
-                        "input exceeds max_array_len",
-                    ));
-                }
-                for item in items {
-                    walk(item, depth + 1, options)?;
-                }
-            }
-            JsonValue::Object(map) => {
-                for value in map.values() {
-                    walk(value, depth + 1, options)?;
-                }
-            }
-            JsonValue::String(value) => {
-                if value.len() > options.max_text_bytes {
-                    return Err(TransformError::new(
-                        TransformErrorKind::InvalidInput,
-                        "input exceeds max_text_bytes",
-                    ));
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    walk(value, 0, options)
-}
-
-pub(crate) fn select_records_from_document(
-    value: &JsonValue,
-    records_path: Option<&str>,
-    path_for_error: &'static str,
-    options: &NormalizationOptions,
-) -> Result<Vec<JsonValue>, TransformError> {
-    let records_value = match records_path {
-        Some(path) => {
-            let tokens = parse_path(path).map_err(|err| {
-                TransformError::new(TransformErrorKind::InvalidRecordsPath, err.message())
-                    .with_path(path_for_error)
-            })?;
-            get_path(value, &tokens).ok_or_else(|| {
-                TransformError::new(
-                    TransformErrorKind::InvalidRecordsPath,
-                    "records_path does not exist",
-                )
-                .with_path(path_for_error)
-            })?
-        }
-        None => value,
-    };
-
-    match records_value {
-        JsonValue::Array(items) => {
-            enforce_records_limit(items.len(), options)?;
-            Ok(items.clone())
-        }
-        JsonValue::Object(_) => {
-            enforce_records_limit(1, options)?;
-            Ok(vec![records_value.clone()])
-        }
-        _ => Err(TransformError::new(
-            TransformErrorKind::InvalidInput,
-            "records_path must point to an array or object",
-        )),
-    }
 }

--- a/crates/rulemorph/src/normalization/records.rs
+++ b/crates/rulemorph/src/normalization/records.rs
@@ -1,0 +1,35 @@
+use std::fmt;
+
+use serde_json::Value as JsonValue;
+
+use crate::error::TransformError;
+
+/// Normalized input records.
+///
+/// Streaming formats can report record-level parse or limit errors while the
+/// iterator is consumed, so callers must drain or collect the iterator when
+/// they need full input validation.
+pub enum NormalizedRecords<'a> {
+    Materialized(std::vec::IntoIter<JsonValue>),
+    Streaming(Box<dyn Iterator<Item = Result<JsonValue, TransformError>> + 'a>),
+}
+
+impl fmt::Debug for NormalizedRecords<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NormalizedRecords::Materialized(_) => formatter.write_str("Materialized(..)"),
+            NormalizedRecords::Streaming(_) => formatter.write_str("Streaming(..)"),
+        }
+    }
+}
+
+impl Iterator for NormalizedRecords<'_> {
+    type Item = Result<JsonValue, TransformError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            NormalizedRecords::Materialized(iter) => iter.next().map(Ok),
+            NormalizedRecords::Streaming(iter) => iter.next(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move normalization input handling, normalized record wrapper, and record/json limit helpers into child modules
- Keep parent normalization module as the public facade and format dispatcher
- Preserve public InputData/NormalizedRecords import paths and internal helper availability for format modules

## Verification
- cargo fmt
- cargo test -p rulemorph --test transform_golden normalization_rejects -- --test-threads=1
- cargo test -p rulemorph --test transform_golden transform_input_rejects_invalid_utf8_bytes -- --test-threads=1
- cargo test -p rulemorph --test transform_golden records_path -- --test-threads=1
- cargo test -p rulemorph --test transform_golden excel_preflight_accepts_byte_input -- --test-threads=1
- cargo test -p rulemorph --test transform_golden html_rejects_array_limit_exceeded -- --test-threads=1
- cargo test -p rulemorph --test transform_golden xml_rejects_records_limit_exceeded -- --test-threads=1
- cargo test -p rulemorph --test preflight -- --test-threads=1
- cargo test -p rulemorph -- --test-threads=1
- cargo fmt --check
- git diff --check
- post-commit: cargo test -p rulemorph --test transform_golden records_path -- --test-threads=1
- post-commit: cargo test -p rulemorph --test preflight -- --test-threads=1
- post-commit: cargo fmt --check
- post-commit: git diff --check origin/v0.3.1...HEAD