### PR TITLE
[codex] Add core performance measurement

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,120 @@
+name: Core Performance
+
+on:
+  pull_request:
+    paths:
+      - "crates/rulemorph/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain*"
+      - ".cargo/**"
+      - ".github/workflows/perf.yml"
+      - "scripts/perf_report.py"
+      - "docs/perf.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  perf:
+    name: rulemorph core perf
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v6.0.2 pinned 2026-05-31. Uses Node.js 24 runtime.
+      - name: Checkout PR code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: pr
+          persist-credentials: false
+
+      # actions/checkout@v6.0.2 pinned 2026-05-31. Uses Node.js 24 runtime.
+      - name: Checkout trusted base for reporting
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+
+      # dtolnay/rust-toolchain pinned 2026-05-09, matching release-cli.yml.
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: 1.88.0
+
+      # Swatinem/rust-cache@v2 pinned 2026-05-31.
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          workspaces: |
+            pr -> pr/target
+
+      - name: Run rulemorph tests
+        working-directory: pr
+        env:
+          GITHUB_STEP_SUMMARY: /dev/null
+        run: cargo test -p rulemorph
+
+      - name: Run allocation canaries
+        working-directory: pr
+        env:
+          GITHUB_STEP_SUMMARY: /dev/null
+        run: cargo test -p rulemorph --test perf_allocation -- --test-threads=1
+
+      - name: Compile all core benches
+        working-directory: pr
+        env:
+          GITHUB_STEP_SUMMARY: /dev/null
+        run: |
+          cargo bench -p rulemorph --bench transform_bench --no-run
+          cargo bench -p rulemorph --bench parse_bench --no-run
+          cargo bench -p rulemorph --bench normalize_bench --no-run
+          cargo bench -p rulemorph --bench exec_mode_bench --no-run
+          cargo bench -p rulemorph --bench trace_bench --no-run
+          cargo bench -p rulemorph --bench v2_bench --no-run
+
+      - name: Run short Criterion canaries
+        working-directory: pr
+        env:
+          GITHUB_STEP_SUMMARY: /dev/null
+        run: |
+          cargo bench -p rulemorph --bench transform_bench -- transform/batch/simple/records_5k --warm-up-time 1 --measurement-time 2
+          cargo bench -p rulemorph --bench trace_bench -- trace_off --warm-up-time 1 --measurement-time 2
+
+      - name: Build performance report
+        if: hashFiles('trusted/scripts/perf_report.py') != ''
+        run: python3 trusted/scripts/perf_report.py --criterion-dir pr/target/criterion --baseline-json trusted/crates/rulemorph/PERF.json --json-output perf-report.json > perf-report.md
+
+      - name: Record missing trusted report renderer
+        if: hashFiles('trusted/scripts/perf_report.py') == ''
+        run: |
+          cat > perf-report.md <<'EOF'
+          # Rulemorph Core Performance Snapshot
+
+          Trusted perf_report.py is not available on the base ref yet. Criterion JSON artifacts were still uploaded; Markdown rendering will start after the reporting script exists on the base branch.
+          EOF
+          cat > perf-report.json <<'EOF'
+          {
+            "schema_version": 1,
+            "benchmarks": {},
+            "missing_from_current": [],
+            "status": "trusted_renderer_missing"
+          }
+          EOF
+
+      - name: Publish performance summary
+        run: cat perf-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload performance artifacts
+        # actions/upload-artifact@v4 pinned 2026-05-31.
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: rulemorph-core-performance
+          retention-days: 7
+          path: |
+            perf-report.md
+            perf-report.json
+            pr/target/criterion/**/new/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,38 @@
-/target
-**/*.rs.bk
-**/*.swp
-.DS_Store
-/docs/plans
-/docs/roadmap
-CLAUDE.md
-**/node_modules/
-.rulemorph/
+# Build outputs
+/target/
 **/dist/
 **/test-results/
+
+# Dependency caches
+**/node_modules/
+
+# Local runtime state
+.rulemorph/
+
+# Local agent/editor files
+.claude/
+CLAUDE.md
+.DS_Store
+Thumbs.db
+**/*.swp
+**/*.swo
+*~
+
+# Temporary and generated diagnostics
+*.log
+*.tmp
+*.temp
+*.bak
+*.orig
+*.rej
+*.profraw
+*.profdata
+**/*.rs.bk
+/perf-report.md
+/perf-report.json
+
+# Local planning and preview artifacts
+/docs/plans/
+/docs/roadmap/
+/docs/superpowers/
+/docs/design/

--- a/crates/rulemorph/Cargo.toml
+++ b/crates/rulemorph/Cargo.toml
@@ -28,3 +28,23 @@ criterion = "0.5"
 [[bench]]
 name = "transform_bench"
 harness = false
+
+[[bench]]
+name = "parse_bench"
+harness = false
+
+[[bench]]
+name = "normalize_bench"
+harness = false
+
+[[bench]]
+name = "exec_mode_bench"
+harness = false
+
+[[bench]]
+name = "trace_bench"
+harness = false
+
+[[bench]]
+name = "v2_bench"
+harness = false

--- a/crates/rulemorph/PERF.json
+++ b/crates/rulemorph/PERF.json
@@ -1,0 +1,187 @@
+{
+  "benchmarks": {
+    "normalize/csv/records_10k": {
+      "delta_percent": 0.0,
+      "mb_sec": 71.48926889349968,
+      "mean_ns": 2625252.5215000003,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "normalize/json/records_10k": {
+      "delta_percent": 0.0,
+      "mb_sec": 86.90880025368726,
+      "mean_ns": 4792918.788181816,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "parse/rule_file_cached/extended": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 2445.4711432261383,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "parse/rule_file_cached/lookup": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 677.9650418977571,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "parse/rule_file_cached/simple": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 386.25969238006587,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "parse/rule_file_cold_like/extended": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 83194.38998498136,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "parse/rule_file_cold_like/lookup": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 19831.494998336733,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "parse/rule_file_cold_like/simple": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 10143.290312305826,
+      "records_sec": null,
+      "status": "ok"
+    },
+    "trace/simple/trace_metadata_only": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 20618281.376666665,
+      "records_sec": 48500.647640383926,
+      "status": "ok"
+    },
+    "trace/simple/trace_off": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 1819784.7286464304,
+      "records_sec": 549515.5466788687,
+      "status": "ok"
+    },
+    "trace/simple/trace_raw": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 21506644.323333334,
+      "records_sec": 46497.258473515736,
+      "status": "ok"
+    },
+    "transform/batch/extended/cold_parse_records_5k": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 126790549.1,
+      "records_sec": 39435.1159095974,
+      "status": "ok"
+    },
+    "transform/batch/extended/hot_records_5k": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 129421364.22,
+      "records_sec": 38633.497878299524,
+      "status": "ok"
+    },
+    "transform/batch/lookup/records_5k_context_100": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 145282092.97,
+      "records_sec": 34415.80374969181,
+      "status": "ok"
+    },
+    "transform/batch/lookup_scale/context_size/10": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 1437106.7351167065,
+      "records_sec": 173960.63485827146,
+      "status": "ok"
+    },
+    "transform/batch/lookup_scale/context_size/100": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 7041686.715,
+      "records_sec": 35502.85749967506,
+      "status": "ok"
+    },
+    "transform/batch/lookup_scale/context_size/1000": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 62139345.44,
+      "records_sec": 4023.215858322694,
+      "status": "ok"
+    },
+    "transform/batch/simple/records_5k": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 10072815.955000002,
+      "records_sec": 496385.52142095595,
+      "status": "ok"
+    },
+    "transform/end_to_end/json/batch_transform": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 19096434.279999997,
+      "records_sec": 523657.96951282996,
+      "status": "ok"
+    },
+    "transform/end_to_end/json/stream_drain": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 18634889.71,
+      "records_sec": 536627.8070663182,
+      "status": "ok"
+    },
+    "transform/evaluator/json/record_loop": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 13709660.85,
+      "records_sec": 729412.6462654254,
+      "status": "ok"
+    },
+    "transform/stream/csv/records_10k": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 10914280.923999997,
+      "records_sec": 916230.768626311,
+      "status": "ok"
+    },
+    "transform/v2/collection/items_per_record/16": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 25542453.11,
+      "records_sec": 19575.253709842284,
+      "status": "ok"
+    },
+    "transform/v2/collection/items_per_record/4": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 5306636.583000001,
+      "records_sec": 94221.63967319108,
+      "status": "ok"
+    },
+    "transform/v2/collection/items_per_record/64": {
+      "delta_percent": 0.0,
+      "mb_sec": null,
+      "mean_ns": 236207631.23,
+      "records_sec": 2116.7817373061084,
+      "status": "ok"
+    }
+  },
+  "generated_at": "2026-05-31T12:11:20.760735Z",
+  "missing_from_current": [],
+  "schema_version": 1,
+  "thresholds": {
+    "improvement_percent": -5.0,
+    "regression_percent": 20.0,
+    "warn_percent": 10.0
+  }
+}

--- a/crates/rulemorph/PERF.md
+++ b/crates/rulemorph/PERF.md
@@ -1,0 +1,29 @@
+# Rulemorph Core Performance Snapshot
+
+| benchmark | mean ns/iter | records/sec | MB/sec | baseline delta | status |
+| --- | ---: | ---: | ---: | ---: | --- |
+| normalize/csv/records_10k | 2625253 | - | 71.49 | +0.00% | ok |
+| normalize/json/records_10k | 4792919 | - | 86.91 | +0.00% | ok |
+| parse/rule_file_cached/extended | 2445 | - | - | +0.00% | ok |
+| parse/rule_file_cached/lookup | 678 | - | - | +0.00% | ok |
+| parse/rule_file_cached/simple | 386 | - | - | +0.00% | ok |
+| parse/rule_file_cold_like/extended | 83194 | - | - | +0.00% | ok |
+| parse/rule_file_cold_like/lookup | 19831 | - | - | +0.00% | ok |
+| parse/rule_file_cold_like/simple | 10143 | - | - | +0.00% | ok |
+| trace/simple/trace_metadata_only | 20618281 | 48500.65 | - | +0.00% | ok |
+| trace/simple/trace_off | 1819785 | 549515.55 | - | +0.00% | ok |
+| trace/simple/trace_raw | 21506644 | 46497.26 | - | +0.00% | ok |
+| transform/batch/extended/cold_parse_records_5k | 126790549 | 39435.12 | - | +0.00% | ok |
+| transform/batch/extended/hot_records_5k | 129421364 | 38633.50 | - | +0.00% | ok |
+| transform/batch/lookup/records_5k_context_100 | 145282093 | 34415.80 | - | +0.00% | ok |
+| transform/batch/lookup_scale/context_size/10 | 1437107 | 173960.63 | - | +0.00% | ok |
+| transform/batch/lookup_scale/context_size/100 | 7041687 | 35502.86 | - | +0.00% | ok |
+| transform/batch/lookup_scale/context_size/1000 | 62139345 | 4023.22 | - | +0.00% | ok |
+| transform/batch/simple/records_5k | 10072816 | 496385.52 | - | +0.00% | ok |
+| transform/end_to_end/json/batch_transform | 19096434 | 523657.97 | - | +0.00% | ok |
+| transform/end_to_end/json/stream_drain | 18634890 | 536627.81 | - | +0.00% | ok |
+| transform/evaluator/json/record_loop | 13709661 | 729412.65 | - | +0.00% | ok |
+| transform/stream/csv/records_10k | 10914281 | 916230.77 | - | +0.00% | ok |
+| transform/v2/collection/items_per_record/16 | 25542453 | 19575.25 | - | +0.00% | ok |
+| transform/v2/collection/items_per_record/4 | 5306637 | 94221.64 | - | +0.00% | ok |
+| transform/v2/collection/items_per_record/64 | 236207631 | 2116.78 | - | +0.00% | ok |

--- a/crates/rulemorph/benches/common/mod.rs
+++ b/crates/rulemorph/benches/common/mod.rs
@@ -1,0 +1,164 @@
+#![allow(dead_code)]
+
+use criterion::Throughput;
+use rulemorph::{RuleFile, TransformStream, parse_rule_file};
+use serde_json::{Value as JsonValue, json};
+
+pub const SIMPLE_RULES: &str = r#"
+version: 1
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "id"
+    source: "input.id"
+  - target: "name"
+    source: "input.name"
+  - target: "price"
+    source: "input.price"
+    type: "float"
+"#;
+
+pub const LOOKUP_RULES: &str = r#"
+version: 1
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "id"
+    source: "input.id"
+  - target: "user_name"
+    expr:
+      op: "lookup_first"
+      args:
+        - { ref: "context.users" }
+        - "id"
+        - { ref: "input.user_id" }
+        - "name"
+  - target: "tags"
+    expr:
+      op: "lookup"
+      args:
+        - { ref: "context.tags" }
+        - "id"
+        - { ref: "input.tag_id" }
+        - "value"
+"#;
+
+pub const V2_COLLECTION_RULES: &str = r#"
+version: 2
+input:
+  format: json
+mappings:
+  - target: "id"
+    source: "input.id"
+  - target: "active_total"
+    expr:
+      - "@input.items"
+      - filter: ["@item.active"]
+      - map:
+          - "@item.amount"
+      - sum
+"#;
+
+pub fn parse_rule(source: &str) -> RuleFile {
+    parse_rule_file(source).expect("benchmark rule should parse")
+}
+
+pub fn simple_input(record_count: usize) -> String {
+    let records: Vec<JsonValue> = (0..record_count)
+        .map(|i| {
+            json!({
+                "id": i as i64,
+                "name": format!("item-{}", i),
+                "price": (i % 100) as f64 + 0.5,
+            })
+        })
+        .collect();
+    serde_json::to_string(&records).expect("failed to serialize simple input")
+}
+
+pub fn lookup_input(record_count: usize, user_count: usize, tag_count: usize) -> String {
+    let records: Vec<JsonValue> = (0..record_count)
+        .map(|i| {
+            json!({
+                "id": i as i64,
+                "user_id": (i % user_count) as i64,
+                "tag_id": format!("t{}", i % tag_count),
+            })
+        })
+        .collect();
+    serde_json::to_string(&records).expect("failed to serialize lookup input")
+}
+
+pub fn lookup_context(user_count: usize, tag_count: usize) -> JsonValue {
+    let users: Vec<JsonValue> = (0..user_count)
+        .map(|i| json!({ "id": i as i64, "name": format!("user-{}", i) }))
+        .collect();
+    let tags: Vec<JsonValue> = (0..tag_count)
+        .map(|i| json!({ "id": format!("t{}", i), "value": format!("tag-{}", i) }))
+        .collect();
+    json!({ "users": users, "tags": tags })
+}
+
+pub fn v2_collection_input(record_count: usize, item_count: usize) -> String {
+    let records: Vec<JsonValue> = (0..record_count)
+        .map(|i| {
+            let items: Vec<JsonValue> = (0..item_count)
+                .map(|j| json!({ "active": j % 2 == 0, "amount": ((i + j) % 10) as i64 }))
+                .collect();
+            json!({ "id": i as i64, "items": items })
+        })
+        .collect();
+    serde_json::to_string(&records).expect("failed to serialize v2 input")
+}
+
+pub fn extended_input(record_count: usize) -> String {
+    let records: Vec<JsonValue> = (0..record_count)
+        .map(|_| {
+            json!({
+                "text": "abc-123-abc",
+                "regex_text": "a1b2c3",
+                "csv": "a,b,c",
+                "pad": "7",
+                "num_a": 80.6,
+                "num_b": "2.5",
+                "num_c": 3,
+                "base_value": 255,
+                "date_simple": "2024-01-02 03:04:05",
+                "date_tz": "2024-01-02T03:04:05+09:00",
+                "unix_s": "1970-01-01T00:00:01Z",
+                "unix_ms": "1970-01-01T00:00:00.123Z"
+            })
+        })
+        .collect();
+    serde_json::to_string(&records).expect("failed to serialize extended input")
+}
+
+pub fn csv_input(record_count: usize) -> String {
+    let mut input = String::from("id,name,price\n");
+    for i in 0..record_count {
+        input.push_str(&format!("{},item-{},{:.1}\n", i, i, (i % 100) as f64 + 0.5));
+    }
+    input
+}
+
+pub fn drain_stream(stream: TransformStream<'_>) -> usize {
+    let mut count = 0usize;
+    for item in stream {
+        let item = item.expect("stream item should transform");
+        if item.output.is_some() {
+            count += 1;
+        }
+        std::hint::black_box(item.warnings);
+    }
+    count
+}
+
+pub fn elements(records: usize) -> Throughput {
+    Throughput::Elements(records as u64)
+}
+
+pub fn bytes(input: &str) -> Throughput {
+    Throughput::Bytes(input.len() as u64)
+}

--- a/crates/rulemorph/benches/exec_mode_bench.rs
+++ b/crates/rulemorph/benches/exec_mode_bench.rs
@@ -1,0 +1,82 @@
+mod common;
+
+use common::{SIMPLE_RULES, csv_input, drain_stream, elements, parse_rule, simple_input};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rulemorph::{transform, transform_record, transform_stream};
+use serde_json::Value as JsonValue;
+
+const CSV_RULES: &str = r#"
+version: 1
+input:
+  format: csv
+  csv:
+    has_header: true
+mappings:
+  - target: "id"
+    source: "input.id"
+  - target: "name"
+    source: "input.name"
+"#;
+
+fn bench_exec_modes(c: &mut Criterion) {
+    let record_count = 10_000usize;
+    let rule = parse_rule(SIMPLE_RULES);
+    let input = simple_input(record_count);
+    let records: Vec<JsonValue> =
+        serde_json::from_str(&input).expect("benchmark json should parse");
+
+    let mut end_to_end = c.benchmark_group("transform/end_to_end/json");
+    end_to_end.throughput(elements(record_count));
+
+    end_to_end.bench_function("batch_transform", |b| {
+        b.iter(|| {
+            let output = transform(&rule, black_box(&input), None).expect("transform failed");
+            black_box(output);
+        })
+    });
+
+    end_to_end.bench_function("stream_drain", |b| {
+        b.iter(|| {
+            let stream = transform_stream(&rule, black_box(&input), None).expect("stream failed");
+            let count = drain_stream(stream);
+            black_box(count);
+        })
+    });
+    end_to_end.finish();
+
+    let mut evaluator = c.benchmark_group("transform/evaluator/json");
+    evaluator.throughput(elements(record_count));
+
+    evaluator.bench_function("record_loop", |b| {
+        b.iter(|| {
+            let mut count = 0usize;
+            for record in &records {
+                let output = transform_record(&rule, black_box(record), None)
+                    .expect("record transform failed");
+                if output.is_some() {
+                    count += 1;
+                }
+            }
+            black_box(count);
+        })
+    });
+
+    evaluator.finish();
+
+    let csv_rule = parse_rule(CSV_RULES);
+    let csv_data = csv_input(record_count);
+    let mut csv_stream = c.benchmark_group("transform/stream/csv");
+    csv_stream.throughput(elements(record_count));
+    csv_stream.bench_function("records_10k", |b| {
+        b.iter(|| {
+            let stream =
+                transform_stream(&csv_rule, black_box(&csv_data), None).expect("stream failed");
+            let count = drain_stream(stream);
+            black_box(count);
+        })
+    });
+    csv_stream.finish();
+}
+
+criterion_group!(benches, bench_exec_modes);
+criterion_main!(benches);

--- a/crates/rulemorph/benches/normalize_bench.rs
+++ b/crates/rulemorph/benches/normalize_bench.rs
@@ -1,0 +1,63 @@
+mod common;
+
+use common::{SIMPLE_RULES, bytes, csv_input, parse_rule, simple_input};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rulemorph::{InputData, normalize_records};
+
+const CSV_RULES: &str = r#"
+version: 1
+input:
+  format: csv
+  csv:
+    has_header: true
+mappings:
+  - target: "id"
+    source: "input.id"
+"#;
+
+fn bench_normalize_json(c: &mut Criterion) {
+    let record_count = 10_000usize;
+    let rule = parse_rule(SIMPLE_RULES);
+    let input = simple_input(record_count);
+    let mut group = c.benchmark_group("normalize/json");
+    group.throughput(bytes(&input));
+    group.bench_function("records_10k", |b| {
+        b.iter(|| {
+            let mut count = 0usize;
+            for record in normalize_records(&rule, InputData::Text(black_box(&input)))
+                .expect("json should normalize")
+            {
+                let record = record.expect("json record should normalize");
+                black_box(record);
+                count += 1;
+            }
+            black_box(count);
+        })
+    });
+    group.finish();
+}
+
+fn bench_normalize_csv(c: &mut Criterion) {
+    let record_count = 10_000usize;
+    let rule = parse_rule(CSV_RULES);
+    let input = csv_input(record_count);
+    let mut group = c.benchmark_group("normalize/csv");
+    group.throughput(bytes(&input));
+    group.bench_function("records_10k", |b| {
+        b.iter(|| {
+            let mut count = 0usize;
+            for record in normalize_records(&rule, InputData::Text(black_box(&input)))
+                .expect("csv should normalize")
+            {
+                let record = record.expect("csv record should normalize");
+                black_box(record);
+                count += 1;
+            }
+            black_box(count);
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_normalize_json, bench_normalize_csv);
+criterion_main!(benches);

--- a/crates/rulemorph/benches/parse_bench.rs
+++ b/crates/rulemorph/benches/parse_bench.rs
@@ -1,0 +1,50 @@
+mod common;
+
+use common::{LOOKUP_RULES, SIMPLE_RULES};
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use rulemorph::parse_rule_file;
+
+const EXTENDED_RULES: &str = include_str!("../tests/fixtures/t13_expr_extended/rules.yaml");
+
+fn bench_parse_rules(c: &mut Criterion) {
+    let mut cached = c.benchmark_group("parse/rule_file_cached");
+    for (name, source) in [
+        ("simple", SIMPLE_RULES),
+        ("lookup", LOOKUP_RULES),
+        ("extended", EXTENDED_RULES),
+    ] {
+        cached.bench_function(name, |b| {
+            b.iter(|| {
+                let rule = parse_rule_file(black_box(source)).expect("rule should parse");
+                black_box(rule);
+            })
+        });
+    }
+    cached.finish();
+
+    let mut cold_like = c.benchmark_group("parse/rule_file_cold_like");
+    for (name, source) in [
+        ("simple", SIMPLE_RULES),
+        ("lookup", LOOKUP_RULES),
+        ("extended", EXTENDED_RULES),
+    ] {
+        let mut iteration = 0usize;
+        cold_like.bench_function(name, |b| {
+            b.iter_batched(
+                || {
+                    iteration += 1;
+                    format!("{}\n# bench-{}", source, iteration)
+                },
+                |source| {
+                    let rule = parse_rule_file(black_box(&source)).expect("rule should parse");
+                    black_box(rule);
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    cold_like.finish();
+}
+
+criterion_group!(benches, bench_parse_rules);
+criterion_main!(benches);

--- a/crates/rulemorph/benches/trace_bench.rs
+++ b/crates/rulemorph/benches/trace_bench.rs
@@ -1,0 +1,64 @@
+mod common;
+
+use common::{SIMPLE_RULES, elements, parse_rule, simple_input};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rulemorph::{InputData, TransformTraceOptions, transform, transform_input_with_trace};
+
+fn bench_trace_overhead(c: &mut Criterion) {
+    let record_count = 1_000usize;
+    let rule = parse_rule(SIMPLE_RULES);
+    let input = simple_input(record_count);
+    let metadata_only = TransformTraceOptions::metadata_only();
+    let raw = TransformTraceOptions::raw();
+
+    let mut group = c.benchmark_group("trace/simple");
+    group.throughput(elements(record_count));
+
+    group.bench_function("trace_off", |b| {
+        b.iter(|| {
+            let output = transform(&rule, black_box(&input), None).expect("transform failed");
+            black_box(output);
+        })
+    });
+
+    group.bench_function("trace_metadata_only", |b| {
+        b.iter(|| {
+            let result = transform_input_with_trace(
+                &rule,
+                InputData::Text(black_box(&input)),
+                None,
+                &metadata_only,
+            )
+            .expect("trace transform failed");
+            let event_count: usize = result
+                .trace
+                .records
+                .iter()
+                .map(|record| record.events.len())
+                .sum();
+            black_box(result.output);
+            black_box(event_count);
+        })
+    });
+
+    group.bench_function("trace_raw", |b| {
+        b.iter(|| {
+            let result =
+                transform_input_with_trace(&rule, InputData::Text(black_box(&input)), None, &raw)
+                    .expect("trace transform failed");
+            let event_count: usize = result
+                .trace
+                .records
+                .iter()
+                .map(|record| record.events.len())
+                .sum();
+            black_box(result.output);
+            black_box(event_count);
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_trace_overhead);
+criterion_main!(benches);

--- a/crates/rulemorph/benches/transform_bench.rs
+++ b/crates/rulemorph/benches/transform_bench.rs
@@ -1,160 +1,104 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+mod common;
+
+use common::{
+    LOOKUP_RULES, SIMPLE_RULES, elements, extended_input, lookup_context, lookup_input, parse_rule,
+    simple_input,
+};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use rulemorph::{parse_rule_file, transform};
-use serde_json::json;
 
 const EXTENDED_RULES: &str = include_str!("../tests/fixtures/t13_expr_extended/rules.yaml");
 
-const SIMPLE_RULES: &str = r#"
-version: 1
-input:
-  format: json
-  json: {}
-mappings:
-  - target: "id"
-    source: "input.id"
-  - target: "name"
-    source: "input.name"
-  - target: "price"
-    source: "input.price"
-    type: "float"
-"#;
-
-const LOOKUP_RULES: &str = r#"
-version: 1
-input:
-  format: json
-  json: {}
-mappings:
-  - target: "id"
-    source: "input.id"
-  - target: "user_name"
-    expr:
-      op: "lookup_first"
-      args:
-        - { ref: "context.users" }
-        - "id"
-        - { ref: "input.user_id" }
-        - "name"
-  - target: "tags"
-    expr:
-      op: "lookup"
-      args:
-        - { ref: "context.tags" }
-        - "id"
-        - { ref: "input.tag_id" }
-        - "value"
-"#;
-
 fn bench_simple_transform(c: &mut Criterion) {
-    let rule = parse_rule_file(SIMPLE_RULES).expect("failed to parse rules");
-    let input = build_simple_input(5000);
+    let record_count = 5_000usize;
+    let rule = parse_rule(SIMPLE_RULES);
+    let input = simple_input(record_count);
 
-    c.bench_function("transform_simple", |b| {
+    let mut group = c.benchmark_group("transform/batch/simple");
+    group.throughput(elements(record_count));
+    group.bench_function("records_5k", |b| {
         b.iter(|| {
             let output = transform(&rule, black_box(&input), None).expect("transform failed");
             black_box(output);
         })
     });
+    group.finish();
 }
 
 fn bench_lookup_transform(c: &mut Criterion) {
-    let rule = parse_rule_file(LOOKUP_RULES).expect("failed to parse rules");
-    let input = build_lookup_input(5000, 100, 100);
-    let context = build_context(100, 100);
+    let record_count = 5_000usize;
+    let user_count = 100usize;
+    let tag_count = 100usize;
+    let rule = parse_rule(LOOKUP_RULES);
+    let input = lookup_input(record_count, user_count, tag_count);
+    let context = lookup_context(user_count, tag_count);
 
-    c.bench_function("transform_lookup", |b| {
+    let mut group = c.benchmark_group("transform/batch/lookup");
+    group.throughput(elements(record_count));
+    group.bench_function("records_5k_context_100", |b| {
         b.iter(|| {
             let output =
                 transform(&rule, black_box(&input), Some(&context)).expect("transform failed");
             black_box(output);
         })
     });
+    group.finish();
 }
 
 fn bench_extended_transform_with_rule_parse(c: &mut Criterion) {
-    let input = build_extended_input(5000);
+    let record_count = 5_000usize;
+    let input = extended_input(record_count);
 
-    c.bench_function("transform_extended_parse_rule", |b| {
+    let mut group = c.benchmark_group("transform/batch/extended");
+    group.throughput(elements(record_count));
+    group.bench_function("cold_parse_records_5k", |b| {
         b.iter(|| {
             let rule = parse_rule_file(EXTENDED_RULES).expect("failed to parse rules");
             let output = transform(&rule, black_box(&input), None).expect("transform failed");
             black_box(output);
         })
     });
+
+    let rule = parse_rule_file(EXTENDED_RULES).expect("failed to parse rules");
+    group.bench_function("hot_records_5k", |b| {
+        b.iter(|| {
+            let output = transform(&rule, black_box(&input), None).expect("transform failed");
+            black_box(output);
+        })
+    });
+    group.finish();
 }
 
-fn build_simple_input(count: usize) -> String {
-    let mut records = Vec::with_capacity(count);
-    for i in 0..count {
-        records.push(json!({
-            "id": i as i64,
-            "name": format!("item-{}", i),
-            "price": (i % 100) as f64 + 0.5,
-        }));
-    }
-    serde_json::to_string(&records).expect("failed to serialize input")
-}
+fn bench_lookup_scale(c: &mut Criterion) {
+    let record_count = 250usize;
+    let rule = parse_rule(LOOKUP_RULES);
+    let mut group = c.benchmark_group("transform/batch/lookup_scale");
+    group.throughput(elements(record_count));
 
-fn build_lookup_input(count: usize, user_count: usize, tag_count: usize) -> String {
-    let mut records = Vec::with_capacity(count);
-    for i in 0..count {
-        records.push(json!({
-            "id": i as i64,
-            "user_id": (i % user_count) as i64,
-            "tag_id": format!("t{}", i % tag_count),
-        }));
-    }
-    serde_json::to_string(&records).expect("failed to serialize input")
-}
-
-fn build_context(user_count: usize, tag_count: usize) -> serde_json::Value {
-    let mut users = Vec::with_capacity(user_count);
-    for i in 0..user_count {
-        users.push(json!({
-            "id": i as i64,
-            "name": format!("user-{}", i),
-        }));
+    for context_size in [10usize, 100, 1_000] {
+        let input = lookup_input(record_count, context_size, context_size);
+        let context = lookup_context(context_size, context_size);
+        group.bench_with_input(
+            BenchmarkId::new("context_size", context_size),
+            &context_size,
+            |b, _| {
+                b.iter(|| {
+                    let output = transform(&rule, black_box(&input), Some(&context))
+                        .expect("transform failed");
+                    black_box(output);
+                })
+            },
+        );
     }
 
-    let mut tags = Vec::with_capacity(tag_count);
-    for i in 0..tag_count {
-        tags.push(json!({
-            "id": format!("t{}", i),
-            "value": format!("tag-{}", i),
-        }));
-    }
-
-    json!({
-        "users": users,
-        "tags": tags,
-    })
-}
-
-fn build_extended_input(count: usize) -> String {
-    let mut records = Vec::with_capacity(count);
-    for _ in 0..count {
-        records.push(json!({
-            "text": "abc-123-abc",
-            "regex_text": "a1b2c3",
-            "csv": "a,b,c",
-            "pad": "7",
-            "num_a": 80.6,
-            "num_b": "2.5",
-            "num_c": 3,
-            "base_value": 255,
-            "date_simple": "2024-01-02 03:04:05",
-            "date_tz": "2024-01-02T03:04:05+09:00",
-            "unix_s": "1970-01-01T00:00:01Z",
-            "unix_ms": "1970-01-01T00:00:00.123Z"
-        }));
-    }
-    serde_json::to_string(&records).expect("failed to serialize input")
+    group.finish();
 }
 
 criterion_group!(
     benches,
     bench_simple_transform,
     bench_lookup_transform,
-    bench_extended_transform_with_rule_parse
+    bench_extended_transform_with_rule_parse,
+    bench_lookup_scale
 );
 criterion_main!(benches);

--- a/crates/rulemorph/benches/v2_bench.rs
+++ b/crates/rulemorph/benches/v2_bench.rs
@@ -1,0 +1,32 @@
+mod common;
+
+use common::{V2_COLLECTION_RULES, elements, parse_rule, v2_collection_input};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use rulemorph::transform;
+
+fn bench_v2_collection(c: &mut Criterion) {
+    let record_count = 500usize;
+    let rule = parse_rule(V2_COLLECTION_RULES);
+    let mut group = c.benchmark_group("transform/v2/collection");
+    group.throughput(elements(record_count));
+
+    for item_count in [4usize, 16, 64] {
+        let input = v2_collection_input(record_count, item_count);
+        group.bench_with_input(
+            BenchmarkId::new("items_per_record", item_count),
+            &item_count,
+            |b, _| {
+                b.iter(|| {
+                    let output =
+                        transform(&rule, black_box(&input), None).expect("transform failed");
+                    black_box(output);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_v2_collection);
+criterion_main!(benches);

--- a/crates/rulemorph/tests/perf_allocation.rs
+++ b/crates/rulemorph/tests/perf_allocation.rs
@@ -1,0 +1,191 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use rulemorph::{parse_rule_file, transform, transform_record, transform_stream};
+use serde_json::json;
+
+struct CountingAlloc;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+static CURRENT_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+static MEASURE_LOCK: Mutex<()> = Mutex::new(());
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if ENABLED.load(Ordering::Relaxed) && !ptr.is_null() {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+            let current = CURRENT_BYTES.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            let mut observed = PEAK_BYTES.load(Ordering::Relaxed);
+            while current > observed
+                && PEAK_BYTES
+                    .compare_exchange(observed, current, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_err()
+            {
+                observed = PEAK_BYTES.load(Ordering::Relaxed);
+            }
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ENABLED.load(Ordering::Relaxed) && !ptr.is_null() {
+            CURRENT_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[derive(Debug)]
+struct AllocSnapshot {
+    allocs: usize,
+    bytes: usize,
+    peak_bytes: usize,
+}
+
+fn measure<T>(f: impl FnOnce() -> T) -> (T, AllocSnapshot) {
+    let _guard = MEASURE_LOCK
+        .lock()
+        .expect("allocation measure lock poisoned");
+    ALLOCS.store(0, Ordering::Relaxed);
+    BYTES.store(0, Ordering::Relaxed);
+    CURRENT_BYTES.store(0, Ordering::Relaxed);
+    PEAK_BYTES.store(0, Ordering::Relaxed);
+    ENABLED.store(true, Ordering::Relaxed);
+    let result = f();
+    ENABLED.store(false, Ordering::Relaxed);
+    let snapshot = AllocSnapshot {
+        allocs: ALLOCS.load(Ordering::Relaxed),
+        bytes: BYTES.load(Ordering::Relaxed),
+        peak_bytes: PEAK_BYTES.load(Ordering::Relaxed),
+    };
+    (result, snapshot)
+}
+
+const CSV_RULES: &str = r#"
+version: 1
+input:
+  format: csv
+  csv:
+    has_header: true
+mappings:
+  - target: "id"
+    source: "input.id"
+  - target: "name"
+    source: "input.name"
+"#;
+
+fn csv_input(record_count: usize) -> String {
+    let mut input = String::from("id,name\n");
+    for i in 0..record_count {
+        input.push_str(&format!("{},item-{}\n", i, i));
+    }
+    input
+}
+
+#[test]
+fn stream_peak_memory_grows_slower_than_batch_for_csv() {
+    let _test_guard = TEST_LOCK.lock().expect("allocation test lock poisoned");
+    let rule = parse_rule_file(CSV_RULES).expect("rule should parse");
+    let small = csv_input(1_000);
+    let large = csv_input(20_000);
+
+    let (_, small_stream) = measure(|| {
+        let stream = transform_stream(&rule, &small, None).expect("stream should start");
+        stream
+            .map(|item| item.expect("stream item should transform"))
+            .filter(|item| item.output.is_some())
+            .count()
+    });
+    let (_, large_stream) = measure(|| {
+        let stream = transform_stream(&rule, &large, None).expect("stream should start");
+        stream
+            .map(|item| item.expect("stream item should transform"))
+            .filter(|item| item.output.is_some())
+            .count()
+    });
+    let (_, small_batch) = measure(|| transform(&rule, &small, None).expect("batch should pass"));
+    let (_, large_batch) = measure(|| transform(&rule, &large, None).expect("batch should pass"));
+
+    eprintln!(
+        "stream allocation baseline: small={:?} large={:?}; batch baseline: small={:?} large={:?}",
+        small_stream, large_stream, small_batch, large_batch
+    );
+
+    assert!(
+        large_stream.peak_bytes < small_stream.peak_bytes * 4,
+        "stream peak should stay near constant: small={:?} large={:?}",
+        small_stream,
+        large_stream
+    );
+    assert!(
+        large_batch.peak_bytes > small_batch.peak_bytes * 8,
+        "batch peak should grow with output records: small={:?} large={:?}",
+        small_batch,
+        large_batch
+    );
+}
+
+#[test]
+fn simple_json_transform_allocation_per_record_stays_bounded() {
+    let _test_guard = TEST_LOCK.lock().expect("allocation test lock poisoned");
+    let rule = parse_rule_file(
+        r#"
+version: 1
+input:
+  format: json
+  json: {}
+mappings:
+  - target: "id"
+    source: "input.id"
+  - target: "name"
+    source: "input.name"
+"#,
+    )
+    .expect("rule should parse");
+    let records: Vec<_> = (0..2_000)
+        .map(|i| json!({ "id": i, "name": format!("item-{}", i) }))
+        .collect();
+
+    let (_, stats) = measure(|| {
+        let mut count = 0usize;
+        for record in &records {
+            if transform_record(&rule, record, None)
+                .expect("record transform should pass")
+                .is_some()
+            {
+                count += 1;
+            }
+        }
+        count
+    });
+    let bytes_per_record = stats.bytes / 2_000;
+    let allocs_per_record = stats.allocs / 2_000;
+
+    eprintln!(
+        "json transform allocation baseline: stats={:?} bytes_per_record={} allocs_per_record={}",
+        stats, bytes_per_record, allocs_per_record
+    );
+
+    assert!(
+        bytes_per_record < 1_800,
+        "bytes per record should stay bounded: stats={:?}",
+        stats
+    );
+    assert!(
+        allocs_per_record < 40,
+        "allocations per record should stay bounded: stats={:?}",
+        stats
+    );
+}

--- a/crates/rulemorph/tests/performance.rs
+++ b/crates/rulemorph/tests/performance.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use rulemorph::{parse_rule_file, transform};
 use serde_json::json;
 
@@ -10,7 +8,7 @@ input:
   json: {}
 mappings:
   - target: "id"
-    source: "id"
+    source: "input.id"
   - target: "user_name"
     expr:
       op: "lookup_first"
@@ -30,33 +28,23 @@ mappings:
 "#;
 
 #[test]
-#[ignore]
-fn perf_lookup_transform() {
-    let record_count = env_usize("PERF_RECORDS", 10_000);
-    let iterations = env_usize("PERF_ITERS", 5);
-    let user_count = env_usize("PERF_USERS", 100);
-    let tag_count = env_usize("PERF_TAGS", 100);
+fn performance_workload_smoke_still_transforms_lookup_records() {
+    let record_count = 1_000usize;
+    let user_count = 100usize;
+    let tag_count = 100usize;
 
     let rule = parse_rule_file(PERF_RULES).expect("failed to parse perf rules");
     let input = build_input(record_count, user_count, tag_count);
     let context = build_context(user_count, tag_count);
 
-    let start = Instant::now();
-    let mut last_len = 0;
-    for _ in 0..iterations {
-        let output = transform(&rule, &input, Some(&context)).expect("transform failed");
-        last_len = output.as_array().map(|items| items.len()).unwrap_or(0);
-        std::hint::black_box(output);
-    }
-    let elapsed = start.elapsed();
+    let output = transform(&rule, &input, Some(&context)).expect("transform failed");
+    let records = output.as_array().expect("output should be an array");
 
-    assert_eq!(last_len, record_count);
-    eprintln!(
-        "perf_lookup_transform records={} iters={} elapsed_ms={}",
-        record_count,
-        iterations,
-        elapsed.as_millis()
-    );
+    assert_eq!(records.len(), record_count);
+    assert_eq!(records[0]["user_name"], "user-0");
+    assert_eq!(records[0]["tags"], json!(["tag-0"]));
+    assert_eq!(records[999]["user_name"], "user-99");
+    assert_eq!(records[999]["tags"], json!(["tag-99"]));
 }
 
 fn build_context(user_count: usize, tag_count: usize) -> serde_json::Value {
@@ -94,11 +82,4 @@ fn build_input(record_count: usize, user_count: usize, tag_count: usize) -> Stri
     }
 
     serde_json::to_string(&records).expect("failed to serialize input")
-}
-
-fn env_usize(name: &str, default: usize) -> usize {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(default)
 }

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -1,0 +1,69 @@
+# Rulemorph Core Performance
+
+この文書は `crates/rulemorph` 本体の性能測定だけを扱います。CLI、MCP、server、UI の性能は対象外です。
+
+## ローカル測定
+
+```bash
+PERF_TARGET="$(mktemp -d /tmp/rulemorph-perf-target.XXXXXX)"
+CARGO_TARGET_DIR="${PERF_TARGET}" cargo bench -p rulemorph --bench transform_bench
+CARGO_TARGET_DIR="${PERF_TARGET}" cargo bench -p rulemorph --bench parse_bench
+CARGO_TARGET_DIR="${PERF_TARGET}" cargo bench -p rulemorph --bench normalize_bench
+CARGO_TARGET_DIR="${PERF_TARGET}" cargo bench -p rulemorph --bench exec_mode_bench
+CARGO_TARGET_DIR="${PERF_TARGET}" cargo bench -p rulemorph --bench trace_bench
+CARGO_TARGET_DIR="${PERF_TARGET}" cargo bench -p rulemorph --bench v2_bench
+python3 scripts/perf_report.py --criterion-dir "${PERF_TARGET}/criterion" --json-output crates/rulemorph/PERF.json > crates/rulemorph/PERF.md
+```
+
+PR や作業ブランチで committed snapshot と比較する場合:
+
+```bash
+python3 scripts/perf_report.py --criterion-dir target/criterion --baseline-json crates/rulemorph/PERF.json --json-output perf-report.json > perf-report.md
+```
+
+## 指標
+
+- `records/sec`: record evaluator や batch transform の主指標。
+- `MB/sec`: normalization の主指標。
+- `mean ns/iter`: Criterion が直接測る反復単位の wall-clock。`crates/rulemorph/PERF.md` の delta 判定に使う。
+- `ns/record`: レポート列には出さず、必要なときに `mean ns/iter` を record 数で割って傾きを確認する補助指標。
+- allocation canary: PR で fail してよい安定指標。
+- Criterion wall-clock: `crates/rulemorph/PERF.json` との delta と artifact で確認する advisory 指標。
+
+## 判定ラベル
+
+- `improvement`: baseline 比で mean ns/iter が 5% 以上改善した。
+- `ok`: baseline 比の変化が +10% 未満。
+- `warn`: baseline 比で +10% 以上遅くなった。PR 説明に理由を書く。
+- `regression`: baseline 比で +20% 以上遅くなった。CI は fail しないが、意図した劣化でなければ修正する。
+- `new`: baseline に存在しない benchmark。新規追加時は `crates/rulemorph/PERF.json` を更新する。
+- `missing`: baseline には存在するが、今回の short canary では実行されなかった benchmark。PR CI では advisory として表示し、full baseline 更新時には空にする。
+
+## ゲート方針
+
+wall-clock の Criterion regression は GitHub runner で揺れるため、単独では fail しません。fail してよいのは `cargo test -p rulemorph --test perf_allocation -- --test-threads=1` のような deterministic canary です。`iai-callgrind` を導入するまでは allocation canary を blocking gate とし、Criterion delta は advisory として扱います。
+
+allocation canary の閾値は初回実測値から決めます。初期値は `cargo test -p rulemorph --test perf_allocation -- --test-threads=1 --nocapture` の観測値の 1.25 倍以上にし、複数回の CI 実行で安定してからだけ tighten します。
+
+## CI セキュリティ
+
+performance CI は PR の code を `cargo test` / `cargo bench` で実行するため、`pull_request_target` ではなく `pull_request` だけを使います。workflow 権限は `permissions: contents: read` に固定し、secrets や write 権限に依存しません。checkout は `persist-credentials: false` にし、未信頼 code を実行する step では `GITHUB_STEP_SUMMARY=/dev/null` を設定します。
+
+human-facing report は base branch から checkout した trusted `scripts/perf_report.py` で生成します。PR head 側の script は cargo bench の対象にはなりますが、summary renderer としては使いません。初回導入 PR のように base branch に trusted renderer がまだ無い場合は、PR script に fallback せず、固定文の report と Criterion JSON artifact だけを残します。
+
+将来 PR comment を自動投稿する場合は、この benchmark 実行 job に `pull-requests: write` を足しません。別 workflow/job に分け、PR job 由来 artifact は未信頼 data として schema、size、文字種を検証します。artifact 内の script や HTML は実行せず、PR head も checkout せず、base branch の trusted parser だけで Markdown を再生成します。
+
+`$GITHUB_STEP_SUMMARY` に出す benchmark ID は Markdown table 用に escape します。benchmark ID は通常 repo 内定数ですが、report spoofing を避けるため script 側で `|` と改行を無害化します。
+
+trusted renderer は未信頼 PR code が生成した Criterion JSON を読むため、入力サイズにも上限を置きます。`scripts/perf_report.py` は symlink / non-file JSON、Criterion result file 数、JSON file size、benchmark ID 長、mean / throughput 値の範囲を制限し、異常な artifact は Markdown 生成前に拒否します。
+
+## 更新ルール
+
+性能改善または意図した性能劣化がある PR では、`crates/rulemorph/PERF.md` と `crates/rulemorph/PERF.json` を同時に更新します。挙動変更では `cargo test -p rulemorph` を必ず通し、normalization を触る場合は `docs/agent-guides/input-normalization-security.md`、trace を触る場合は `docs/agent-guides/semantic-trace.md` の invariant を確認します。
+
+## Future Work
+
+- Linux runner で `iai-callgrind` を導入し、instruction count を deterministic gate にできるか検証する。
+- HTML / Excel normalization bench は resource limit と fixture サイズを固定してから feature-gated bench として追加する。
+- 複数回の CI 実行結果を見て、allocation canary の閾値を tighten する。
+- PR comment 自動投稿を入れる場合は、benchmark 実行 workflow から分離した read-only artifact parser として設計する。

--- a/scripts/perf_report.py
+++ b/scripts/perf_report.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import math
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CRITERION = ROOT / "target" / "criterion"
+WARN_THRESHOLD = 10.0
+REGRESSION_THRESHOLD = 20.0
+IMPROVEMENT_THRESHOLD = -5.0
+MAX_CRITERION_RESULT_FILES = 200
+MAX_JSON_BYTES = 1_048_576
+MAX_BENCHMARK_ID_CHARS = 300
+MAX_THROUGHPUT_VALUE = 1_000_000_000_000
+
+
+def load_estimates(criterion_dir):
+    rows = []
+    for estimates_path in estimate_paths(criterion_dir):
+        data = load_json_limited(estimates_path)
+        mean = data.get("mean", {})
+        raw_point = mean.get("point_estimate")
+        if raw_point is None:
+            continue
+        point = finite_number(raw_point)
+        if point is None or point <= 0:
+            raise ValueError(f"invalid Criterion mean point estimate: {estimates_path}")
+        new_dir = estimates_path.parent
+        benchmark = load_benchmark(new_dir / "benchmark.json")
+        throughput = benchmark.get("throughput")
+        name = benchmark_id(benchmark, estimates_path, criterion_dir)
+        if len(name) > MAX_BENCHMARK_ID_CHARS:
+            raise ValueError(f"benchmark id is too long: {estimates_path}")
+        rows.append(
+            {
+                "benchmark": name,
+                "mean_ns": point,
+                "records_sec": records_per_sec(point, throughput),
+                "mb_sec": mb_per_sec(point, throughput),
+            }
+        )
+    return sorted(rows, key=lambda row: row["benchmark"])
+
+
+def estimate_paths(criterion_dir):
+    paths = []
+    for path in criterion_dir.glob("**/new/estimates.json"):
+        paths.append(path)
+        if len(paths) > MAX_CRITERION_RESULT_FILES:
+            raise ValueError(
+                f"too many Criterion result files under {criterion_dir}: "
+                f"limit is {MAX_CRITERION_RESULT_FILES}"
+            )
+    return sorted(paths)
+
+
+def load_json_limited(path):
+    path_stat = path.lstat()
+    if stat.S_ISLNK(path_stat.st_mode):
+        raise ValueError(f"refusing to read symlinked JSON file: {path}")
+    if not stat.S_ISREG(path_stat.st_mode):
+        raise ValueError(f"refusing to read non-file JSON path: {path}")
+    if path_stat.st_size > MAX_JSON_BYTES:
+        raise ValueError(f"JSON file is too large: {path} ({path_stat.st_size} bytes)")
+
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        fd_stat = os.fstat(fd)
+        if not stat.S_ISREG(fd_stat.st_mode):
+            raise ValueError(f"refusing to read non-file JSON path: {path}")
+        if fd_stat.st_size > MAX_JSON_BYTES:
+            raise ValueError(f"JSON file is too large: {path} ({fd_stat.st_size} bytes)")
+        with os.fdopen(fd, "r", encoding="utf-8") as f:
+            fd = None
+            return json.load(f)
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def load_benchmark(path):
+    if not path.exists():
+        return {}
+    return load_json_limited(path)
+
+
+def benchmark_id(benchmark, estimates_path, criterion_dir):
+    group = benchmark.get("group_id")
+    if isinstance(group, str) and group:
+        parts = [group]
+        function_id = benchmark.get("function_id")
+        value_str = benchmark.get("value_str")
+        if isinstance(function_id, str) and function_id:
+            parts.append(function_id)
+        if isinstance(value_str, str) and value_str:
+            parts.append(value_str)
+        return "/".join(parts)
+    return estimates_path.parents[1].relative_to(criterion_dir).as_posix()
+
+
+def records_per_sec(mean_ns, throughput):
+    if not isinstance(throughput, dict) or "Elements" not in throughput:
+        return None
+    elements = throughput_value(throughput.get("Elements"), "Elements")
+    seconds = mean_ns / 1_000_000_000
+    return elements / seconds
+
+
+def mb_per_sec(mean_ns, throughput):
+    if not isinstance(throughput, dict) or "Bytes" not in throughput:
+        return None
+    bytes_value = throughput_value(throughput.get("Bytes"), "Bytes")
+    seconds = mean_ns / 1_000_000_000
+    return (bytes_value / 1_048_576) / seconds
+
+
+def finite_number(value):
+    if not isinstance(value, (int, float)) or not math.isfinite(value):
+        return None
+    return float(value)
+
+
+def throughput_value(value, name):
+    number = finite_number(value)
+    if number is None or number < 0 or number > MAX_THROUGHPUT_VALUE:
+        raise ValueError(f"invalid Criterion throughput {name}: {value!r}")
+    return number
+
+
+def load_json_baseline(path):
+    if path is None or not path.exists():
+        return {}
+    data = load_json_limited(path)
+    baseline = {}
+    for name, values in data.get("benchmarks", {}).items():
+        if isinstance(values, dict):
+            baseline[name] = values
+    return baseline
+
+
+def baseline_mean(entry):
+    if not isinstance(entry, dict):
+        return None
+    mean_ns = entry.get("mean_ns")
+    if isinstance(mean_ns, (int, float)):
+        return float(mean_ns)
+    return None
+
+
+def delta_value(current, baseline):
+    if baseline is None:
+        return None
+    return ((current - baseline) / baseline) * 100
+
+
+def classify_delta(delta):
+    if delta is None:
+        return "new"
+    if delta <= IMPROVEMENT_THRESHOLD:
+        return "improvement"
+    if delta >= REGRESSION_THRESHOLD:
+        return "regression"
+    if delta >= WARN_THRESHOLD:
+        return "warn"
+    return "ok"
+
+
+def with_comparison(rows, baseline):
+    compared = []
+    for row in rows:
+        delta = delta_value(row["mean_ns"], baseline_mean(baseline.get(row["benchmark"])))
+        compared.append(
+            {
+                **row,
+                "delta_percent": delta,
+                "status": classify_delta(delta),
+            }
+        )
+    return compared
+
+
+def format_optional(value, suffix=""):
+    if value is None:
+        return "-"
+    return f"{value:.2f}{suffix}"
+
+
+def format_delta(delta):
+    if delta is None:
+        return "-"
+    return f"{delta:+.2f}%"
+
+
+def markdown_cell(value):
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\r", " ")
+        .replace("\n", " ")
+    )
+
+
+def write_json_snapshot(rows, missing, path):
+    if path is None:
+        return
+    payload = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "thresholds": {
+            "improvement_percent": IMPROVEMENT_THRESHOLD,
+            "warn_percent": WARN_THRESHOLD,
+            "regression_percent": REGRESSION_THRESHOLD,
+        },
+        "benchmarks": {
+            row["benchmark"]: {
+                "mean_ns": row["mean_ns"],
+                "records_sec": row["records_sec"],
+                "mb_sec": row["mb_sec"],
+                "delta_percent": row["delta_percent"],
+                "status": row["status"],
+            }
+            for row in rows
+        },
+        "missing_from_current": missing,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def print_markdown(rows, missing):
+    print("# Rulemorph Core Performance Snapshot")
+    print()
+    print("| benchmark | mean ns/iter | records/sec | MB/sec | baseline delta | status |")
+    print("| --- | ---: | ---: | ---: | ---: | --- |")
+    for row in rows:
+        print(
+            f"| {markdown_cell(row['benchmark'])} | {row['mean_ns']:.0f} | "
+            f"{format_optional(row['records_sec'])} | "
+            f"{format_optional(row['mb_sec'])} | "
+            f"{format_delta(row['delta_percent'])} | "
+            f"{markdown_cell(row['status'])} |"
+        )
+    for name in missing:
+        print(f"| {markdown_cell(name)} | - | - | - | - | missing |")
+    if not rows and not missing:
+        print("| `_no_criterion_results_found_` | 0 | - | - | - | new |")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--criterion-dir", type=Path, default=DEFAULT_CRITERION)
+    parser.add_argument("--baseline-json", type=Path)
+    parser.add_argument("--json-output", type=Path)
+    args = parser.parse_args()
+
+    rows = load_estimates(args.criterion_dir)
+    baseline = load_json_baseline(args.baseline_json)
+    compared = with_comparison(rows, baseline)
+    current_names = {row["benchmark"] for row in compared}
+    missing = sorted(name for name in baseline if name not in current_names)
+
+    write_json_snapshot(compared, missing, args.json_output)
+    print_markdown(compared, missing)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

`crates/rulemorph` 本体の性能測定基盤を追加します。CLI / MCP / server / UI の性能は対象外にし、core library の parse / normalization / transform / trace / execution mode / v2 collection を継続比較できるようにしました。

## 変更内容

- Criterion bench を整理し、`transform/batch/...` などの構造化 benchmark ID と throughput を追加
- `PERF.md` / `PERF.json` に初回 baseline snapshot を追加
- deterministic な allocation canary を追加
- `scripts/perf_report.py` で Criterion JSON から Markdown / JSON report を生成
- read-only の performance CI を追加し、trusted base 側の renderer で report を生成
- root の一時計画・preview・agent作業資材を ignore し、OSS に含める対象を整理

## セキュリティ設計

- workflow は `pull_request` のみで、`pull_request_target` は不使用
- `permissions: contents: read`
- checkout は `persist-credentials: false`
- human-facing report は base branch 側の trusted `perf_report.py` で生成
- report script は symlink / non-file JSON、file count、file size、benchmark ID length、mean / throughput 値を検証

## 検証

- `cargo fmt`
- `cargo test -p rulemorph`
- `cargo test -p rulemorph --test perf_allocation -- --test-threads=1`
- `cargo bench -p rulemorph --bench transform_bench --no-run`
- `cargo bench -p rulemorph --bench parse_bench --no-run`
- `cargo bench -p rulemorph --bench normalize_bench --no-run`
- `cargo bench -p rulemorph --bench exec_mode_bench --no-run`
- `cargo bench -p rulemorph --bench trace_bench --no-run`
- `cargo bench -p rulemorph --bench v2_bench --no-run`
- `cargo bench -p rulemorph --bench transform_bench -- transform/batch/simple/records_5k --warm-up-time 1 --measurement-time 2`
- `python3 -m py_compile scripts/perf_report.py`
- workflow YAML parse check
- `git diff --check`

Note: the short Criterion canary exited 0, but Criterion printed a local-history advisory regression for `transform/batch/simple/records_5k`. This is not a blocking gate; fresh `PERF.md` / `PERF.json` baseline was regenerated from a clean target dir.
