### PR TITLE
Refactor rule source tests

### DIFF
--- a/crates/rulemorph/src/rule_source.rs
+++ b/crates/rulemorph/src/rule_source.rs
@@ -181,42 +181,4 @@ pub fn parse_rule_file_with_format(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::path::Path;
-
-    use super::{RuleFormat, RuleParseError};
-    use crate::error::YamlLocation;
-
-    #[test]
-    fn rule_format_from_path_keeps_json_extension_detection() {
-        assert_eq!(
-            RuleFormat::from_path(Path::new("rules.json")),
-            RuleFormat::Json
-        );
-        assert_eq!(
-            RuleFormat::from_path(Path::new("rules.JSON")),
-            RuleFormat::Json
-        );
-        assert_eq!(
-            RuleFormat::from_path(Path::new("rules.yaml")),
-            RuleFormat::Yaml
-        );
-        assert_eq!(
-            RuleFormat::from_path(Path::new("rules.yml")),
-            RuleFormat::Yaml
-        );
-        assert_eq!(RuleFormat::from_path(Path::new("rules")), RuleFormat::Yaml);
-    }
-
-    #[test]
-    fn rule_parse_error_display_and_location_are_stable() {
-        let err = RuleParseError {
-            format: RuleFormat::Json,
-            message: "duplicate key".to_string(),
-            location: Some(YamlLocation { line: 2, column: 4 }),
-        };
-
-        assert_eq!(err.line_column(), Some((2, 4)));
-        assert_eq!(err.to_string(), "failed to parse json rules: duplicate key");
-    }
-}
+mod tests;

--- a/crates/rulemorph/src/rule_source/tests.rs
+++ b/crates/rulemorph/src/rule_source/tests.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use super::{RuleFormat, RuleParseError};
+use crate::error::YamlLocation;
+
+#[test]
+fn rule_format_from_path_keeps_json_extension_detection() {
+    assert_eq!(
+        RuleFormat::from_path(Path::new("rules.json")),
+        RuleFormat::Json
+    );
+    assert_eq!(
+        RuleFormat::from_path(Path::new("rules.JSON")),
+        RuleFormat::Json
+    );
+    assert_eq!(
+        RuleFormat::from_path(Path::new("rules.yaml")),
+        RuleFormat::Yaml
+    );
+    assert_eq!(
+        RuleFormat::from_path(Path::new("rules.yml")),
+        RuleFormat::Yaml
+    );
+    assert_eq!(RuleFormat::from_path(Path::new("rules")), RuleFormat::Yaml);
+}
+
+#[test]
+fn rule_parse_error_display_and_location_are_stable() {
+    let err = RuleParseError {
+        format: RuleFormat::Json,
+        message: "duplicate key".to_string(),
+        location: Some(YamlLocation { line: 2, column: 4 }),
+    };
+
+    assert_eq!(err.line_column(), Some((2, 4)));
+    assert_eq!(err.to_string(), "failed to parse json rules: duplicate key");
+}


### PR DESCRIPTION
## Summary
- move inline rule_source unit tests into rule_source/tests.rs
- keep parser/cache/error implementation and public exports unchanged
- preserve format detection and parse error display/location assertions

## Verification
- cargo fmt
- cargo test -p rulemorph --lib rule_source::tests -- --test-threads=1
- cargo test -p rulemorph --test transform_golden t30_json_rule_file_transform_golden -- --test-threads=1
- cargo test -p rulemorph_mcp --test stdio transform_accepts_text_input_normalization_formats -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check