### PR TITLE
Refactor v2 validator dependency tests

### DIFF
--- a/crates/rulemorph/src/v2_validator/dependencies.rs
+++ b/crates/rulemorph/src/v2_validator/dependencies.rs
@@ -146,45 +146,4 @@ fn has_cycle(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_no_cycle() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let targets = vec![
-            ("a".to_string(), HashSet::new()),
-            ("b".to_string(), ["a".to_string()].into_iter().collect()),
-            ("c".to_string(), ["b".to_string()].into_iter().collect()),
-        ];
-
-        validate_no_cyclic_dependencies(&targets, "mappings", &mut ctx);
-
-        assert!(!ctx.has_errors());
-    }
-
-    #[test]
-    fn test_self_reference_cycle() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let targets = vec![("a".to_string(), ["a".to_string()].into_iter().collect())];
-
-        validate_no_cyclic_dependencies(&targets, "mappings", &mut ctx);
-
-        assert!(ctx.has_errors());
-        assert_eq!(ctx.errors()[0].code, ErrorCode::CyclicDependency);
-    }
-
-    #[test]
-    fn test_indirect_cycle() {
-        let mut ctx = V2ValidationCtx::new(None);
-        let targets = vec![
-            ("a".to_string(), ["b".to_string()].into_iter().collect()),
-            ("b".to_string(), ["a".to_string()].into_iter().collect()),
-        ];
-
-        validate_no_cyclic_dependencies(&targets, "mappings", &mut ctx);
-
-        assert!(ctx.has_errors());
-        assert_eq!(ctx.errors()[0].code, ErrorCode::CyclicDependency);
-    }
-}
+mod tests;

--- a/crates/rulemorph/src/v2_validator/dependencies/tests.rs
+++ b/crates/rulemorph/src/v2_validator/dependencies/tests.rs
@@ -1,0 +1,45 @@
+use std::collections::HashSet;
+
+use crate::error::ErrorCode;
+use crate::v2_validator::V2ValidationCtx;
+
+use super::validate_no_cyclic_dependencies;
+
+#[test]
+fn test_no_cycle() {
+    let mut ctx = V2ValidationCtx::new(None);
+    let targets = vec![
+        ("a".to_string(), HashSet::new()),
+        ("b".to_string(), ["a".to_string()].into_iter().collect()),
+        ("c".to_string(), ["b".to_string()].into_iter().collect()),
+    ];
+
+    validate_no_cyclic_dependencies(&targets, "mappings", &mut ctx);
+
+    assert!(!ctx.has_errors());
+}
+
+#[test]
+fn test_self_reference_cycle() {
+    let mut ctx = V2ValidationCtx::new(None);
+    let targets = vec![("a".to_string(), ["a".to_string()].into_iter().collect())];
+
+    validate_no_cyclic_dependencies(&targets, "mappings", &mut ctx);
+
+    assert!(ctx.has_errors());
+    assert_eq!(ctx.errors()[0].code, ErrorCode::CyclicDependency);
+}
+
+#[test]
+fn test_indirect_cycle() {
+    let mut ctx = V2ValidationCtx::new(None);
+    let targets = vec![
+        ("a".to_string(), ["b".to_string()].into_iter().collect()),
+        ("b".to_string(), ["a".to_string()].into_iter().collect()),
+    ];
+
+    validate_no_cyclic_dependencies(&targets, "mappings", &mut ctx);
+
+    assert!(ctx.has_errors());
+    assert_eq!(ctx.errors()[0].code, ErrorCode::CyclicDependency);
+}


### PR DESCRIPTION
## Summary
- move inline v2 validator dependency unit tests into v2_validator/dependencies/tests.rs
- keep dependency collection and cycle detection implementation unchanged
- preserve no-cycle, self-cycle, and indirect-cycle assertions

## Verification
- cargo fmt
- cargo test -p rulemorph --lib v2_validator::dependencies::tests -- --test-threads=1
- cargo test -p rulemorph --test validation v2_forward_out_ref_should_fail_validation -- --test-threads=1
- cargo test -p rulemorph --test validation v2_invalid_rules_should_fail_validation -- --test-threads=1
- cargo fmt --check
- git diff --check
- git diff --cached --check