### PR TITLE
Make HTML and Excel input parsers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ Supported languages: `rust`, `typescript`, `python`, `go`, `java`, `kotlin`, `sw
 rulemorph = "0.3.1"
 ```
 
+The `html` and `excel` input parsers are enabled by default. Library users that only need
+CSV, JSON, YAML, TOML, and XML can disable them to reduce optional parser dependencies:
+
+```toml
+[dependencies]
+rulemorph = { version = "0.3.1", default-features = false }
+```
+
+Re-enable one parser explicitly with `features = ["html"]` or `features = ["excel"]`.
+If a disabled parser is selected by a rule, transformation fails with `invalid_input`.
+
 ```rust
 use rulemorph::{parse_rule_file, transform};
 

--- a/crates/rulemorph/Cargo.toml
+++ b/crates/rulemorph/Cargo.toml
@@ -8,6 +8,11 @@ repository = "https://github.com/vinhphatfsg/rulemorph"
 keywords = ["transform", "yaml", "json", "csv", "etl"]
 categories = ["command-line-utilities", "data-structures", "encoding"]
 
+[features]
+default = ["excel", "html"]
+excel = ["dep:calamine", "dep:zip"]
+html = ["dep:scraper"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -17,10 +22,10 @@ regex = "1.12"
 chrono = "0.4"
 toml = "0.8"
 toml_edit = "0.22"
-calamine = { version = "0.26", features = ["dates"] }
-zip = "0.6"
+calamine = { version = "0.26", features = ["dates"], optional = true }
+zip = { version = "0.6", optional = true }
 quick-xml = "0.31"
-scraper = "0.20"
+scraper = { version = "0.20", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/rulemorph/src/model.rs
+++ b/crates/rulemorph/src/model.rs
@@ -3,6 +3,10 @@ use serde_json::Value as JsonValue;
 
 mod input;
 
+#[cfg_attr(
+    any(not(feature = "html"), not(feature = "excel")),
+    allow(unused_imports)
+)]
 pub use self::input::{
     Column, ExcelCellErrorPolicy, ExcelColumn, ExcelDatePolicy, ExcelEmptyCellPolicy,
     ExcelFormulaPolicy, ExcelInput, ExcelSheetRef, HtmlInput, HtmlValueKind, InputFormat,

--- a/crates/rulemorph/src/normalization/mod.rs
+++ b/crates/rulemorph/src/normalization/mod.rs
@@ -1,5 +1,7 @@
 mod csv;
+#[cfg(feature = "excel")]
 mod excel;
+#[cfg(feature = "html")]
 mod html;
 mod input;
 mod json;
@@ -15,6 +17,8 @@ pub use options::NormalizationOptions;
 pub use records::NormalizedRecords;
 
 use crate::error::TransformError;
+#[cfg(any(not(feature = "html"), not(feature = "excel")))]
+use crate::error::TransformErrorKind;
 use crate::model::{InputFormat, RuleFile};
 
 use input::text_input;
@@ -50,10 +54,24 @@ pub fn normalize_records_with_options<'a>(
             toml::normalize_toml_records(rule, text_input(input, options)?, options)?
         }
         InputFormat::Xml => xml::normalize_xml_records(rule, text_input(input, options)?, options)?,
+        #[cfg(feature = "html")]
         InputFormat::Html => {
             html::normalize_html_records(rule, text_input(input, options)?, options)?
         }
+        #[cfg(not(feature = "html"))]
+        InputFormat::Html => return Err(unsupported_input_format("html")),
+        #[cfg(feature = "excel")]
         InputFormat::Excel => excel::normalize_excel_records(rule, input, options)?,
+        #[cfg(not(feature = "excel"))]
+        InputFormat::Excel => return Err(unsupported_input_format("excel")),
     };
     Ok(NormalizedRecords::Materialized(records.into_iter()))
+}
+
+#[cfg(any(not(feature = "html"), not(feature = "excel")))]
+fn unsupported_input_format(format: &str) -> TransformError {
+    TransformError::new(
+        TransformErrorKind::InvalidInput,
+        format!("input format {} is not enabled in this build", format),
+    )
 }

--- a/crates/rulemorph/tests/common/mod.rs
+++ b/crates/rulemorph/tests/common/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod golden;
 pub(crate) mod trace;
 pub(crate) mod validation;
+#[cfg(feature = "excel")]
 pub(crate) mod xlsx;

--- a/crates/rulemorph/tests/common/xlsx.rs
+++ b/crates/rulemorph/tests/common/xlsx.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports)]
+
 use std::io::{Cursor, Write};
 
 use zip::{CompressionMethod, ZipWriter, write::FileOptions};

--- a/crates/rulemorph/tests/feature_flags.rs
+++ b/crates/rulemorph/tests/feature_flags.rs
@@ -1,0 +1,60 @@
+#[cfg(not(feature = "html"))]
+#[test]
+fn html_input_returns_invalid_input_when_feature_is_disabled() {
+    let rule = rulemorph::parse_rule_file(
+        r#"
+version: 2
+input:
+  format: html
+  html:
+    records_selector: ".item"
+    fields:
+      id:
+        selector: ".id"
+mappings:
+  - target: "id"
+    source: "id"
+"#,
+    )
+    .expect("parse html rule");
+
+    let err = rulemorph::transform(
+        &rule,
+        r#"<div class="item"><span class="id">1</span></div>"#,
+        None,
+    )
+    .expect_err("html input should fail when html feature is disabled");
+
+    assert_eq!(err.kind, rulemorph::TransformErrorKind::InvalidInput);
+    assert_eq!(
+        err.message,
+        "input format html is not enabled in this build"
+    );
+}
+
+#[cfg(not(feature = "excel"))]
+#[test]
+fn excel_input_returns_invalid_input_when_feature_is_disabled() {
+    let rule = rulemorph::parse_rule_file(
+        r#"
+version: 2
+input:
+  format: excel
+  excel:
+    has_header: true
+mappings:
+  - target: "id"
+    source: "id"
+"#,
+    )
+    .expect("parse excel rule");
+
+    let err = rulemorph::transform_input(&rule, rulemorph::InputData::Bytes(b"not xlsx"), None)
+        .expect_err("excel input should fail when excel feature is disabled");
+
+    assert_eq!(err.kind, rulemorph::TransformErrorKind::InvalidInput);
+    assert_eq!(
+        err.message,
+        "input format excel is not enabled in this build"
+    );
+}

--- a/crates/rulemorph/tests/transform_golden.rs
+++ b/crates/rulemorph/tests/transform_golden.rs
@@ -1,16 +1,20 @@
 use std::fs;
 
+#[cfg(feature = "excel")]
+use rulemorph::preflight_validate_input;
 use rulemorph::{
     InputData, NormalizationOptions, RuleFormat, TransformErrorKind,
-    normalize_records_with_options, parse_rule_file, preflight_validate_input, transform,
-    transform_input,
+    normalize_records_with_options, parse_rule_file, transform, transform_input,
 };
 mod common;
 
+#[cfg(feature = "excel")]
+use common::golden::assert_xlsx_fixture;
 use common::golden::{
-    assert_json_fixture, assert_text_fixture, assert_transform_error_fixture, assert_xlsx_fixture,
-    fixtures_dir, load_json, load_optional_json, load_rule, load_rule_with_format,
+    assert_json_fixture, assert_text_fixture, assert_transform_error_fixture, fixtures_dir,
+    load_json, load_optional_json, load_rule, load_rule_with_format,
 };
+#[cfg(feature = "excel")]
 use common::xlsx::{
     XlsxFixtureOptions, build_dynamodb_users_xlsx, build_string_table_xlsx, build_test_xlsx,
 };
@@ -29,9 +33,11 @@ include!("transform_golden/input_limits.rs");
 
 include!("transform_golden/input_formats.rs");
 
+#[cfg(feature = "excel")]
 include!("transform_golden/excel.rs");
 
 include!("transform_golden/xml.rs");
+#[cfg(feature = "html")]
 include!("transform_golden/html.rs");
 
 include!("transform_golden/structured_inputs.rs");

--- a/crates/rulemorph/tests/transform_golden/input_formats.rs
+++ b/crates/rulemorph/tests/transform_golden/input_formats.rs
@@ -24,21 +24,25 @@ fn t33_xml_input_transform_golden() {
 }
 
 #[test]
+#[cfg(feature = "html")]
 fn t35_html_input_transform_golden() {
     assert_text_fixture("t35_html_input", "input.html");
 }
 
 #[test]
+#[cfg(feature = "excel")]
 fn t36_spreadsheets_plugin_products() {
     assert_xlsx_fixture("t36_spreadsheets_plugin_products");
 }
 
 #[test]
+#[cfg(feature = "excel")]
 fn t37_spreadsheets_plugin_orders() {
     assert_xlsx_fixture("t37_spreadsheets_plugin_orders");
 }
 
 #[test]
+#[cfg(feature = "excel")]
 fn t38_spreadsheets_plugin_survey() {
     assert_xlsx_fixture("t38_spreadsheets_plugin_survey");
 }


### PR DESCRIPTION
## Summary
- rulemorph の HTML / Excel パーサを optional Cargo feature 化し、default では従来どおり有効化
- disabled feature の入力形式が選ばれた場合は invalid_input で fail closed
- HTML / Excel の golden tests を feature gate し、disabled feature 用の regression test を追加
- README に default-features=false の library usage を追記

## Verification
- cargo fmt
- cargo fmt --check
- cargo check -p rulemorph --no-default-features --all-targets
- cargo check -p rulemorph --no-default-features --features html --all-targets
- cargo check -p rulemorph --no-default-features --features excel --all-targets
- cargo check -p rulemorph --no-default-features --features html,excel --all-targets
- cargo test -p rulemorph --no-default-features --test feature_flags
- cargo test -p rulemorph --no-default-features --features html --test feature_flags
- cargo test -p rulemorph --no-default-features --features excel --test feature_flags
- cargo test -p rulemorph --no-default-features
- cargo test -p rulemorph
- git diff --check
- git diff --cached --check
- codex review --uncommitted