### PR TITLE
Refactor endpoint validation rules

### DIFF
--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation.rs
@@ -1,19 +1,18 @@
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
-use rulemorph::{RuleFormat, parse_rule_file_with_format, validate_rule_file_with_source};
-
 use super::{CompiledEndpointRule, EndpointRuleFile, resolve_rule_path};
 
 mod diagnostics;
 mod network;
+mod rules;
 mod source;
 mod state;
 
+use self::diagnostics::push_error;
 pub use self::diagnostics::{RulesDirError, RulesDirErrors};
-use self::diagnostics::{push_error, push_parse_error, push_rule_error};
-use self::network::validate_network_rule;
-use self::source::{parse_rule_type, parse_yaml, read_rule_source};
+use self::rules::validate_rule_path;
+use self::source::{parse_yaml, read_rule_source};
 use self::state::{RuleRefUsage, ValidationState};
 
 pub fn validate_rules_dir(rules_dir: &Path) -> std::result::Result<(), RulesDirErrors> {
@@ -104,109 +103,5 @@ pub fn validate_rules_dir(rules_dir: &Path) -> std::result::Result<(), RulesDirE
         Ok(())
     } else {
         Err(RulesDirErrors { errors })
-    }
-}
-
-fn validate_rule_path(
-    path: &Path,
-    usage: RuleRefUsage,
-    state: &mut ValidationState,
-    errors: &mut Vec<RulesDirError>,
-) {
-    let source = match read_rule_source(path, errors) {
-        Some(source) => source,
-        None => return,
-    };
-    let rule_type = match parse_rule_type(path, &source, errors) {
-        Some(rule_type) => rule_type,
-        None => return,
-    };
-
-    if usage.step && rule_type == "endpoint" {
-        push_error(
-            errors,
-            "EndpointRuleNotAllowed",
-            path,
-            "endpoint rule not allowed as step",
-            Some("type".to_string()),
-            None,
-        );
-    }
-    if usage.body_rule && rule_type != "normal" {
-        push_error(
-            errors,
-            "BodyRuleInvalid",
-            path,
-            "body_rule must be normal",
-            Some("type".to_string()),
-            None,
-        );
-    }
-    if usage.catch_rule && rule_type != "normal" {
-        push_error(
-            errors,
-            "CatchRuleInvalid",
-            path,
-            "catch rule must be normal",
-            Some("type".to_string()),
-            None,
-        );
-    }
-    if usage.branch_rule && rule_type != "normal" {
-        push_error(
-            errors,
-            "BranchRuleInvalid",
-            path,
-            "branch rule must be normal",
-            Some("type".to_string()),
-            None,
-        );
-    }
-
-    if !state.validated_content.insert(path.to_path_buf()) {
-        return;
-    }
-
-    match rule_type.as_str() {
-        "network" => validate_network_rule(&source, path, state, errors),
-        "endpoint" => {}
-        _ => validate_normal_rule(&source, path, state, errors),
-    }
-}
-
-fn validate_normal_rule(
-    source: &str,
-    path: &Path,
-    state: &mut ValidationState,
-    errors: &mut Vec<RulesDirError>,
-) {
-    let rule = match parse_rule_file_with_format(source, RuleFormat::from_path(path)) {
-        Ok(rule) => rule,
-        Err(err) => {
-            push_parse_error(errors, path, &err.to_string(), err.line_column());
-            return;
-        }
-    };
-    if let Err(rule_errors) = validate_rule_file_with_source(&rule, source) {
-        for err in rule_errors {
-            push_rule_error(errors, path, &err);
-        }
-    }
-    if let Some(steps) = &rule.steps {
-        let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        for step in steps {
-            if let Some(branch) = &step.branch {
-                if !branch.then.trim().is_empty() {
-                    let resolved = resolve_rule_path(base_dir, branch.then.as_str());
-                    validate_rule_path(&resolved, RuleRefUsage::branch_rule(), state, errors);
-                }
-                if let Some(r#else) = &branch.r#else {
-                    if !r#else.trim().is_empty() {
-                        let resolved = resolve_rule_path(base_dir, r#else.as_str());
-                        validate_rule_path(&resolved, RuleRefUsage::branch_rule(), state, errors);
-                    }
-                }
-            }
-        }
     }
 }

--- a/crates/rulemorph_endpoint/src/endpoint_engine/validation/rules.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/validation/rules.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+
+use rulemorph::{RuleFormat, parse_rule_file_with_format, validate_rule_file_with_source};
+
+use crate::endpoint_engine::resolve_rule_path;
+
+use super::diagnostics::{RulesDirError, push_error, push_parse_error, push_rule_error};
+use super::network::validate_network_rule;
+use super::source::{parse_rule_type, read_rule_source};
+use super::state::{RuleRefUsage, ValidationState};
+
+pub(super) fn validate_rule_path(
+    path: &Path,
+    usage: RuleRefUsage,
+    state: &mut ValidationState,
+    errors: &mut Vec<RulesDirError>,
+) {
+    let source = match read_rule_source(path, errors) {
+        Some(source) => source,
+        None => return,
+    };
+    let rule_type = match parse_rule_type(path, &source, errors) {
+        Some(rule_type) => rule_type,
+        None => return,
+    };
+
+    if usage.step && rule_type == "endpoint" {
+        push_error(
+            errors,
+            "EndpointRuleNotAllowed",
+            path,
+            "endpoint rule not allowed as step",
+            Some("type".to_string()),
+            None,
+        );
+    }
+    if usage.body_rule && rule_type != "normal" {
+        push_error(
+            errors,
+            "BodyRuleInvalid",
+            path,
+            "body_rule must be normal",
+            Some("type".to_string()),
+            None,
+        );
+    }
+    if usage.catch_rule && rule_type != "normal" {
+        push_error(
+            errors,
+            "CatchRuleInvalid",
+            path,
+            "catch rule must be normal",
+            Some("type".to_string()),
+            None,
+        );
+    }
+    if usage.branch_rule && rule_type != "normal" {
+        push_error(
+            errors,
+            "BranchRuleInvalid",
+            path,
+            "branch rule must be normal",
+            Some("type".to_string()),
+            None,
+        );
+    }
+
+    if !state.validated_content.insert(path.to_path_buf()) {
+        return;
+    }
+
+    match rule_type.as_str() {
+        "network" => validate_network_rule(&source, path, state, errors),
+        "endpoint" => {}
+        _ => validate_normal_rule(&source, path, state, errors),
+    }
+}
+
+fn validate_normal_rule(
+    source: &str,
+    path: &Path,
+    state: &mut ValidationState,
+    errors: &mut Vec<RulesDirError>,
+) {
+    let rule = match parse_rule_file_with_format(source, RuleFormat::from_path(path)) {
+        Ok(rule) => rule,
+        Err(err) => {
+            push_parse_error(errors, path, &err.to_string(), err.line_column());
+            return;
+        }
+    };
+    if let Err(rule_errors) = validate_rule_file_with_source(&rule, source) {
+        for err in rule_errors {
+            push_rule_error(errors, path, &err);
+        }
+    }
+    if let Some(steps) = &rule.steps {
+        let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+        for step in steps {
+            if let Some(branch) = &step.branch {
+                if !branch.then.trim().is_empty() {
+                    let resolved = resolve_rule_path(base_dir, branch.then.as_str());
+                    validate_rule_path(&resolved, RuleRefUsage::branch_rule(), state, errors);
+                }
+                if let Some(r#else) = &branch.r#else {
+                    if !r#else.trim().is_empty() {
+                        let resolved = resolve_rule_path(base_dir, r#else.as_str());
+                        validate_rule_path(&resolved, RuleRefUsage::branch_rule(), state, errors);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Summary:
- move endpoint referenced-rule validation helpers into validation/rules.rs
- keep validate_rules_dir and diagnostics exports unchanged
- keep endpoint validation behavior, contracts, transform semantics, and trace schema unchanged

Verification:
- cargo fmt
- cargo test -p rulemorph_endpoint --test rules_dir_validation -- --test-threads=1
- cargo test -p rulemorph_endpoint -- --test-threads=1
- cargo test -- --test-threads=1
- cargo fmt --check
- git diff --check