### PR TITLE
[codex] Strengthen DTO type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ Supported languages: `rust`, `typescript`, `python`, `go`, `java`, `kotlin`, `sw
 rulemorph = "0.3.1"
 ```
 
+The `html` and `excel` input parsers are enabled by default. Library users that only need
+CSV, JSON, YAML, TOML, and XML can disable them to reduce optional parser dependencies:
+
+```toml
+[dependencies]
+rulemorph = { version = "0.3.1", default-features = false }
+```
+
+Re-enable one parser explicitly with `features = ["html"]` or `features = ["excel"]`.
+If a disabled parser is selected by a rule, transformation fails with `invalid_input`.
+
 ```rust
 use rulemorph::{parse_rule_file, transform};
 

--- a/crates/rulemorph/Cargo.toml
+++ b/crates/rulemorph/Cargo.toml
@@ -8,6 +8,11 @@ repository = "https://github.com/vinhphatfsg/rulemorph"
 keywords = ["transform", "yaml", "json", "csv", "etl"]
 categories = ["command-line-utilities", "data-structures", "encoding"]
 
+[features]
+default = ["excel", "html"]
+excel = ["dep:calamine", "dep:zip"]
+html = ["dep:scraper"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -17,10 +22,10 @@ regex = "1.12"
 chrono = "0.4"
 toml = "0.8"
 toml_edit = "0.22"
-calamine = { version = "0.26", features = ["dates"] }
-zip = "0.6"
+calamine = { version = "0.26", features = ["dates"], optional = true }
+zip = { version = "0.6", optional = true }
 quick-xml = "0.31"
-scraper = "0.20"
+scraper = { version = "0.20", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/rulemorph/src/dto.rs
+++ b/crates/rulemorph/src/dto.rs
@@ -1,3 +1,4 @@
+mod infer;
 mod render;
 mod schema;
 mod support;

--- a/crates/rulemorph/src/dto/infer.rs
+++ b/crates/rulemorph/src/dto/infer.rs
@@ -326,8 +326,12 @@ fn infer_op(
         "int" | "len" | "to_unixtime" | "find_index" | "index_of" => {
             FieldType::Primitive(PrimitiveType::Int)
         }
-        "float" | "+" | "add" | "-" | "subtract" | "*" | "multiply" | "/" | "divide" | "round"
-        | "sum" | "avg" | "min" | "max" => FieldType::Primitive(PrimitiveType::Float),
+        "float" | "+" | "add" | "-" | "subtract" | "*" | "multiply" | "/" | "divide" | "round" => {
+            FieldType::Primitive(PrimitiveType::Float)
+        }
+        "sum" | "avg" | "min" | "max" => {
+            FieldType::Nullable(Box::new(FieldType::Primitive(PrimitiveType::Float)))
+        }
         "bool" | "and" | "or" | "not" | "==" | "!=" | "<" | "<=" | ">" | ">=" | "~=" | "eq"
         | "ne" | "lt" | "lte" | "gt" | "gte" | "match" | "contains" => {
             FieldType::Primitive(PrimitiveType::Bool)
@@ -443,19 +447,7 @@ fn infer_op(
             merged
         }
         "reduce" => FieldType::JsonValue,
-        "fold" => op_step
-            .args
-            .first()
-            .map(|arg| {
-                infer_arg_expr(
-                    arg,
-                    rule,
-                    state,
-                    scope.clone().with_pipe(input_type.clone()),
-                    depth + 1,
-                )
-            })
-            .unwrap_or(FieldType::JsonValue),
+        "fold" => infer_fold(&input_type, &op_step.args, rule, state, scope, depth),
         _ => FieldType::JsonValue,
     }
 }
@@ -793,6 +785,34 @@ fn infer_merge(
     merged
 }
 
+fn infer_fold(
+    input_type: &FieldType,
+    args: &[V2Expr],
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &Scope,
+    depth: usize,
+) -> FieldType {
+    let [initial_arg, fold_arg] = args else {
+        return FieldType::JsonValue;
+    };
+    let element = array_element_type(input_type);
+    let initial_type = infer_arg_expr(
+        initial_arg,
+        rule,
+        state,
+        scope.clone().with_pipe(input_type.clone()),
+        depth + 1,
+    );
+    let fold_scope = scope
+        .clone()
+        .with_pipe(element.clone())
+        .with_item(Some(element))
+        .with_acc(Some(initial_type.clone()));
+    let fold_type = infer_arg_expr(fold_arg, rule, state, fold_scope, depth + 1);
+    merge_types(initial_type, fold_type)
+}
+
 fn literal_path_args(args: &[V2Expr]) -> Vec<String> {
     args.iter().filter_map(literal_string_arg).collect()
 }
@@ -944,11 +964,17 @@ fn merge_object_nodes_for_operation(left: SchemaNode, right: SchemaNode) -> Opti
 
 trait ScopeExt {
     fn with_item(self, item: Option<FieldType>) -> Self;
+    fn with_acc(self, acc: Option<FieldType>) -> Self;
 }
 
 impl ScopeExt for Scope {
     fn with_item(mut self, item: Option<FieldType>) -> Self {
         self.item = item;
+        self
+    }
+
+    fn with_acc(mut self, acc: Option<FieldType>) -> Self {
+        self.acc = acc;
         self
     }
 }

--- a/crates/rulemorph/src/dto/infer.rs
+++ b/crates/rulemorph/src/dto/infer.rs
@@ -1,0 +1,1096 @@
+use std::collections::HashMap;
+
+use serde_json::Value as JsonValue;
+
+use crate::model::{Expr, Mapping, RuleFile};
+use crate::path::{PathToken, parse_path};
+use crate::v2_model::{
+    V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Pipe, V2Ref, V2Start, V2Step,
+};
+use crate::v2_parser::{is_literal_escape, is_pipe_value, is_v2_ref, parse_v2_pipe_from_value};
+
+use super::schema::{Field, FieldType, PrimitiveType, SchemaNode};
+
+const DTO_INFER_MAX_DEPTH: usize = 64;
+const DTO_INFER_MAX_NODES: usize = 4096;
+const DTO_INFER_MAX_OBJECT_FIELDS: usize = 256;
+const DTO_INFER_MAX_ARRAY_ITEMS: usize = 64;
+const DTO_INFER_MAX_PIPE_STEPS: usize = 1024;
+const DTO_INFER_MAX_GENERATED_TYPES: usize = 512;
+const DTO_INFER_MAX_PATH_BYTES: usize = 1024;
+const DTO_INFER_MAX_PATH_TOKENS: usize = 64;
+
+#[derive(Clone)]
+pub(super) struct InferenceState {
+    produced: HashMap<Vec<String>, FieldType>,
+    budget: InferenceBudget,
+}
+
+impl Default for InferenceState {
+    fn default() -> Self {
+        Self {
+            produced: HashMap::new(),
+            budget: InferenceBudget::default(),
+        }
+    }
+}
+
+impl InferenceState {
+    fn enter_node(&mut self, depth: usize) -> bool {
+        self.budget.enter_node(depth)
+    }
+
+    fn reserve_generated_type(&mut self) -> bool {
+        self.budget.reserve_generated_type()
+    }
+
+    fn reserve_generated_types(&mut self, count: usize) -> bool {
+        self.budget.reserve_generated_types(count)
+    }
+
+    fn produced_type(&self, keys: &[String]) -> Option<FieldType> {
+        for prefix_len in (1..=keys.len()).rev() {
+            let prefix = &keys[..prefix_len];
+            let Some(field_type) = self.produced.get(prefix) else {
+                continue;
+            };
+            if prefix_len == keys.len() {
+                return Some(field_type.clone());
+            }
+            return field_type_at_keys(field_type, &keys[prefix_len..]);
+        }
+        None
+    }
+
+    fn produced_type_for_ref(&mut self, keys: &[String]) -> Option<FieldType> {
+        let field_type = self.produced_type(keys)?;
+        let generated_types = generated_type_count(&field_type);
+        if generated_types > 0 && !self.reserve_generated_types(generated_types) {
+            return None;
+        }
+        Some(field_type)
+    }
+}
+
+#[derive(Clone)]
+struct InferenceBudget {
+    remaining_nodes: usize,
+    remaining_generated_types: usize,
+}
+
+impl Default for InferenceBudget {
+    fn default() -> Self {
+        Self {
+            remaining_nodes: DTO_INFER_MAX_NODES,
+            remaining_generated_types: DTO_INFER_MAX_GENERATED_TYPES,
+        }
+    }
+}
+
+impl InferenceBudget {
+    fn enter_node(&mut self, depth: usize) -> bool {
+        if depth > DTO_INFER_MAX_DEPTH || self.remaining_nodes == 0 {
+            return false;
+        }
+        self.remaining_nodes -= 1;
+        true
+    }
+
+    fn reserve_generated_type(&mut self) -> bool {
+        self.reserve_generated_types(1)
+    }
+
+    fn reserve_generated_types(&mut self, count: usize) -> bool {
+        if count > self.remaining_generated_types {
+            return false;
+        }
+        self.remaining_generated_types -= count;
+        true
+    }
+}
+
+#[derive(Clone)]
+struct Scope {
+    pipe: FieldType,
+    item: Option<FieldType>,
+    acc: Option<FieldType>,
+    locals: HashMap<String, FieldType>,
+}
+
+impl Scope {
+    fn new() -> Self {
+        Self {
+            pipe: FieldType::JsonValue,
+            item: None,
+            acc: None,
+            locals: HashMap::new(),
+        }
+    }
+
+    fn with_pipe(mut self, pipe: FieldType) -> Self {
+        self.pipe = pipe;
+        self
+    }
+}
+
+pub(super) fn infer_mapping_field_type(
+    mapping: &Mapping,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+) -> FieldType {
+    if let Some(explicit) = mapping
+        .value_type
+        .as_deref()
+        .and_then(type_from_mapping_type)
+    {
+        return explicit;
+    }
+
+    let primary = if let Some(value) = &mapping.value {
+        infer_json_value(value, state, 0)
+    } else if let Some(expr) = &mapping.expr {
+        infer_expr(expr, rule, state)
+    } else {
+        FieldType::JsonValue
+    };
+
+    match (&primary, &mapping.default) {
+        (FieldType::JsonValue, _) => FieldType::JsonValue,
+        (_, Some(default)) => merge_types(primary, infer_json_value(default, state, 0)),
+        (_, None) => primary,
+    }
+}
+
+pub(super) fn remember_mapping_type(
+    state: &mut InferenceState,
+    target_keys: &[String],
+    field_type: &FieldType,
+) {
+    state
+        .produced
+        .insert(target_keys.to_vec(), field_type.clone());
+}
+
+pub(super) fn type_from_mapping_type(value_type: &str) -> Option<FieldType> {
+    match value_type {
+        "string" => Some(FieldType::Primitive(PrimitiveType::String)),
+        "int" => Some(FieldType::Primitive(PrimitiveType::Int)),
+        "float" => Some(FieldType::Primitive(PrimitiveType::Float)),
+        "bool" => Some(FieldType::Primitive(PrimitiveType::Bool)),
+        _ => None,
+    }
+}
+
+fn infer_json_value(value: &JsonValue, state: &mut InferenceState, depth: usize) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+
+    match value {
+        JsonValue::Null => FieldType::Nullable(Box::new(FieldType::JsonValue)),
+        JsonValue::Bool(_) => FieldType::Primitive(PrimitiveType::Bool),
+        JsonValue::Number(number) => {
+            if number.as_i64().is_some() || number.as_u64().is_some() {
+                FieldType::Primitive(PrimitiveType::Int)
+            } else {
+                FieldType::Primitive(PrimitiveType::Float)
+            }
+        }
+        JsonValue::String(_) => FieldType::Primitive(PrimitiveType::String),
+        JsonValue::Array(items) => {
+            if items.len() > DTO_INFER_MAX_ARRAY_ITEMS {
+                return FieldType::Array(Box::new(FieldType::JsonValue));
+            }
+            let item_type = items
+                .iter()
+                .map(|item| infer_json_value(item, state, depth + 1))
+                .reduce(merge_types)
+                .unwrap_or(FieldType::JsonValue);
+            FieldType::Array(Box::new(item_type))
+        }
+        JsonValue::Object(map) => {
+            if map.len() > DTO_INFER_MAX_OBJECT_FIELDS || !state.reserve_generated_type() {
+                return FieldType::JsonValue;
+            }
+            let fields = map
+                .iter()
+                .map(|(key, value)| Field {
+                    key: key.clone(),
+                    field_type: infer_json_value(value, state, depth + 1),
+                    optional: false,
+                    synthetic: false,
+                })
+                .collect();
+            FieldType::Object(Box::new(SchemaNode { fields }))
+        }
+    }
+}
+
+fn infer_expr(expr: &Expr, rule: &RuleFile, state: &mut InferenceState) -> FieldType {
+    let Some(value) = expr_to_json_for_v2_pipe_bounded(expr, state, 0) else {
+        return FieldType::JsonValue;
+    };
+    if !pipe_json_shape_is_bounded(&value) {
+        return FieldType::JsonValue;
+    }
+    let Ok(pipe) = parse_v2_pipe_from_value(&value) else {
+        return FieldType::JsonValue;
+    };
+    if pipe.steps.len() > DTO_INFER_MAX_PIPE_STEPS {
+        return FieldType::JsonValue;
+    }
+    infer_pipe(&pipe, rule, state, Scope::new(), 0)
+}
+
+fn infer_pipe(
+    pipe: &V2Pipe,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    mut scope: Scope,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+
+    let mut current = infer_start(&pipe.start, state, &scope, depth + 1);
+    scope.pipe = current.clone();
+    for step in &pipe.steps {
+        if !state.enter_node(depth + 1) {
+            return FieldType::JsonValue;
+        }
+        current = infer_step(step, rule, state, &mut scope, current, depth + 1);
+        scope.pipe = current.clone();
+    }
+    current
+}
+
+fn infer_start(
+    start: &V2Start,
+    state: &mut InferenceState,
+    scope: &Scope,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+    match start {
+        V2Start::Ref(value_ref) => infer_ref(value_ref, state, scope, depth + 1),
+        V2Start::PipeValue => scope.pipe.clone(),
+        V2Start::Literal(value) => infer_json_value(value, state, depth + 1),
+        V2Start::V1Expr(_) => FieldType::JsonValue,
+    }
+}
+
+fn infer_step(
+    step: &V2Step,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &mut Scope,
+    input_type: FieldType,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+    match step {
+        V2Step::Op(op_step) => infer_op(op_step, rule, state, scope, input_type, depth + 1),
+        V2Step::Let(let_step) => {
+            infer_let_step(let_step, rule, state, scope, input_type, depth + 1)
+        }
+        V2Step::If(if_step) => infer_if_step(if_step, rule, state, scope, input_type, depth + 1),
+        V2Step::Map(map_step) => {
+            infer_map_step(map_step, rule, state, scope, input_type, depth + 1)
+        }
+        V2Step::Ref(value_ref) => infer_ref(value_ref, state, scope, depth + 1),
+    }
+}
+
+fn infer_op(
+    op_step: &V2OpStep,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &Scope,
+    input_type: FieldType,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+
+    match op_step.op.as_str() {
+        "string" | "to_string" | "trim" | "lowercase" | "uppercase" | "concat" | "replace"
+        | "pad_start" | "pad_end" | "date_format" | "to_base" => {
+            FieldType::Primitive(PrimitiveType::String)
+        }
+        "int" | "len" | "to_unixtime" | "find_index" | "index_of" => {
+            FieldType::Primitive(PrimitiveType::Int)
+        }
+        "float" | "+" | "add" | "-" | "subtract" | "*" | "multiply" | "/" | "divide" | "round"
+        | "sum" | "avg" | "min" | "max" => FieldType::Primitive(PrimitiveType::Float),
+        "bool" | "and" | "or" | "not" | "==" | "!=" | "<" | "<=" | ">" | ">=" | "~=" | "eq"
+        | "ne" | "lt" | "lte" | "gt" | "gte" | "match" | "contains" => {
+            FieldType::Primitive(PrimitiveType::Bool)
+        }
+        "split" | "keys" => FieldType::Array(Box::new(FieldType::Primitive(PrimitiveType::String))),
+        "values" => FieldType::Array(Box::new(object_value_union(&input_type))),
+        "entries" => FieldType::Array(Box::new(FieldType::Object(Box::new(SchemaNode {
+            fields: vec![
+                Field {
+                    key: "key".to_string(),
+                    field_type: FieldType::Primitive(PrimitiveType::String),
+                    optional: false,
+                    synthetic: false,
+                },
+                Field {
+                    key: "value".to_string(),
+                    field_type: object_value_union(&input_type),
+                    optional: false,
+                    synthetic: false,
+                },
+            ],
+        })))),
+        "from_entries" => FieldType::Map(Box::new(FieldType::JsonValue)),
+        "map" => {
+            let element = array_element_type(&input_type);
+            let Some(arg) = op_step.args.first() else {
+                return FieldType::Array(Box::new(FieldType::JsonValue));
+            };
+            let arg_scope = scope
+                .clone()
+                .with_pipe(element.clone())
+                .with_item(Some(element));
+            FieldType::Array(Box::new(infer_arg_expr(
+                arg,
+                rule,
+                state,
+                arg_scope,
+                depth + 1,
+            )))
+        }
+        "flat_map" => {
+            let element = array_element_type(&input_type);
+            let Some(arg) = op_step.args.first() else {
+                return FieldType::Array(Box::new(FieldType::JsonValue));
+            };
+            let arg_scope = scope
+                .clone()
+                .with_pipe(element.clone())
+                .with_item(Some(element));
+            match infer_arg_expr(arg, rule, state, arg_scope, depth + 1) {
+                FieldType::Array(inner) => FieldType::Array(inner),
+                other => FieldType::Array(Box::new(other)),
+            }
+        }
+        "filter" | "unique" | "distinct_by" | "sort_by" | "take" | "drop" | "slice" => input_type,
+        "flatten" => match input_type {
+            FieldType::Array(inner) => match *inner {
+                FieldType::Array(nested) => FieldType::Array(nested),
+                other => FieldType::Array(Box::new(other)),
+            },
+            other => other,
+        },
+        "chunk" => FieldType::Array(Box::new(FieldType::Array(Box::new(array_element_type(
+            &input_type,
+        ))))),
+        "zip" => FieldType::Array(Box::new(FieldType::Array(Box::new(FieldType::JsonValue)))),
+        "zip_with" => {
+            let Some(arg) = op_step.args.last() else {
+                return FieldType::Array(Box::new(FieldType::JsonValue));
+            };
+            let arg_scope = scope
+                .clone()
+                .with_pipe(FieldType::Array(Box::new(FieldType::JsonValue)))
+                .with_item(Some(FieldType::Array(Box::new(FieldType::JsonValue))));
+            FieldType::Array(Box::new(infer_arg_expr(
+                arg,
+                rule,
+                state,
+                arg_scope,
+                depth + 1,
+            )))
+        }
+        "group_by" => FieldType::Map(Box::new(FieldType::Array(Box::new(array_element_type(
+            &input_type,
+        ))))),
+        "key_by" => FieldType::Map(Box::new(array_element_type(&input_type))),
+        "partition" => FieldType::Array(Box::new(FieldType::Array(Box::new(array_element_type(
+            &input_type,
+        ))))),
+        "find" | "first" | "last" => FieldType::Nullable(Box::new(array_element_type(&input_type))),
+        "lookup" => FieldType::Array(Box::new(FieldType::JsonValue)),
+        "lookup_first" => FieldType::Nullable(Box::new(FieldType::JsonValue)),
+        "get" => infer_get(&input_type, &op_step.args),
+        "pick" => infer_pick(&input_type, &op_step.args),
+        "omit" => infer_omit(&input_type, &op_step.args),
+        "merge" | "deep_merge" => {
+            infer_merge(&input_type, &op_step.args, rule, state, scope, depth)
+        }
+        "object_flatten" => FieldType::Map(Box::new(FieldType::JsonValue)),
+        "object_unflatten" => FieldType::JsonValue,
+        "coalesce" => {
+            let mut merged = input_type;
+            for arg in &op_step.args {
+                let arg_type = infer_arg_expr(
+                    arg,
+                    rule,
+                    state,
+                    scope.clone().with_pipe(merged.clone()),
+                    depth + 1,
+                );
+                merged = merge_types(merged, arg_type);
+            }
+            merged
+        }
+        "reduce" => FieldType::JsonValue,
+        "fold" => op_step
+            .args
+            .first()
+            .map(|arg| {
+                infer_arg_expr(
+                    arg,
+                    rule,
+                    state,
+                    scope.clone().with_pipe(input_type.clone()),
+                    depth + 1,
+                )
+            })
+            .unwrap_or(FieldType::JsonValue),
+        _ => FieldType::JsonValue,
+    }
+}
+
+fn infer_let_step(
+    let_step: &V2LetStep,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &mut Scope,
+    input_type: FieldType,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+    scope.pipe = input_type.clone();
+    for (name, expr) in &let_step.bindings {
+        let value_type = infer_arg_expr(expr, rule, state, scope.clone(), depth + 1);
+        scope.locals.insert(name.clone(), value_type);
+    }
+    input_type
+}
+
+fn infer_if_step(
+    if_step: &V2IfStep,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &Scope,
+    input_type: FieldType,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+    let then_type = infer_pipe(
+        &if_step.then_branch,
+        rule,
+        state,
+        scope.clone().with_pipe(input_type.clone()),
+        depth + 1,
+    );
+    let else_type = if_step
+        .else_branch
+        .as_ref()
+        .map(|else_branch| {
+            infer_pipe(
+                else_branch,
+                rule,
+                state,
+                scope.clone().with_pipe(input_type.clone()),
+                depth + 1,
+            )
+        })
+        .unwrap_or(input_type);
+    merge_types(then_type, else_type)
+}
+
+fn infer_map_step(
+    map_step: &V2MapStep,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &Scope,
+    input_type: FieldType,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+    let element = array_element_type(&input_type);
+    let mut item_scope = scope
+        .clone()
+        .with_pipe(element.clone())
+        .with_item(Some(element));
+    let mut current = item_scope.pipe.clone();
+    for step in &map_step.steps {
+        current = infer_step(step, rule, state, &mut item_scope, current, depth + 1);
+        item_scope.pipe = current.clone();
+    }
+    FieldType::Array(Box::new(current))
+}
+
+fn infer_arg_expr(
+    expr: &V2Expr,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: Scope,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+    match expr {
+        V2Expr::Pipe(pipe) => infer_pipe(pipe, rule, state, scope, depth + 1),
+        V2Expr::V1Fallback(_) => FieldType::JsonValue,
+    }
+}
+
+fn infer_ref(
+    value_ref: &V2Ref,
+    state: &mut InferenceState,
+    scope: &Scope,
+    _depth: usize,
+) -> FieldType {
+    match value_ref {
+        V2Ref::Input(_) | V2Ref::Context(_) => FieldType::JsonValue,
+        V2Ref::Out(path) => key_path(path)
+            .filter(|keys| !keys.is_empty())
+            .and_then(|keys| state.produced_type_for_ref(&keys))
+            .unwrap_or(FieldType::JsonValue),
+        V2Ref::Item(path) => scoped_path_type(scope.item.as_ref(), path),
+        V2Ref::Acc(path) => scoped_path_type(scope.acc.as_ref(), path),
+        V2Ref::Local(name) => scope
+            .locals
+            .get(name)
+            .cloned()
+            .unwrap_or(FieldType::JsonValue),
+    }
+}
+
+fn scoped_path_type(base: Option<&FieldType>, path: &str) -> FieldType {
+    let Some(base) = base else {
+        return FieldType::JsonValue;
+    };
+    if path.is_empty() {
+        return base.clone();
+    }
+    field_type_at_path(base, path).unwrap_or(FieldType::JsonValue)
+}
+
+fn key_path(path: &str) -> Option<Vec<String>> {
+    let tokens = parse_path_bounded(path)?;
+    let mut keys = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        match token {
+            PathToken::Key(key) => keys.push(key),
+            PathToken::Index(_) => return None,
+        }
+    }
+    Some(keys)
+}
+
+fn parse_path_bounded(path: &str) -> Option<Vec<PathToken>> {
+    if path.len() > DTO_INFER_MAX_PATH_BYTES {
+        return None;
+    }
+    let tokens = parse_path(path).ok()?;
+    if tokens.len() > DTO_INFER_MAX_PATH_TOKENS {
+        return None;
+    }
+    Some(tokens)
+}
+
+fn field_type_at_path(field_type: &FieldType, path: &str) -> Option<FieldType> {
+    let tokens = parse_path_bounded(path)?;
+    field_type_at_tokens(field_type, &tokens)
+}
+
+fn field_type_at_keys(field_type: &FieldType, keys: &[String]) -> Option<FieldType> {
+    if keys.is_empty() {
+        return Some(field_type.clone());
+    }
+    match field_type {
+        FieldType::Object(node) => node
+            .fields
+            .iter()
+            .find(|field| field.key == keys[0])
+            .and_then(|field| field_type_at_keys(&field.field_type, &keys[1..])),
+        FieldType::Map(inner) => field_type_at_keys(inner, &keys[1..]),
+        FieldType::Nullable(inner) => field_type_at_keys(inner, keys),
+        _ => None,
+    }
+}
+
+fn field_type_at_tokens(field_type: &FieldType, tokens: &[PathToken]) -> Option<FieldType> {
+    if tokens.is_empty() {
+        return Some(field_type.clone());
+    }
+    match (&tokens[0], field_type) {
+        (PathToken::Key(key), FieldType::Object(node)) => node
+            .fields
+            .iter()
+            .find(|field| field.key == *key)
+            .and_then(|field| field_type_at_tokens(&field.field_type, &tokens[1..])),
+        (PathToken::Key(_), FieldType::Map(inner)) => field_type_at_tokens(inner, &tokens[1..]),
+        (PathToken::Index(_), FieldType::Array(inner)) => field_type_at_tokens(inner, &tokens[1..]),
+        (_, FieldType::Nullable(inner)) => field_type_at_tokens(inner, tokens),
+        _ => None,
+    }
+}
+
+fn infer_get(input_type: &FieldType, args: &[V2Expr]) -> FieldType {
+    let Some(path) = args.first().and_then(literal_string_arg) else {
+        return FieldType::JsonValue;
+    };
+    field_type_at_path(input_type, &path).unwrap_or(FieldType::JsonValue)
+}
+
+fn infer_pick(input_type: &FieldType, args: &[V2Expr]) -> FieldType {
+    let FieldType::Object(node) = input_type else {
+        return FieldType::JsonValue;
+    };
+    let paths = literal_path_args(args);
+    if paths.len() != args.len() {
+        return FieldType::JsonValue;
+    }
+    let mut fields = Vec::new();
+    for path in paths {
+        let Some(keys) = key_path(&path) else {
+            return FieldType::JsonValue;
+        };
+        let Some(field) = pick_field_at_keys(&node.fields, &keys) else {
+            continue;
+        };
+        if !merge_projected_field(&mut fields, field) {
+            return FieldType::JsonValue;
+        }
+    }
+    FieldType::Object(Box::new(SchemaNode { fields }))
+}
+
+fn infer_omit(input_type: &FieldType, args: &[V2Expr]) -> FieldType {
+    let FieldType::Object(node) = input_type else {
+        return FieldType::JsonValue;
+    };
+    let paths = literal_path_args(args);
+    if paths.len() != args.len() {
+        return FieldType::JsonValue;
+    }
+    let mut omit_keys = Vec::new();
+    for path in paths {
+        let Some(keys) = key_path(&path) else {
+            return FieldType::JsonValue;
+        };
+        if keys.is_empty() {
+            return FieldType::JsonValue;
+        }
+        omit_keys.push(keys);
+    }
+    let mut fields = node.fields.clone();
+    for keys in omit_keys {
+        omit_path_from_fields(&mut fields, &keys);
+    }
+    FieldType::Object(Box::new(SchemaNode { fields }))
+}
+
+fn pick_field_at_keys(fields: &[Field], keys: &[String]) -> Option<Field> {
+    let key = keys.first()?;
+    let field = fields.iter().find(|field| field.key == *key)?;
+    if keys.len() == 1 {
+        return Some(field.clone());
+    }
+
+    let FieldType::Object(child) = &field.field_type else {
+        return None;
+    };
+    let child_field = pick_field_at_keys(&child.fields, &keys[1..])?;
+    Some(Field {
+        key: field.key.clone(),
+        field_type: FieldType::Object(Box::new(SchemaNode {
+            fields: vec![child_field],
+        })),
+        optional: field.optional,
+        synthetic: field.synthetic,
+    })
+}
+
+fn merge_projected_field(fields: &mut Vec<Field>, projected: Field) -> bool {
+    if let Some(existing) = fields.iter_mut().find(|field| field.key == projected.key) {
+        existing.field_type =
+            merge_projected_types(existing.field_type.clone(), projected.field_type);
+        existing.optional = existing.optional || projected.optional;
+        !matches!(existing.field_type, FieldType::JsonValue)
+    } else if fields.len() >= DTO_INFER_MAX_OBJECT_FIELDS {
+        false
+    } else {
+        fields.push(projected);
+        true
+    }
+}
+
+fn merge_projected_types(left: FieldType, right: FieldType) -> FieldType {
+    match (&left, &right) {
+        (FieldType::Object(_), FieldType::Object(_)) => {
+            merge_object_types_for_operation(left, right)
+        }
+        _ => merge_types(left, right),
+    }
+}
+
+fn omit_path_from_fields(fields: &mut Vec<Field>, keys: &[String]) {
+    let Some(key) = keys.first() else {
+        return;
+    };
+    if keys.len() == 1 {
+        fields.retain(|field| field.key != *key);
+        return;
+    }
+
+    let Some(field) = fields.iter_mut().find(|field| field.key == *key) else {
+        return;
+    };
+    if let FieldType::Object(child) = &mut field.field_type {
+        omit_path_from_fields(&mut child.fields, &keys[1..]);
+    }
+}
+
+fn infer_merge(
+    input_type: &FieldType,
+    args: &[V2Expr],
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &Scope,
+    depth: usize,
+) -> FieldType {
+    let mut merged = match input_type {
+        FieldType::Object(_) => input_type.clone(),
+        _ => return FieldType::JsonValue,
+    };
+    for arg in args {
+        let arg_type = infer_arg_expr(
+            arg,
+            rule,
+            state,
+            scope.clone().with_pipe(merged.clone()),
+            depth + 1,
+        );
+        if !matches!(arg_type, FieldType::Object(_)) {
+            return FieldType::JsonValue;
+        }
+        merged = merge_object_types_for_operation(merged, arg_type);
+        if matches!(merged, FieldType::JsonValue) {
+            return FieldType::JsonValue;
+        }
+    }
+    merged
+}
+
+fn literal_path_args(args: &[V2Expr]) -> Vec<String> {
+    args.iter().filter_map(literal_string_arg).collect()
+}
+
+fn literal_string_arg(expr: &V2Expr) -> Option<String> {
+    match expr {
+        V2Expr::Pipe(pipe) if pipe.steps.is_empty() => match &pipe.start {
+            V2Start::Literal(JsonValue::String(value)) => Some(value.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn array_element_type(field_type: &FieldType) -> FieldType {
+    match field_type {
+        FieldType::Array(inner) => (**inner).clone(),
+        FieldType::Nullable(inner) => array_element_type(inner),
+        _ => FieldType::JsonValue,
+    }
+}
+
+fn object_value_union(field_type: &FieldType) -> FieldType {
+    match field_type {
+        FieldType::Object(node) => node
+            .fields
+            .iter()
+            .map(|field| field.field_type.clone())
+            .reduce(merge_types)
+            .unwrap_or(FieldType::JsonValue),
+        FieldType::Map(inner) => (**inner).clone(),
+        FieldType::Nullable(inner) => object_value_union(inner),
+        _ => FieldType::JsonValue,
+    }
+}
+
+fn generated_type_count(field_type: &FieldType) -> usize {
+    match field_type {
+        FieldType::Object(node) => {
+            1 + node
+                .fields
+                .iter()
+                .map(|field| generated_type_count(&field.field_type))
+                .sum::<usize>()
+        }
+        FieldType::Array(inner) | FieldType::Map(inner) | FieldType::Nullable(inner) => {
+            generated_type_count(inner)
+        }
+        FieldType::Primitive(_) | FieldType::JsonValue => 0,
+    }
+}
+
+fn merge_types(left: FieldType, right: FieldType) -> FieldType {
+    use FieldType::*;
+    match (left, right) {
+        (JsonValue, _) | (_, JsonValue) => JsonValue,
+        (Primitive(a), Primitive(b)) if a == b => Primitive(a),
+        (Primitive(PrimitiveType::Int), Primitive(PrimitiveType::Float))
+        | (Primitive(PrimitiveType::Float), Primitive(PrimitiveType::Int)) => {
+            Primitive(PrimitiveType::Float)
+        }
+        (Nullable(a), Nullable(b)) => Nullable(Box::new(merge_types(*a, *b))),
+        (Nullable(a), _) if *a == JsonValue => JsonValue,
+        (_, Nullable(b)) if *b == JsonValue => JsonValue,
+        (Nullable(a), b) | (b, Nullable(a)) => Nullable(Box::new(merge_types(*a, b))),
+        (Array(a), Array(b)) => Array(Box::new(merge_types(*a, *b))),
+        (Map(a), Map(b)) => Map(Box::new(merge_types(*a, *b))),
+        (Object(a), Object(b)) => match merge_object_nodes(*a, *b) {
+            Some(node) => Object(Box::new(node)),
+            None => JsonValue,
+        },
+        (Primitive(_), Primitive(_)) => JsonValue,
+        (Array(_), _)
+        | (_, Array(_))
+        | (Map(_), _)
+        | (_, Map(_))
+        | (Object(_), _)
+        | (_, Object(_)) => JsonValue,
+    }
+}
+
+fn merge_object_nodes(left: SchemaNode, right: SchemaNode) -> Option<SchemaNode> {
+    let mut right_fields = right.fields;
+    let mut fields = Vec::with_capacity(left.fields.len() + right_fields.len());
+
+    for mut left_field in left.fields {
+        if let Some(index) = right_fields
+            .iter()
+            .position(|right_field| right_field.key == left_field.key)
+        {
+            let right_field = right_fields.remove(index);
+            left_field.field_type = merge_types(left_field.field_type, right_field.field_type);
+            left_field.optional = left_field.optional || right_field.optional;
+            fields.push(left_field);
+        } else {
+            left_field.optional = true;
+            fields.push(left_field);
+        }
+    }
+
+    for mut right_field in right_fields {
+        right_field.optional = true;
+        fields.push(right_field);
+    }
+
+    if fields.len() > DTO_INFER_MAX_OBJECT_FIELDS {
+        None
+    } else {
+        Some(SchemaNode { fields })
+    }
+}
+
+fn merge_object_types_for_operation(left: FieldType, right: FieldType) -> FieldType {
+    match (left, right) {
+        (FieldType::Object(left), FieldType::Object(right)) => {
+            match merge_object_nodes_for_operation(*left, *right) {
+                Some(node) => FieldType::Object(Box::new(node)),
+                None => FieldType::JsonValue,
+            }
+        }
+        _ => FieldType::JsonValue,
+    }
+}
+
+fn merge_object_nodes_for_operation(left: SchemaNode, right: SchemaNode) -> Option<SchemaNode> {
+    let mut right_fields = right.fields;
+    let mut fields = Vec::with_capacity(left.fields.len() + right_fields.len());
+
+    for mut left_field in left.fields {
+        if let Some(index) = right_fields
+            .iter()
+            .position(|right_field| right_field.key == left_field.key)
+        {
+            let right_field = right_fields.remove(index);
+            left_field.field_type = merge_types(left_field.field_type, right_field.field_type);
+            left_field.optional = left_field.optional || right_field.optional;
+        }
+        fields.push(left_field);
+    }
+
+    fields.extend(right_fields);
+
+    if fields.len() > DTO_INFER_MAX_OBJECT_FIELDS {
+        None
+    } else {
+        Some(SchemaNode { fields })
+    }
+}
+
+trait ScopeExt {
+    fn with_item(self, item: Option<FieldType>) -> Self;
+}
+
+impl ScopeExt for Scope {
+    fn with_item(mut self, item: Option<FieldType>) -> Self {
+        self.item = item;
+        self
+    }
+}
+
+fn expr_to_json_for_v2_pipe_bounded(
+    expr: &Expr,
+    state: &mut InferenceState,
+    depth: usize,
+) -> Option<JsonValue> {
+    if !state.enter_node(depth) {
+        return None;
+    }
+    match expr {
+        Expr::Literal(value @ JsonValue::Array(items)) => {
+            if items.len().saturating_sub(1) > DTO_INFER_MAX_PIPE_STEPS {
+                return None;
+            }
+            clone_json_bounded(value, state, depth + 1, JsonCloneContext::PipeRoot)
+        }
+        Expr::Literal(JsonValue::String(value))
+            if is_v2_ref(value) || is_pipe_value(value) || is_literal_escape(value) =>
+        {
+            Some(JsonValue::String(value.clone()))
+        }
+        Expr::Ref(expr_ref)
+            if expr_ref.ref_path.starts_with('@') || is_literal_escape(&expr_ref.ref_path) =>
+        {
+            Some(JsonValue::Array(vec![JsonValue::String(
+                expr_ref.ref_path.clone(),
+            )]))
+        }
+        Expr::Chain(chain) => {
+            if chain.chain.len().saturating_sub(1) > DTO_INFER_MAX_PIPE_STEPS {
+                return None;
+            }
+            let starts_with_v2_ref = matches!(
+                chain.chain.first(),
+                Some(Expr::Ref(first)) if first.ref_path.starts_with('@')
+            );
+            if !starts_with_v2_ref {
+                return None;
+            }
+            let mut values = Vec::with_capacity(chain.chain.len());
+            for item in &chain.chain {
+                values.push(expr_to_json_value_bounded(item, state, depth + 1)?);
+            }
+            Some(JsonValue::Array(values))
+        }
+        _ => None,
+    }
+}
+
+fn expr_to_json_value_bounded(
+    expr: &Expr,
+    state: &mut InferenceState,
+    depth: usize,
+) -> Option<JsonValue> {
+    if !state.enter_node(depth) {
+        return None;
+    }
+    match expr {
+        Expr::Ref(value_ref) => Some(JsonValue::String(value_ref.ref_path.clone())),
+        Expr::Literal(value) => {
+            clone_json_bounded(value, state, depth + 1, JsonCloneContext::ExprValue)
+        }
+        Expr::Op(op) => {
+            if op.args.len() > DTO_INFER_MAX_ARRAY_ITEMS {
+                return None;
+            }
+            let mut args = Vec::with_capacity(op.args.len());
+            for arg in &op.args {
+                args.push(expr_to_json_value_bounded(arg, state, depth + 1)?);
+            }
+            let mut object = serde_json::Map::new();
+            object.insert(op.op.clone(), JsonValue::Array(args));
+            Some(JsonValue::Object(object))
+        }
+        Expr::Chain(chain) => {
+            if chain.chain.len().saturating_sub(1) > DTO_INFER_MAX_PIPE_STEPS {
+                return None;
+            }
+            let mut values = Vec::with_capacity(chain.chain.len());
+            for item in &chain.chain {
+                values.push(expr_to_json_value_bounded(item, state, depth + 1)?);
+            }
+            Some(JsonValue::Array(values))
+        }
+    }
+}
+
+fn clone_json_bounded(
+    value: &JsonValue,
+    state: &mut InferenceState,
+    depth: usize,
+    context: JsonCloneContext,
+) -> Option<JsonValue> {
+    if !state.enter_node(depth) {
+        return None;
+    }
+    match value {
+        JsonValue::Array(items) => {
+            let max_items = match context {
+                JsonCloneContext::PipeRoot => DTO_INFER_MAX_PIPE_STEPS + 1,
+                JsonCloneContext::ExprValue => DTO_INFER_MAX_ARRAY_ITEMS,
+            };
+            if items.len() > max_items {
+                return None;
+            }
+            let mut cloned = Vec::with_capacity(items.len());
+            for item in items {
+                cloned.push(clone_json_bounded(
+                    item,
+                    state,
+                    depth + 1,
+                    JsonCloneContext::ExprValue,
+                )?);
+            }
+            Some(JsonValue::Array(cloned))
+        }
+        JsonValue::Object(map) => {
+            if map.len() > DTO_INFER_MAX_OBJECT_FIELDS {
+                return None;
+            }
+            let mut cloned = serde_json::Map::new();
+            for (key, value) in map {
+                cloned.insert(
+                    key.clone(),
+                    clone_json_bounded(value, state, depth + 1, JsonCloneContext::ExprValue)?,
+                );
+            }
+            Some(JsonValue::Object(cloned))
+        }
+        scalar => Some(scalar.clone()),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum JsonCloneContext {
+    PipeRoot,
+    ExprValue,
+}
+
+fn pipe_json_shape_is_bounded(value: &JsonValue) -> bool {
+    !matches!(value, JsonValue::Array(items) if items.len().saturating_sub(1) > DTO_INFER_MAX_PIPE_STEPS)
+}

--- a/crates/rulemorph/src/dto/render.rs
+++ b/crates/rulemorph/src/dto/render.rs
@@ -8,7 +8,7 @@ mod swift;
 mod typescript;
 
 use super::DtoLanguage;
-use super::schema::{FieldType, SchemaNode, field_is_optional, field_type_has_required_object};
+use super::schema::{FieldType, SchemaNode, field_is_optional};
 use super::support::field_identifier;
 
 pub(super) use self::go::render_go;
@@ -30,9 +30,7 @@ fn schema_has_optional(node: &SchemaNode) -> bool {
 fn field_type_has_optional(field_type: &FieldType) -> bool {
     match field_type {
         FieldType::Nullable(_) => true,
-        FieldType::Object(child) => {
-            !field_type_has_required_object(field_type) || schema_has_optional(child)
-        }
+        FieldType::Object(child) => schema_has_optional(child),
         FieldType::Array(inner) | FieldType::Map(inner) => field_type_has_optional(inner),
         FieldType::Primitive(_) | FieldType::JsonValue => false,
     }

--- a/crates/rulemorph/src/dto/render.rs
+++ b/crates/rulemorph/src/dto/render.rs
@@ -8,7 +8,7 @@ mod swift;
 mod typescript;
 
 use super::DtoLanguage;
-use super::schema::{FieldType, SchemaNode, node_has_required};
+use super::schema::{FieldType, SchemaNode, field_is_optional, field_type_has_required_object};
 use super::support::field_identifier;
 
 pub(super) use self::go::render_go;
@@ -20,20 +20,22 @@ pub(super) use self::typescript::render_typescript;
 
 fn schema_has_optional(node: &SchemaNode) -> bool {
     for field in &node.fields {
-        match &field.field_type {
-            FieldType::Object(child) => {
-                if !node_has_required(child) || schema_has_optional(child) {
-                    return true;
-                }
-            }
-            _ => {
-                if field.optional {
-                    return true;
-                }
-            }
+        if field_is_optional(field) || field_type_has_optional(&field.field_type) {
+            return true;
         }
     }
     false
+}
+
+fn field_type_has_optional(field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::Nullable(_) => true,
+        FieldType::Object(child) => {
+            !field_type_has_required_object(field_type) || schema_has_optional(child)
+        }
+        FieldType::Array(inner) | FieldType::Map(inner) => field_type_has_optional(inner),
+        FieldType::Primitive(_) | FieldType::JsonValue => false,
+    }
 }
 
 fn schema_has_rename(node: &SchemaNode, lang: DtoLanguage) -> bool {
@@ -43,11 +45,19 @@ fn schema_has_rename(node: &SchemaNode, lang: DtoLanguage) -> bool {
         if ident != field.key {
             return true;
         }
-        if let FieldType::Object(child) = &field.field_type {
-            if schema_has_rename(child, lang) {
-                return true;
-            }
+        if field_type_has_rename(&field.field_type, lang) {
+            return true;
         }
     }
     false
+}
+
+fn field_type_has_rename(field_type: &FieldType, lang: DtoLanguage) -> bool {
+    match field_type {
+        FieldType::Object(child) => schema_has_rename(child, lang),
+        FieldType::Array(inner) | FieldType::Map(inner) | FieldType::Nullable(inner) => {
+            field_type_has_rename(inner, lang)
+        }
+        FieldType::Primitive(_) | FieldType::JsonValue => false,
+    }
 }

--- a/crates/rulemorph/src/dto/render/go.rs
+++ b/crates/rulemorph/src/dto/render/go.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::dto::schema::{
-    Field, FieldType, PrimitiveType, SchemaNode, node_has_required, node_uses_json,
+    Field, FieldType, PrimitiveType, SchemaNode, field_is_optional, node_uses_json,
 };
 use crate::dto::support::{NameRegistry, collect_types, field_identifier, go_json_tag_literal};
 use crate::dto::{DtoError, DtoLanguage};
@@ -24,10 +24,7 @@ pub(in crate::dto) fn render_go(schema: &SchemaNode, name: &str) -> Result<Strin
         let mut used = HashMap::new();
         for field in &def.node.fields {
             let ident = field_identifier(DtoLanguage::Go, &field.key, &mut used);
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
+            let optional = field_is_optional(field);
             let field_type = go_type_for_field(field, &def.path, &registry, optional);
             let tag = go_json_tag_literal(&field.key, optional);
             out.push_str(&format!("    {} {} {}\n", ident, field_type, tag));
@@ -44,21 +41,37 @@ fn go_type_for_field(
     registry: &NameRegistry,
     optional: bool,
 ) -> String {
-    let base = match &field.field_type {
+    let mut path = parent_path.to_vec();
+    path.push(field.key.clone());
+    let base = go_type_for_type(&field.field_type, &path, registry);
+
+    if optional && !base.starts_with('*') {
+        format!("*{}", base)
+    } else {
+        base
+    }
+}
+
+fn go_type_for_type(field_type: &FieldType, path: &[String], registry: &NameRegistry) -> String {
+    match field_type {
         FieldType::Primitive(PrimitiveType::String) => "string".to_string(),
         FieldType::Primitive(PrimitiveType::Int) => "int64".to_string(),
         FieldType::Primitive(PrimitiveType::Float) => "float64".to_string(),
         FieldType::Primitive(PrimitiveType::Bool) => "bool".to_string(),
-        FieldType::JsonValue => "json.RawMessage".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
+        FieldType::Array(inner) => format!("[]{}", go_type_for_type(inner, path, registry)),
+        FieldType::Map(inner) => format!("map[string]{}", go_type_for_type(inner, path, registry)),
+        FieldType::Nullable(inner) => {
+            let inner_type = go_type_for_type(inner, path, registry);
+            if inner_type.starts_with('*') {
+                inner_type
+            } else {
+                format!("*{}", inner_type)
+            }
         }
-    };
-
-    if optional { format!("*{}", base) } else { base }
+        FieldType::JsonValue => "json.RawMessage".to_string(),
+        FieldType::Object(_) => registry
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| "Record".to_string()),
+    }
 }

--- a/crates/rulemorph/src/dto/render/jvm.rs
+++ b/crates/rulemorph/src/dto/render/jvm.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::dto::schema::{
-    Field, FieldType, PrimitiveType, SchemaNode, node_has_required, node_uses_json,
+    Field, FieldType, PrimitiveType, SchemaNode, field_is_optional, node_uses_json,
 };
 use crate::dto::support::{NameRegistry, collect_types, field_identifier, json_string_literal};
 use crate::dto::{DtoError, DtoLanguage};
@@ -16,6 +16,8 @@ pub(in crate::dto) fn render_java(schema: &SchemaNode, name: &str) -> Result<Str
     let uses_json = node_uses_json(schema);
     let uses_optional = schema_has_optional(schema);
     let uses_rename = schema_has_rename(schema, DtoLanguage::Java);
+    let uses_list = schema_uses_array(schema);
+    let uses_map = schema_uses_map(schema);
 
     let mut out = String::new();
     if uses_rename {
@@ -27,7 +29,13 @@ pub(in crate::dto) fn render_java(schema: &SchemaNode, name: &str) -> Result<Str
     if uses_optional {
         out.push_str("import java.util.Optional;\n");
     }
-    if uses_rename || uses_json || uses_optional {
+    if uses_list {
+        out.push_str("import java.util.List;\n");
+    }
+    if uses_map {
+        out.push_str("import java.util.Map;\n");
+    }
+    if uses_rename || uses_json || uses_optional || uses_list || uses_map {
         out.push('\n');
     }
 
@@ -38,10 +46,7 @@ pub(in crate::dto) fn render_java(schema: &SchemaNode, name: &str) -> Result<Str
         for field in &def.node.fields {
             let ident = field_identifier(DtoLanguage::Java, &field.key, &mut used);
             let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
+            let optional = field_is_optional(field);
             let field_type = java_type_for_field(field, &def.path, &registry, optional);
 
             if rename {
@@ -64,26 +69,40 @@ fn java_type_for_field(
     registry: &NameRegistry,
     optional: bool,
 ) -> String {
-    let base = match &field.field_type {
+    let mut path = parent_path.to_vec();
+    path.push(field.key.clone());
+    let base = java_type_for_type(&field.field_type, &path, registry);
+
+    if optional && !base.starts_with("Optional<") {
+        format!("Optional<{}>", base)
+    } else {
+        base
+    }
+}
+
+fn java_type_for_type(field_type: &FieldType, path: &[String], registry: &NameRegistry) -> String {
+    match field_type {
         FieldType::Primitive(PrimitiveType::String) => "String".to_string(),
         FieldType::Primitive(PrimitiveType::Int) => "Long".to_string(),
         FieldType::Primitive(PrimitiveType::Float) => "Double".to_string(),
         FieldType::Primitive(PrimitiveType::Bool) => "Boolean".to_string(),
-        FieldType::JsonValue => "JsonNode".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
+        FieldType::Array(inner) => format!("List<{}>", java_type_for_type(inner, path, registry)),
+        FieldType::Map(inner) => {
+            format!("Map<String, {}>", java_type_for_type(inner, path, registry))
         }
-    };
-
-    if optional {
-        format!("Optional<{}>", base)
-    } else {
-        base
+        FieldType::Nullable(inner) => {
+            let inner_type = java_type_for_type(inner, path, registry);
+            if inner_type.starts_with("Optional<") {
+                inner_type
+            } else {
+                format!("Optional<{}>", inner_type)
+            }
+        }
+        FieldType::JsonValue => "JsonNode".to_string(),
+        FieldType::Object(_) => registry
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| "Record".to_string()),
     }
 }
 
@@ -112,10 +131,7 @@ pub(in crate::dto) fn render_kotlin(schema: &SchemaNode, name: &str) -> Result<S
         for (index, field) in def.node.fields.iter().enumerate() {
             let ident = field_identifier(DtoLanguage::Kotlin, &field.key, &mut used);
             let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
+            let optional = field_is_optional(field);
             let field_type = kotlin_type_for_field(field, &def.path, &registry, optional);
 
             if rename {
@@ -143,21 +159,76 @@ fn kotlin_type_for_field(
     registry: &NameRegistry,
     optional: bool,
 ) -> String {
-    let base = match &field.field_type {
+    let mut path = parent_path.to_vec();
+    path.push(field.key.clone());
+    let base = kotlin_type_for_type(&field.field_type, &path, registry);
+
+    if optional && !base.ends_with('?') {
+        format!("{}?", base)
+    } else {
+        base
+    }
+}
+
+fn kotlin_type_for_type(
+    field_type: &FieldType,
+    path: &[String],
+    registry: &NameRegistry,
+) -> String {
+    match field_type {
         FieldType::Primitive(PrimitiveType::String) => "String".to_string(),
         FieldType::Primitive(PrimitiveType::Int) => "Long".to_string(),
         FieldType::Primitive(PrimitiveType::Float) => "Double".to_string(),
         FieldType::Primitive(PrimitiveType::Bool) => "Boolean".to_string(),
-        FieldType::JsonValue => "JsonNode".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
+        FieldType::Array(inner) => format!("List<{}>", kotlin_type_for_type(inner, path, registry)),
+        FieldType::Map(inner) => {
+            format!(
+                "Map<String, {}>",
+                kotlin_type_for_type(inner, path, registry)
+            )
         }
-    };
+        FieldType::Nullable(inner) => {
+            let inner_type = kotlin_type_for_type(inner, path, registry);
+            if inner_type.ends_with('?') {
+                inner_type
+            } else {
+                format!("{}?", inner_type)
+            }
+        }
+        FieldType::JsonValue => "JsonNode".to_string(),
+        FieldType::Object(_) => registry
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| "Record".to_string()),
+    }
+}
 
-    if optional { format!("{}?", base) } else { base }
+fn schema_uses_array(node: &SchemaNode) -> bool {
+    node.fields
+        .iter()
+        .any(|field| field_type_uses_array(&field.field_type))
+}
+
+fn field_type_uses_array(field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::Array(_) => true,
+        FieldType::Map(inner) | FieldType::Nullable(inner) => field_type_uses_array(inner),
+        FieldType::Object(child) => schema_uses_array(child),
+        FieldType::Primitive(_) | FieldType::JsonValue => false,
+    }
+}
+
+fn schema_uses_map(node: &SchemaNode) -> bool {
+    node.fields
+        .iter()
+        .any(|field| field_type_uses_map(&field.field_type))
+}
+
+fn field_type_uses_map(field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::Map(_) => true,
+        FieldType::Array(inner) | FieldType::Nullable(inner) => field_type_uses_map(inner),
+        FieldType::Object(child) => schema_uses_map(child),
+        FieldType::Primitive(_) | FieldType::JsonValue => false,
+    }
 }

--- a/crates/rulemorph/src/dto/render/jvm.rs
+++ b/crates/rulemorph/src/dto/render/jvm.rs
@@ -113,6 +113,8 @@ pub(in crate::dto) fn render_kotlin(schema: &SchemaNode, name: &str) -> Result<S
 
     let uses_json = node_uses_json(schema);
     let uses_rename = schema_has_rename(schema, DtoLanguage::Kotlin);
+    let uses_list = schema_uses_array(schema);
+    let uses_map = schema_uses_map(schema);
 
     let mut out = String::new();
     if uses_rename {
@@ -121,7 +123,13 @@ pub(in crate::dto) fn render_kotlin(schema: &SchemaNode, name: &str) -> Result<S
     if uses_json {
         out.push_str("import com.fasterxml.jackson.databind.JsonNode\n");
     }
-    if uses_rename || uses_json {
+    if uses_list {
+        out.push_str("import kotlin.collections.List\n");
+    }
+    if uses_map {
+        out.push_str("import kotlin.collections.Map\n");
+    }
+    if uses_rename || uses_json || uses_list || uses_map {
         out.push('\n');
     }
 

--- a/crates/rulemorph/src/dto/render/python.rs
+++ b/crates/rulemorph/src/dto/render/python.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::dto::schema::{
-    Field, FieldType, PrimitiveType, SchemaNode, node_has_required, node_uses_json,
+    Field, FieldType, PrimitiveType, SchemaNode, field_is_optional, node_uses_json,
 };
 use crate::dto::support::{
     NameRegistry, collect_types, field_identifier, json_string_literal, safe_comment_text,
@@ -59,10 +59,7 @@ pub(in crate::dto) fn render_python(schema: &SchemaNode, name: &str) -> Result<S
         for field in &def.node.fields {
             let ident = field_identifier(DtoLanguage::Python, &field.key, &mut used);
             let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
+            let optional = field_is_optional(field);
             let field_type = python_type_for_field(field, &def.path, &registry, optional);
             fields.push(RenderField {
                 key: field.key.clone(),
@@ -122,25 +119,43 @@ fn python_type_for_field(
     registry: &NameRegistry,
     optional: bool,
 ) -> String {
-    let base = match &field.field_type {
+    let mut path = parent_path.to_vec();
+    path.push(field.key.clone());
+    let base = python_type_for_type(&field.field_type, &path, registry);
+
+    if optional && !base.starts_with("Optional[") {
+        format!("Optional[{}]", base)
+    } else {
+        base
+    }
+}
+
+fn python_type_for_type(
+    field_type: &FieldType,
+    path: &[String],
+    registry: &NameRegistry,
+) -> String {
+    match field_type {
         FieldType::Primitive(PrimitiveType::String) => "str".to_string(),
         FieldType::Primitive(PrimitiveType::Int) => "int".to_string(),
         FieldType::Primitive(PrimitiveType::Float) => "float".to_string(),
         FieldType::Primitive(PrimitiveType::Bool) => "bool".to_string(),
-        FieldType::JsonValue => "Any".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
+        FieldType::Array(inner) => format!("list[{}]", python_type_for_type(inner, path, registry)),
+        FieldType::Map(inner) => {
+            format!("dict[str, {}]", python_type_for_type(inner, path, registry))
         }
-    };
-
-    if optional {
-        format!("Optional[{}]", base)
-    } else {
-        base
+        FieldType::Nullable(inner) => {
+            let inner_type = python_type_for_type(inner, path, registry);
+            if inner_type.starts_with("Optional[") {
+                inner_type
+            } else {
+                format!("Optional[{}]", inner_type)
+            }
+        }
+        FieldType::JsonValue => "Any".to_string(),
+        FieldType::Object(_) => registry
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| "Record".to_string()),
     }
 }

--- a/crates/rulemorph/src/dto/render/python.rs
+++ b/crates/rulemorph/src/dto/render/python.rs
@@ -18,8 +18,12 @@ pub(in crate::dto) fn render_python(schema: &SchemaNode, name: &str) -> Result<S
     let uses_json = node_uses_json(schema);
     let uses_optional = schema_has_optional(schema);
     let uses_rename = schema_has_rename(schema, DtoLanguage::Python);
+    let uses_builtin_generics = schema_uses_builtin_generics(schema);
 
     let mut out = String::new();
+    if uses_builtin_generics {
+        out.push_str("from __future__ import annotations\n");
+    }
     out.push_str("from dataclasses import dataclass");
     if uses_rename {
         out.push_str(", field");
@@ -157,5 +161,20 @@ fn python_type_for_type(
             .get(path)
             .cloned()
             .unwrap_or_else(|| "Record".to_string()),
+    }
+}
+
+fn schema_uses_builtin_generics(node: &SchemaNode) -> bool {
+    node.fields
+        .iter()
+        .any(|field| field_type_uses_builtin_generics(&field.field_type))
+}
+
+fn field_type_uses_builtin_generics(field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::Array(_) | FieldType::Map(_) => true,
+        FieldType::Nullable(inner) => field_type_uses_builtin_generics(inner),
+        FieldType::Object(child) => schema_uses_builtin_generics(child),
+        FieldType::Primitive(_) | FieldType::JsonValue => false,
     }
 }

--- a/crates/rulemorph/src/dto/render/rust.rs
+++ b/crates/rulemorph/src/dto/render/rust.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::dto::schema::{
-    Field, FieldType, PrimitiveType, SchemaNode, node_has_required, node_uses_json,
+    Field, FieldType, PrimitiveType, SchemaNode, field_is_optional, node_uses_json,
 };
 use crate::dto::support::{NameRegistry, collect_types, field_identifier, rust_string_literal};
 use crate::dto::{DtoError, DtoLanguage};
@@ -13,6 +13,9 @@ pub(in crate::dto) fn render_rust(schema: &SchemaNode, name: &str) -> Result<Str
 
     let mut out = String::new();
     out.push_str("use serde::{Deserialize, Serialize};\n");
+    if schema_uses_map(schema) {
+        out.push_str("use std::collections::HashMap;\n");
+    }
     if node_uses_json(schema) {
         out.push_str("use serde_json::Value;\n");
     }
@@ -26,10 +29,7 @@ pub(in crate::dto) fn render_rust(schema: &SchemaNode, name: &str) -> Result<Str
         for field in &def.node.fields {
             let ident = field_identifier(DtoLanguage::Rust, &field.key, &mut used);
             let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
+            let optional = field_is_optional(field);
             let field_type = rust_type_for_field(field, &def.path, &registry);
 
             let mut attrs = Vec::new();
@@ -60,19 +60,46 @@ pub(in crate::dto) fn render_rust(schema: &SchemaNode, name: &str) -> Result<Str
 }
 
 fn rust_type_for_field(field: &Field, parent_path: &[String], registry: &NameRegistry) -> String {
-    match &field.field_type {
+    let mut path = parent_path.to_vec();
+    path.push(field.key.clone());
+    rust_type_for_type(&field.field_type, &path, registry)
+}
+
+fn rust_type_for_type(field_type: &FieldType, path: &[String], registry: &NameRegistry) -> String {
+    match field_type {
         FieldType::Primitive(PrimitiveType::String) => "String".to_string(),
         FieldType::Primitive(PrimitiveType::Int) => "i64".to_string(),
         FieldType::Primitive(PrimitiveType::Float) => "f64".to_string(),
         FieldType::Primitive(PrimitiveType::Bool) => "bool".to_string(),
-        FieldType::JsonValue => "Value".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
+        FieldType::Array(inner) => format!("Vec<{}>", rust_type_for_type(inner, path, registry)),
+        FieldType::Map(inner) => {
+            format!(
+                "HashMap<String, {}>",
+                rust_type_for_type(inner, path, registry)
+            )
         }
+        FieldType::Nullable(inner) => {
+            format!("Option<{}>", rust_type_for_type(inner, path, registry))
+        }
+        FieldType::JsonValue => "Value".to_string(),
+        FieldType::Object(_) => registry
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| "Record".to_string()),
+    }
+}
+
+fn schema_uses_map(node: &SchemaNode) -> bool {
+    node.fields
+        .iter()
+        .any(|field| field_type_uses_map(&field.field_type))
+}
+
+fn field_type_uses_map(field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::Map(_) => true,
+        FieldType::Array(inner) | FieldType::Nullable(inner) => field_type_uses_map(inner),
+        FieldType::Object(child) => schema_uses_map(child),
+        FieldType::Primitive(_) | FieldType::JsonValue => false,
     }
 }

--- a/crates/rulemorph/src/dto/render/swift.rs
+++ b/crates/rulemorph/src/dto/render/swift.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::dto::schema::{
-    Field, FieldType, PrimitiveType, SchemaNode, node_has_required, node_uses_json,
+    Field, FieldType, PrimitiveType, SchemaNode, field_is_optional, node_uses_json,
 };
 use crate::dto::support::{NameRegistry, collect_types, field_identifier, swift_string_literal};
 use crate::dto::{DtoError, DtoLanguage};
@@ -21,10 +21,7 @@ pub(in crate::dto) fn render_swift(schema: &SchemaNode, name: &str) -> Result<St
         for field in &def.node.fields {
             let ident = field_identifier(DtoLanguage::Swift, &field.key, &mut used);
             let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
+            let optional = field_is_optional(field);
             let field_type = swift_type_for_field(field, &def.path, &registry, optional);
 
             out.push_str(&format!("    let {}: {}\n", ident, field_type));
@@ -62,23 +59,41 @@ fn swift_type_for_field(
     registry: &NameRegistry,
     optional: bool,
 ) -> String {
-    let base = match &field.field_type {
+    let mut path = parent_path.to_vec();
+    path.push(field.key.clone());
+    let base = swift_type_for_type(&field.field_type, &path, registry);
+
+    if optional && !base.ends_with('?') {
+        format!("{}?", base)
+    } else {
+        base
+    }
+}
+
+fn swift_type_for_type(field_type: &FieldType, path: &[String], registry: &NameRegistry) -> String {
+    match field_type {
         FieldType::Primitive(PrimitiveType::String) => "String".to_string(),
         FieldType::Primitive(PrimitiveType::Int) => "Int".to_string(),
         FieldType::Primitive(PrimitiveType::Float) => "Double".to_string(),
         FieldType::Primitive(PrimitiveType::Bool) => "Bool".to_string(),
-        FieldType::JsonValue => "JSONValue".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
+        FieldType::Array(inner) => format!("[{}]", swift_type_for_type(inner, path, registry)),
+        FieldType::Map(inner) => {
+            format!("[String: {}]", swift_type_for_type(inner, path, registry))
         }
-    };
-
-    if optional { format!("{}?", base) } else { base }
+        FieldType::Nullable(inner) => {
+            let inner_type = swift_type_for_type(inner, path, registry);
+            if inner_type.ends_with('?') {
+                inner_type
+            } else {
+                format!("{}?", inner_type)
+            }
+        }
+        FieldType::JsonValue => "JSONValue".to_string(),
+        FieldType::Object(_) => registry
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| "Record".to_string()),
+    }
 }
 
 const SWIFT_JSON_VALUE: &str = "enum JSONValue: Codable {\n    case string(String)\n    case number(Double)\n    case bool(Bool)\n    case object([String: JSONValue])\n    case array([JSONValue])\n    case null\n\n    init(from decoder: Decoder) throws {\n        let container = try decoder.singleValueContainer()\n        if container.decodeNil() {\n            self = .null\n        } else if let value = try? container.decode(Bool.self) {\n            self = .bool(value)\n        } else if let value = try? container.decode(Double.self) {\n            self = .number(value)\n        } else if let value = try? container.decode(String.self) {\n            self = .string(value)\n        } else if let value = try? container.decode([String: JSONValue].self) {\n            self = .object(value)\n        } else if let value = try? container.decode([JSONValue].self) {\n            self = .array(value)\n        } else {\n            throw DecodingError.typeMismatch(JSONValue.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: \"Unsupported JSON value\"))\n        }\n    }\n\n    func encode(to encoder: Encoder) throws {\n        var container = encoder.singleValueContainer()\n        switch self {\n        case .string(let value):\n            try container.encode(value)\n        case .number(let value):\n            try container.encode(value)\n        case .bool(let value):\n            try container.encode(value)\n        case .object(let value):\n            try container.encode(value)\n        case .array(let value):\n            try container.encode(value)\n        case .null:\n            try container.encodeNil()\n        }\n    }\n}\n";

--- a/crates/rulemorph/src/dto/render/typescript.rs
+++ b/crates/rulemorph/src/dto/render/typescript.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::dto::schema::{Field, FieldType, PrimitiveType, SchemaNode, node_has_required};
+use crate::dto::schema::{Field, FieldType, PrimitiveType, SchemaNode, field_is_optional};
 use crate::dto::support::{
     NameRegistry, collect_types, field_identifier, json_string_literal, safe_comment_text,
 };
@@ -21,10 +21,7 @@ pub(in crate::dto) fn render_typescript(
         for field in &def.node.fields {
             let ident = field_identifier(DtoLanguage::TypeScript, &field.key, &mut used);
             let rename = ident != field.key;
-            let optional = match &field.field_type {
-                FieldType::Object(child) => !node_has_required(child),
-                _ => field.optional,
-            };
+            let optional = field_is_optional(field);
             let field_type = typescript_type_for_field(field, &def.path, &registry);
             if rename {
                 out.push_str(&format!(
@@ -46,19 +43,47 @@ fn typescript_type_for_field(
     parent_path: &[String],
     registry: &NameRegistry,
 ) -> String {
-    match &field.field_type {
+    let mut path = parent_path.to_vec();
+    path.push(field.key.clone());
+    typescript_type_for_type(&field.field_type, &path, registry)
+}
+
+fn typescript_type_for_type(
+    field_type: &FieldType,
+    path: &[String],
+    registry: &NameRegistry,
+) -> String {
+    match field_type {
         FieldType::Primitive(PrimitiveType::String) => "string".to_string(),
         FieldType::Primitive(PrimitiveType::Int) => "number".to_string(),
         FieldType::Primitive(PrimitiveType::Float) => "number".to_string(),
         FieldType::Primitive(PrimitiveType::Bool) => "boolean".to_string(),
-        FieldType::JsonValue => "unknown".to_string(),
-        FieldType::Object(_) => {
-            let mut path = parent_path.to_vec();
-            path.push(field.key.clone());
-            registry
-                .get(&path)
-                .cloned()
-                .unwrap_or_else(|| "Record".to_string())
+        FieldType::Array(inner) => {
+            let inner_type = typescript_type_for_type(inner, path, registry);
+            if inner_type.contains(" | ") {
+                format!("({})[]", inner_type)
+            } else {
+                format!("{}[]", inner_type)
+            }
         }
+        FieldType::Map(inner) => {
+            format!(
+                "{{ [key: string]: {} }}",
+                typescript_type_for_type(inner, path, registry)
+            )
+        }
+        FieldType::Nullable(inner) => {
+            let inner_type = typescript_type_for_type(inner, path, registry);
+            if inner_type.ends_with(" | null") {
+                inner_type
+            } else {
+                format!("{} | null", inner_type)
+            }
+        }
+        FieldType::JsonValue => "unknown".to_string(),
+        FieldType::Object(_) => registry
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| "Record".to_string()),
     }
 }

--- a/crates/rulemorph/src/dto/schema.rs
+++ b/crates/rulemorph/src/dto/schema.rs
@@ -1,29 +1,36 @@
 use serde_json::Value as JsonValue;
 
 use super::DtoError;
+use super::infer::{
+    InferenceState, infer_mapping_field_type, remember_mapping_type, type_from_mapping_type,
+};
 use crate::model::{Expr, RuleFile};
 use crate::path::{PathToken, parse_path};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub(super) struct SchemaNode {
     pub(super) fields: Vec<Field>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub(super) struct Field {
     pub(super) key: String,
     pub(super) field_type: FieldType,
     pub(super) optional: bool,
+    pub(super) synthetic: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub(super) enum FieldType {
     Primitive(PrimitiveType),
+    Array(Box<FieldType>),
+    Map(Box<FieldType>),
+    Nullable(Box<FieldType>),
     Object(Box<SchemaNode>),
     JsonValue,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub(super) enum PrimitiveType {
     String,
     Int,
@@ -33,6 +40,7 @@ pub(super) enum PrimitiveType {
 
 pub(super) fn build_schema(rule: &RuleFile) -> Result<SchemaNode, DtoError> {
     let mut root = SchemaNode { fields: Vec::new() };
+    let mut inference = InferenceState::default();
 
     let step_mappings = rule
         .steps
@@ -63,14 +71,14 @@ pub(super) fn build_schema(rule: &RuleFile) -> Result<SchemaNode, DtoError> {
             return Err(DtoError::new("target path is invalid"));
         }
 
-        let field_type = match mapping.value_type.as_deref() {
-            Some("string") => FieldType::Primitive(PrimitiveType::String),
-            Some("int") => FieldType::Primitive(PrimitiveType::Int),
-            Some("float") => FieldType::Primitive(PrimitiveType::Float),
-            Some("bool") => FieldType::Primitive(PrimitiveType::Bool),
-            Some(_) => return Err(DtoError::new("unsupported type in mapping")),
-            None => FieldType::JsonValue,
-        };
+        if mapping
+            .value_type
+            .as_deref()
+            .is_some_and(|value_type| type_from_mapping_type(value_type).is_none())
+        {
+            return Err(DtoError::new("unsupported type in mapping"));
+        }
+        let field_type = infer_mapping_field_type(mapping, rule, &mut inference);
         let conditional = match &mapping.when {
             None => false,
             Some(Expr::Literal(JsonValue::Bool(true))) => false,
@@ -79,7 +87,8 @@ pub(super) fn build_schema(rule: &RuleFile) -> Result<SchemaNode, DtoError> {
         let optional = conditional
             || !(mapping.required || mapping.value.is_some() || mapping.default.is_some());
 
-        insert_field(&mut root, &keys, field_type, optional)?;
+        insert_field(&mut root, &keys, field_type.clone(), optional)?;
+        remember_mapping_type(&mut inference, &keys, &field_type);
     }
 
     Ok(root)
@@ -104,6 +113,7 @@ fn insert_field(
             key: key.clone(),
             field_type,
             optional,
+            synthetic: false,
         });
         return Ok(());
     }
@@ -123,20 +133,28 @@ fn insert_field(
         key: key.clone(),
         field_type: FieldType::Object(Box::new(child)),
         optional: false,
+        synthetic: true,
     });
     Ok(())
+}
+
+pub(super) fn field_is_optional(field: &Field) -> bool {
+    match &field.field_type {
+        FieldType::Object(child) if field.synthetic => field.optional || !node_has_required(child),
+        _ => field.optional,
+    }
 }
 
 pub(super) fn node_has_required(node: &SchemaNode) -> bool {
     for field in &node.fields {
         match &field.field_type {
             FieldType::Object(child) => {
-                if node_has_required(child) {
+                if !field_is_optional(field) || node_has_required(child) {
                     return true;
                 }
             }
             _ => {
-                if !field.optional {
+                if !field_is_optional(field) {
                     return true;
                 }
             }
@@ -146,16 +164,28 @@ pub(super) fn node_has_required(node: &SchemaNode) -> bool {
 }
 
 pub(super) fn node_uses_json(node: &SchemaNode) -> bool {
-    for field in &node.fields {
-        match &field.field_type {
-            FieldType::JsonValue => return true,
-            FieldType::Object(child) => {
-                if node_uses_json(child) {
-                    return true;
-                }
-            }
-            _ => {}
+    node.fields
+        .iter()
+        .any(|field| field_type_uses_json(&field.field_type))
+}
+
+pub(super) fn field_type_uses_json(field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::JsonValue => true,
+        FieldType::Array(inner) | FieldType::Map(inner) | FieldType::Nullable(inner) => {
+            field_type_uses_json(inner)
         }
+        FieldType::Object(child) => node_uses_json(child),
+        FieldType::Primitive(_) => false,
     }
-    false
+}
+
+pub(super) fn field_type_has_required_object(field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::Object(child) => node_has_required(child),
+        FieldType::Array(inner) | FieldType::Map(inner) | FieldType::Nullable(inner) => {
+            field_type_has_required_object(inner)
+        }
+        FieldType::Primitive(_) | FieldType::JsonValue => true,
+    }
 }

--- a/crates/rulemorph/src/dto/schema.rs
+++ b/crates/rulemorph/src/dto/schema.rs
@@ -87,8 +87,8 @@ pub(super) fn build_schema(rule: &RuleFile) -> Result<SchemaNode, DtoError> {
         let optional = conditional
             || !(mapping.required || mapping.value.is_some() || mapping.default.is_some());
 
-        insert_field(&mut root, &keys, field_type.clone(), optional)?;
-        remember_mapping_type(&mut inference, &keys, &field_type);
+        insert_field(&mut root, &keys, field_type, optional)?;
+        remember_output_prefixes(&mut inference, &root, &keys);
     }
 
     Ok(root)
@@ -138,6 +138,27 @@ fn insert_field(
     Ok(())
 }
 
+fn remember_output_prefixes(inference: &mut InferenceState, root: &SchemaNode, keys: &[String]) {
+    for prefix_len in 1..=keys.len() {
+        let prefix = &keys[..prefix_len];
+        if let Some(field_type) = field_type_at_keys(root, prefix) {
+            remember_mapping_type(inference, prefix, field_type);
+        }
+    }
+}
+
+fn field_type_at_keys<'a>(node: &'a SchemaNode, keys: &[String]) -> Option<&'a FieldType> {
+    let key = keys.first()?;
+    let field = node.fields.iter().find(|field| field.key == *key)?;
+    if keys.len() == 1 {
+        return Some(&field.field_type);
+    }
+    match &field.field_type {
+        FieldType::Object(child) => field_type_at_keys(child, &keys[1..]),
+        _ => None,
+    }
+}
+
 pub(super) fn field_is_optional(field: &Field) -> bool {
     match &field.field_type {
         FieldType::Object(child) if field.synthetic => field.optional || !node_has_required(child),
@@ -177,15 +198,5 @@ pub(super) fn field_type_uses_json(field_type: &FieldType) -> bool {
         }
         FieldType::Object(child) => node_uses_json(child),
         FieldType::Primitive(_) => false,
-    }
-}
-
-pub(super) fn field_type_has_required_object(field_type: &FieldType) -> bool {
-    match field_type {
-        FieldType::Object(child) => node_has_required(child),
-        FieldType::Array(inner) | FieldType::Map(inner) | FieldType::Nullable(inner) => {
-            field_type_has_required_object(inner)
-        }
-        FieldType::Primitive(_) | FieldType::JsonValue => true,
     }
 }

--- a/crates/rulemorph/src/dto/support.rs
+++ b/crates/rulemorph/src/dto/support.rs
@@ -69,16 +69,31 @@ pub(super) fn collect_types<'a>(
     out: &mut Vec<TypeDef<'a>>,
 ) {
     for field in &node.fields {
-        if let FieldType::Object(child) = &field.field_type {
-            let mut child_path = path.clone();
-            child_path.push(field.key.clone());
-            registry.type_name_for_path(&child_path);
-            collect_types(child, child_path, registry, out);
-        }
+        let mut child_path = path.clone();
+        child_path.push(field.key.clone());
+        collect_nested_types(&field.field_type, child_path, registry, out);
     }
 
     let name = registry.type_name_for_path(&path);
     out.push(TypeDef { name, node, path });
+}
+
+fn collect_nested_types<'a>(
+    field_type: &'a FieldType,
+    path: Vec<String>,
+    registry: &mut NameRegistry,
+    out: &mut Vec<TypeDef<'a>>,
+) {
+    match field_type {
+        FieldType::Object(child) => {
+            registry.type_name_for_path(&path);
+            collect_types(child, path, registry, out);
+        }
+        FieldType::Array(inner) | FieldType::Map(inner) | FieldType::Nullable(inner) => {
+            collect_nested_types(inner, path, registry, out);
+        }
+        FieldType::Primitive(_) | FieldType::JsonValue => {}
+    }
 }
 
 fn words_from_key(key: &str) -> Vec<String> {
@@ -86,6 +101,16 @@ fn words_from_key(key: &str) -> Vec<String> {
     let mut current = String::new();
     for ch in key.chars() {
         if ch.is_ascii_alphanumeric() {
+            if ch.is_ascii_uppercase()
+                && !current.is_empty()
+                && current
+                    .chars()
+                    .last()
+                    .is_some_and(|prev| prev.is_ascii_lowercase() || prev.is_ascii_digit())
+            {
+                words.push(current);
+                current = String::new();
+            }
             current.push(ch);
         } else if !current.is_empty() {
             words.push(current);

--- a/crates/rulemorph/src/dto/support/literals.rs
+++ b/crates/rulemorph/src/dto/support/literals.rs
@@ -34,6 +34,8 @@ pub(in crate::dto) fn go_json_tag_literal(key: &str, optional: bool) -> String {
         && !key.contains('\\')
         && !key.contains('\r')
         && !key.contains('\n')
+        && !key.contains('\t')
+        && !key.chars().any(char::is_control)
     {
         if optional {
             return format!("`json:\"{},omitempty\"`", key);

--- a/crates/rulemorph/src/expr_json.rs
+++ b/crates/rulemorph/src/expr_json.rs
@@ -3,7 +3,7 @@ use serde_json::{Map, Value as JsonValue};
 use crate::model::Expr;
 use crate::v2_parser::{is_literal_escape, is_pipe_value, is_v2_ref};
 
-pub(super) fn literal_string(expr: &Expr) -> Option<&str> {
+pub(crate) fn literal_string(expr: &Expr) -> Option<&str> {
     match expr {
         Expr::Literal(value) => value.as_str(),
         _ => None,
@@ -16,7 +16,7 @@ pub(super) fn literal_string(expr: &Expr) -> Option<&str> {
 /// - Ref where ref_path starts with @ -> single element array
 /// - Chain where first element starts with @ -> convert to array
 /// Returns None if it looks like v1 expression and should be handled by v1 eval.
-pub(super) fn expr_to_json_for_v2_pipe(expr: &Expr) -> Option<JsonValue> {
+pub(crate) fn expr_to_json_for_v2_pipe(expr: &Expr) -> Option<JsonValue> {
     match expr {
         Expr::Literal(JsonValue::Array(arr)) => {
             // Direct array - v2 pipe
@@ -45,7 +45,7 @@ pub(super) fn expr_to_json_for_v2_pipe(expr: &Expr) -> Option<JsonValue> {
                     if r.ref_path.starts_with('@') {
                         // Convert chain to array
                         let arr: Vec<JsonValue> =
-                            chain.chain.iter().map(|e| expr_to_json_value(e)).collect();
+                            chain.chain.iter().map(expr_to_json_value).collect();
                         return Some(JsonValue::Array(arr));
                     }
                 }
@@ -58,7 +58,7 @@ pub(super) fn expr_to_json_for_v2_pipe(expr: &Expr) -> Option<JsonValue> {
 
 /// Convert an Expr to JSON value for v2 condition parsing.
 /// Accepts literal values and v2-looking refs/chains while avoiding v1-only forms.
-pub(super) fn expr_to_json_for_v2_condition(expr: &Expr) -> Option<JsonValue> {
+pub(crate) fn expr_to_json_for_v2_condition(expr: &Expr) -> Option<JsonValue> {
     match expr {
         Expr::Literal(value) => Some(value.clone()),
         Expr::Ref(ref_expr)
@@ -82,7 +82,7 @@ pub(super) fn expr_to_json_for_v2_condition(expr: &Expr) -> Option<JsonValue> {
     }
 }
 
-/// Helper to convert Expr to JsonValue (for Chain conversion)
+/// Helper to convert Expr to JsonValue (for Chain conversion).
 fn expr_to_json_value(expr: &Expr) -> JsonValue {
     match expr {
         Expr::Ref(r) => JsonValue::String(r.ref_path.clone()),

--- a/crates/rulemorph/src/lib.rs
+++ b/crates/rulemorph/src/lib.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod dto;
 mod error;
+mod expr_json;
 mod locator;
 mod model;
 pub mod normalization;

--- a/crates/rulemorph/src/model.rs
+++ b/crates/rulemorph/src/model.rs
@@ -3,6 +3,10 @@ use serde_json::Value as JsonValue;
 
 mod input;
 
+#[cfg_attr(
+    any(not(feature = "html"), not(feature = "excel")),
+    allow(unused_imports)
+)]
 pub use self::input::{
     Column, ExcelCellErrorPolicy, ExcelColumn, ExcelDatePolicy, ExcelEmptyCellPolicy,
     ExcelFormulaPolicy, ExcelInput, ExcelSheetRef, HtmlInput, HtmlValueKind, InputFormat,

--- a/crates/rulemorph/src/normalization/mod.rs
+++ b/crates/rulemorph/src/normalization/mod.rs
@@ -1,5 +1,7 @@
 mod csv;
+#[cfg(feature = "excel")]
 mod excel;
+#[cfg(feature = "html")]
 mod html;
 mod input;
 mod json;
@@ -15,6 +17,8 @@ pub use options::NormalizationOptions;
 pub use records::NormalizedRecords;
 
 use crate::error::TransformError;
+#[cfg(any(not(feature = "html"), not(feature = "excel")))]
+use crate::error::TransformErrorKind;
 use crate::model::{InputFormat, RuleFile};
 
 use input::text_input;
@@ -50,10 +54,24 @@ pub fn normalize_records_with_options<'a>(
             toml::normalize_toml_records(rule, text_input(input, options)?, options)?
         }
         InputFormat::Xml => xml::normalize_xml_records(rule, text_input(input, options)?, options)?,
+        #[cfg(feature = "html")]
         InputFormat::Html => {
             html::normalize_html_records(rule, text_input(input, options)?, options)?
         }
+        #[cfg(not(feature = "html"))]
+        InputFormat::Html => return Err(unsupported_input_format("html")),
+        #[cfg(feature = "excel")]
         InputFormat::Excel => excel::normalize_excel_records(rule, input, options)?,
+        #[cfg(not(feature = "excel"))]
+        InputFormat::Excel => return Err(unsupported_input_format("excel")),
     };
     Ok(NormalizedRecords::Materialized(records.into_iter()))
+}
+
+#[cfg(any(not(feature = "html"), not(feature = "excel")))]
+fn unsupported_input_format(format: &str) -> TransformError {
+    TransformError::new(
+        TransformErrorKind::InvalidInput,
+        format!("input format {} is not enabled in this build", format),
+    )
 }

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -50,7 +50,6 @@ fn cached_regex(pattern: &str, path: &str) -> Result<Regex, TransformError> {
 
 mod api;
 mod branch;
-mod expr_json;
 mod finalize;
 mod mapping;
 mod operators;
@@ -66,7 +65,6 @@ mod v2_trace;
 
 use self::api::transform_record_with_warnings_inner;
 use self::branch::{BranchContext, load_rule_from_path, merge_branch_output};
-use self::expr_json::{expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe, literal_string};
 use self::finalize::{apply_finalize, apply_finalize_traced, sort_key_from_value};
 use self::mapping::{eval_mapping, eval_mapping_traced};
 pub(crate) use self::operators::eval_op;
@@ -88,5 +86,6 @@ use self::v1_expr::{
 };
 use self::v1_trace::eval_expr_traced;
 use self::v2_trace::{eval_v2_condition_traced, eval_v2_pipe_traced, sort_key_to_json};
+use crate::expr_json::{expr_to_json_for_v2_condition, expr_to_json_for_v2_pipe, literal_string};
 pub use api::*;
 pub use stream::*;

--- a/crates/rulemorph/tests/common/mod.rs
+++ b/crates/rulemorph/tests/common/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod golden;
 pub(crate) mod trace;
 pub(crate) mod validation;
+#[cfg(feature = "excel")]
 pub(crate) mod xlsx;

--- a/crates/rulemorph/tests/common/xlsx.rs
+++ b/crates/rulemorph/tests/common/xlsx.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports)]
+
 use std::io::{Cursor, Write};
 
 use zip::{CompressionMethod, ZipWriter, write::FileOptions};

--- a/crates/rulemorph/tests/dto_inference.rs
+++ b/crates/rulemorph/tests/dto_inference.rs
@@ -1,0 +1,425 @@
+use rulemorph::{DtoLanguage, generate_dto, parse_rule_file};
+
+fn render(yaml: &str, language: DtoLanguage) -> String {
+    let rule = parse_rule_file(yaml).expect("rule parses");
+    generate_dto(&rule, language, Some("Record")).expect("dto renders")
+}
+
+#[test]
+fn dto_infers_scalars_from_terminal_ops() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: active
+    expr: ["@input.active_text", "bool"]
+    required: true
+  - target: score
+    expr: ["@input.score_text", "int"]
+    required: true
+  - target: ratio
+    expr: ["@input.total", { divide: [3] }]
+    required: true
+  - target: normalized
+    expr: ["@input.name", "trim", "lowercase"]
+    required: true
+  - target: size
+    expr: ["@input.items", "len"]
+    required: true
+"#;
+
+    let rust = render(yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub active: bool,"));
+    assert!(rust.contains("pub score: i64,"));
+    assert!(rust.contains("pub ratio: f64,"));
+    assert!(rust.contains("pub normalized: String,"));
+    assert!(rust.contains("pub size: i64,"));
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("active: boolean;"));
+    assert!(typescript.contains("score: number;"));
+    assert!(typescript.contains("ratio: number;"));
+    assert!(typescript.contains("normalized: string;"));
+    assert!(typescript.contains("size: number;"));
+}
+
+#[test]
+fn dto_infers_literal_object_arrays_and_maps() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: payload
+    expr:
+      - { id: "demo", count: 3, tags: ["a", "b"], meta: { enabled: true } }
+    required: true
+  - target: parts
+    expr: ["@input.csv", { split: [","] }]
+    required: true
+  - target: grouped
+    expr: ["@input.items", { group_by: ["@item.category"] }]
+    required: true
+"#;
+
+    let rust = render(yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub payload: RecordPayload,"));
+    assert!(rust.contains("pub tags: Vec<String>,"));
+    assert!(rust.contains("pub meta: RecordPayloadMeta,"));
+    assert!(rust.contains("pub enabled: bool,"));
+    assert!(rust.contains("pub parts: Vec<String>,"));
+    assert!(rust.contains("HashMap<String, Vec<Value>>"));
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("payload: RecordPayload;"));
+    assert!(typescript.contains("tags: string[];"));
+    assert!(typescript.contains("meta: RecordPayloadMeta;"));
+    assert!(typescript.contains("enabled: boolean;"));
+    assert!(typescript.contains("parts: string[];"));
+    assert!(typescript.contains("grouped: { [key: string]: unknown[] };"));
+    assert!(!typescript.contains("Record<string,"));
+}
+
+#[test]
+fn dto_explicit_type_overrides_inference() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: active
+    expr: ["@input.active_text", "bool"]
+    type: string
+    required: true
+"#;
+
+    let rust = render(yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub active: String,"));
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("active: string;"));
+}
+
+#[test]
+fn dto_default_does_not_narrow_dynamic_unknown() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: payload
+    source: input.payload
+    default: { role: "user" }
+    required: true
+  - target: selected
+    expr: ["@input.dynamic", { get: ["@input.path"] }]
+    default: "fallback"
+    required: true
+"#;
+
+    let rust = render(yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub payload: Value,"));
+    assert!(rust.contains("pub selected: Value,"));
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("payload: unknown;"));
+    assert!(typescript.contains("selected: unknown;"));
+}
+
+#[test]
+fn dto_default_and_coalesce_do_not_narrow_nullable_unknown() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: firstItem
+    expr: ["@input.items", "first"]
+    default: "fallback"
+    required: true
+  - target: coalesced
+    expr: ["@input.items", "first", { coalesce: ["fallback"] }]
+    required: true
+"#;
+
+    let rust = render(yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub first_item: Value,"));
+    assert!(rust.contains("pub coalesced: Value,"));
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("firstItem: unknown;"));
+    assert!(typescript.contains("coalesced: unknown;"));
+}
+
+#[test]
+fn dto_projection_falls_back_for_dynamic_or_indexed_paths() {
+    let long_path = "profile.".repeat(200) + "name";
+    let yaml = format!(
+        r#"
+version: 2
+input:
+  format: json
+  json: {{}}
+mappings:
+  - target: base
+    value: {{ id: "u1", profile: {{ name: "Ada", age: 37 }}, active: true }}
+    required: true
+  - target: mixedPick
+    expr: ["@out.base", {{ pick: ["id", "@input.dynamicPath"] }}]
+    required: true
+  - target: mixedOmit
+    expr: ["@out.base", {{ omit: ["active", "@input.dynamicPath"] }}]
+    required: true
+  - target: indexedOut
+    expr: ["@out.base[0].id"]
+    required: true
+  - target: hugePath
+    expr: ["@out.base", {{ get: ["{}"] }}]
+    required: true
+"#,
+        long_path
+    );
+
+    let rust = render(&yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub mixed_pick: Value,"));
+    assert!(rust.contains("pub mixed_omit: Value,"));
+    assert!(rust.contains("pub indexed_out: Value,"));
+    assert!(rust.contains("pub huge_path: Value,"));
+
+    let typescript = render(&yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("mixedPick: unknown;"));
+    assert!(typescript.contains("mixedOmit: unknown;"));
+    assert!(typescript.contains("indexedOut: unknown;"));
+    assert!(typescript.contains("hugePath: unknown;"));
+}
+
+#[test]
+fn dto_out_object_copies_are_charged_to_generated_type_budget() {
+    let mut mappings =
+        String::from("  - target: base\n    value: { id: \"u1\" }\n    required: true\n");
+    for index in 0..530 {
+        mappings.push_str(&format!(
+            "  - target: copy{index}\n    expr: [\"@out.base\"]\n    required: true\n"
+        ));
+    }
+    let yaml = format!(
+        r#"
+version: 2
+input:
+  format: json
+  json: {{}}
+mappings:
+{}
+"#,
+        mappings
+    );
+
+    let rust = render(&yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub copy529: Value,"));
+}
+
+#[test]
+fn dto_inference_budget_falls_back_for_large_literal_shapes() {
+    let mut fields = String::new();
+    for index in 0..300 {
+        fields.push_str(&format!("        k{}: {}\n", index, index));
+    }
+    let yaml = format!(
+        r#"
+version: 2
+input:
+  format: json
+  json: {{}}
+mappings:
+  - target: payload
+    value:
+{}
+    required: true
+"#,
+        fields
+    );
+
+    let rust = render(&yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub payload: Value,"));
+
+    let typescript = render(&yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("payload: unknown;"));
+}
+
+#[test]
+fn dto_inference_budget_is_shared_across_mappings_and_pipe_steps() {
+    let mut mappings = String::new();
+    for index in 0..600 {
+        mappings.push_str(&format!(
+            "  - target: payload{index}\n    value: {{ nested: {{ value: {index} }} }}\n    required: true\n"
+        ));
+    }
+
+    let many_mappings_yaml = format!(
+        r#"
+version: 2
+input:
+  format: json
+  json: {{}}
+mappings:
+{}
+"#,
+        mappings
+    );
+
+    let many_mappings_rust = render(&many_mappings_yaml, DtoLanguage::Rust);
+    assert!(many_mappings_rust.contains("pub payload599: Value,"));
+
+    let long_pipe = std::iter::repeat("\"trim\"")
+        .take(5000)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let long_pipe_yaml = format!(
+        r#"
+version: 2
+input:
+  format: json
+  json: {{}}
+mappings:
+  - target: value
+    expr: ["@input.value", {}]
+    required: true
+"#,
+        long_pipe
+    );
+
+    let long_pipe_rust = render(&long_pipe_yaml, DtoLanguage::Rust);
+    assert!(long_pipe_rust.contains("pub value: Value,"));
+}
+
+#[test]
+fn dto_inference_budget_falls_back_when_object_merge_expands_shape() {
+    let mut base_fields = String::new();
+    let mut merge_fields = Vec::new();
+    for index in 0..200 {
+        base_fields.push_str(&format!("        l{}: {}\n", index, index));
+        merge_fields.push(format!("r{}: {}", index, index));
+    }
+    let merge_arg = merge_fields.join(", ");
+    let yaml = format!(
+        r#"
+version: 2
+input:
+  format: json
+  json: {{}}
+mappings:
+  - target: base
+    value:
+{}
+    required: true
+  - target: merged
+    expr: ["@out.base", {{ merge: [{{ {} }}] }}]
+    required: true
+"#,
+        base_fields, merge_arg
+    );
+
+    let rust = render(&yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub merged: Value,"));
+}
+
+#[test]
+fn dto_infers_object_projection_and_merge_shapes() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: base
+    value: { id: "u1", profile: { name: "Ada", age: 37 }, active: true }
+    required: true
+  - target: profile
+    expr: ["@out.base", { get: ["profile"] }]
+    required: true
+  - target: publicBase
+    expr: ["@out.base", { pick: ["id", "active"] }]
+    required: true
+  - target: publicProfile
+    expr: ["@out.base", { pick: ["profile.name"] }]
+    required: true
+  - target: withoutAge
+    expr: ["@out.base", { omit: ["profile.age"] }]
+    required: true
+  - target: merged
+    expr: ["@out.publicBase", { merge: [{ plan: "pro" }] }]
+    required: true
+"#;
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("profile: RecordProfile;"));
+    assert!(typescript.contains("name: string;"));
+    assert!(typescript.contains("age: number;"));
+    assert!(typescript.contains("publicBase: RecordPublicBase;"));
+    assert!(typescript.contains("id: string;"));
+    assert!(typescript.contains("active: boolean;"));
+    assert!(typescript.contains("publicProfile: RecordPublicProfile;"));
+    assert!(typescript.contains("profile: RecordPublicProfileProfile;"));
+    assert!(typescript.contains("interface RecordPublicProfileProfile"));
+    assert!(typescript.contains("merged: RecordMerged;"));
+    assert!(typescript.contains("plan: string;"));
+}
+
+#[test]
+fn dto_renders_json_wrappers_across_languages() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: items
+    expr: ["@input.obj", "values"]
+    required: true
+  - target: flat
+    expr: ["@input.obj", "object_flatten"]
+    required: true
+  - target: maybe
+    expr: ["@input.items", "first"]
+    required: true
+"#;
+
+    let go = render(yaml, DtoLanguage::Go);
+    assert!(go.contains("import \"encoding/json\""));
+    assert!(go.contains("Items []json.RawMessage"));
+    assert!(go.contains("Flat map[string]json.RawMessage"));
+    assert!(go.contains("Maybe *json.RawMessage"));
+
+    let java = render(yaml, DtoLanguage::Java);
+    assert!(java.contains("import com.fasterxml.jackson.databind.JsonNode;"));
+    assert!(java.contains("import java.util.List;"));
+    assert!(java.contains("import java.util.Map;"));
+    assert!(java.contains("import java.util.Optional;"));
+    assert!(java.contains("public List<JsonNode> items;"));
+    assert!(java.contains("public Map<String, JsonNode> flat;"));
+    assert!(java.contains("public Optional<JsonNode> maybe;"));
+
+    let kotlin = render(yaml, DtoLanguage::Kotlin);
+    assert!(kotlin.contains("import com.fasterxml.jackson.databind.JsonNode"));
+    assert!(kotlin.contains("val items: List<JsonNode>"));
+    assert!(kotlin.contains("val flat: Map<String, JsonNode>"));
+    assert!(kotlin.contains("val maybe: JsonNode?"));
+
+    let python = render(yaml, DtoLanguage::Python);
+    assert!(python.contains("from typing import Optional, Any"));
+    assert!(python.contains("items: list[Any]"));
+    assert!(python.contains("flat: dict[str, Any]"));
+    assert!(python.contains("maybe: Optional[Any]"));
+
+    let swift = render(yaml, DtoLanguage::Swift);
+    assert!(swift.contains("let items: [JSONValue]"));
+    assert!(swift.contains("let flat: [String: JSONValue]"));
+    assert!(swift.contains("let maybe: JSONValue?"));
+    assert!(swift.contains("enum JSONValue: Codable"));
+}

--- a/crates/rulemorph/tests/dto_inference.rs
+++ b/crates/rulemorph/tests/dto_inference.rs
@@ -46,6 +46,31 @@ mappings:
 }
 
 #[test]
+fn dto_infers_nullable_array_aggregates_and_fold_result() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: total
+    expr: ["@input.items", "sum"]
+    required: true
+  - target: folded
+    expr: ["@input.items", { fold: [0, ["@acc", "to_string"]] }]
+    required: true
+"#;
+
+    let rust = render(yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub total: Option<f64>,"));
+    assert!(rust.contains("pub folded: Value,"));
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("total: number | null;"));
+    assert!(typescript.contains("folded: unknown;"));
+}
+
+#[test]
 fn dto_infers_literal_object_arrays_and_maps() {
     let yaml = r#"
 version: 2
@@ -81,6 +106,75 @@ mappings:
     assert!(typescript.contains("parts: string[];"));
     assert!(typescript.contains("grouped: { [key: string]: unknown[] };"));
     assert!(!typescript.contains("Record<string,"));
+}
+
+#[test]
+fn dto_reuses_synthetic_parent_out_shapes() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: base.id
+    value: "u1"
+    required: true
+  - target: base.active
+    value: true
+    required: true
+  - target: copy
+    expr: ["@out.base"]
+    required: true
+"#;
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("base: RecordBase;"));
+    assert!(typescript.contains("copy: RecordCopy;"));
+    assert!(typescript.contains("interface RecordCopy"));
+    assert!(typescript.contains("id: string;"));
+    assert!(typescript.contains("active: boolean;"));
+}
+
+#[test]
+fn dto_python_container_annotations_are_future_safe() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: parts
+    expr: ["@input.csv", { split: [","] }]
+    required: true
+  - target: grouped
+    expr: ["@input.items", { group_by: ["@item.category"] }]
+    required: true
+"#;
+
+    let python = render(yaml, DtoLanguage::Python);
+    assert!(python.starts_with("from __future__ import annotations\n"));
+    assert!(python.contains("parts: list[str]"));
+    assert!(python.contains("grouped: dict[str, list[Any]]"));
+}
+
+#[test]
+fn dto_required_empty_object_does_not_emit_optional_imports() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: empty
+    value: {}
+    required: true
+"#;
+
+    let java = render(yaml, DtoLanguage::Java);
+    assert!(!java.contains("import java.util.Optional;"));
+
+    let python = render(yaml, DtoLanguage::Python);
+    assert!(!python.contains("Optional"));
 }
 
 #[test]
@@ -407,6 +501,8 @@ mappings:
 
     let kotlin = render(yaml, DtoLanguage::Kotlin);
     assert!(kotlin.contains("import com.fasterxml.jackson.databind.JsonNode"));
+    assert!(kotlin.contains("import kotlin.collections.List"));
+    assert!(kotlin.contains("import kotlin.collections.Map"));
     assert!(kotlin.contains("val items: List<JsonNode>"));
     assert!(kotlin.contains("val flat: Map<String, JsonNode>"));
     assert!(kotlin.contains("val maybe: JsonNode?"));

--- a/crates/rulemorph/tests/dto_security.rs
+++ b/crates/rulemorph/tests/dto_security.rs
@@ -45,3 +45,106 @@ fn dto_generation_sanitizes_type_name_and_escapes_json_keys() {
     assert!(go.contains(r#""json:\"bad\\\"key\"""#));
     assert!(go.contains(r#""json:\"tick`key\"""#));
 }
+
+#[test]
+fn dto_generation_sanitizes_inferred_structured_keys() {
+    let rule = parse_rule_file(
+        r#"version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: payload
+    value:
+      bad*/key:
+        quote"key: "x"
+        "slash\\key": "b"
+        "line\nkey": "y"
+      tick`key:
+        - class: true
+          "tab\tkey": "z"
+      items:
+        - id: "a"
+          "bad*/item": 1
+          "quote\"item": true
+          "slash\\item": false
+    required: true
+  - target: byKey
+    expr: ["@out.payload.items", { key_by: ["@item.id"] }]
+    required: true
+"#,
+    )
+    .expect("parse rule");
+
+    for language in [
+        DtoLanguage::Rust,
+        DtoLanguage::TypeScript,
+        DtoLanguage::Python,
+        DtoLanguage::Go,
+        DtoLanguage::Java,
+        DtoLanguage::Kotlin,
+        DtoLanguage::Swift,
+    ] {
+        let output = generate_dto(&rule, language, Some("Record { hacked"))
+            .expect("generate dto should not fail");
+        assert!(!output.contains("Record { hacked"));
+        assert!(!output.contains("bad*/key */"));
+        assert!(!output.contains("bad*/item */"));
+        assert!(!output.contains("quote\"key"));
+        assert!(!output.contains("slash\\key"));
+        assert!(!output.contains("line\nkey"));
+        assert!(!output.contains("tab\tkey"));
+    }
+
+    let rust =
+        generate_dto(&rule, DtoLanguage::Rust, Some("Record { hacked")).expect("generate rust dto");
+    assert!(rust.contains(r#"rename = "bad*/key""#));
+    assert!(rust.contains(r#"rename = "quote\"key""#));
+    assert!(rust.contains(r#"rename = "slash\\key""#));
+    assert!(rust.contains(r#"rename = "line\nkey""#));
+
+    let go =
+        generate_dto(&rule, DtoLanguage::Go, Some("Record { hacked")).expect("generate go dto");
+    assert!(go.contains(r#""json:\"tick`key\"""#));
+    assert!(go.contains(r#""json:\"quote\\\"key\"""#));
+    assert!(go.contains(r#""json:\"slash\\\\key\"""#));
+    assert!(go.contains(r#""json:\"line\\nkey\"""#));
+
+    let python =
+        generate_dto(&rule, DtoLanguage::Python, Some("Record")).expect("generate python dto");
+    assert!(python.contains(r#"# json: "bad* /key""#));
+    assert!(python.contains(r#"# json: "quote\"key""#));
+    assert!(python.contains(r#"# json: "slash\\key""#));
+    assert!(python.contains(r#"metadata={"json_key": "quote\"key"}"#));
+    assert!(python.contains(r#"metadata={"json_key": "slash\\key"}"#));
+    assert!(python.contains(r#"metadata={"json_key": "line\nkey"}"#));
+
+    let typescript = generate_dto(&rule, DtoLanguage::TypeScript, Some("Record"))
+        .expect("generate typescript dto");
+    assert!(typescript.contains(r#"json: "bad* /key""#));
+    assert!(typescript.contains(r#"json: "quote\"key""#));
+    assert!(typescript.contains(r#"json: "slash\\key""#));
+    assert!(typescript.contains(r#"json: "line\\nkey""#));
+    assert!(typescript.contains("{ [key: string]:"));
+    assert!(!typescript.contains("Record<string,"));
+
+    let java = generate_dto(&rule, DtoLanguage::Java, Some("Record")).expect("generate java dto");
+    assert!(java.contains(r#"@JsonProperty("bad*/key")"#));
+    assert!(java.contains(r#"@JsonProperty("quote\"key")"#));
+    assert!(java.contains(r#"@JsonProperty("slash\\key")"#));
+    assert!(java.contains(r#"@JsonProperty("line\nkey")"#));
+
+    let kotlin =
+        generate_dto(&rule, DtoLanguage::Kotlin, Some("Record")).expect("generate kotlin dto");
+    assert!(kotlin.contains(r#"@JsonProperty("bad*/key")"#));
+    assert!(kotlin.contains(r#"@JsonProperty("quote\"key")"#));
+    assert!(kotlin.contains(r#"@JsonProperty("slash\\key")"#));
+    assert!(kotlin.contains(r#"@JsonProperty("line\nkey")"#));
+
+    let swift =
+        generate_dto(&rule, DtoLanguage::Swift, Some("Record")).expect("generate swift dto");
+    assert!(swift.contains(r#"case badKey = "bad*/key""#));
+    assert!(swift.contains(r#"case quoteKey = "quote\"key""#));
+    assert!(swift.contains(r#"case slashKey = "slash\\key""#));
+    assert!(swift.contains(r#"line\nkey"#));
+}

--- a/crates/rulemorph/tests/feature_flags.rs
+++ b/crates/rulemorph/tests/feature_flags.rs
@@ -1,0 +1,60 @@
+#[cfg(not(feature = "html"))]
+#[test]
+fn html_input_returns_invalid_input_when_feature_is_disabled() {
+    let rule = rulemorph::parse_rule_file(
+        r#"
+version: 2
+input:
+  format: html
+  html:
+    records_selector: ".item"
+    fields:
+      id:
+        selector: ".id"
+mappings:
+  - target: "id"
+    source: "id"
+"#,
+    )
+    .expect("parse html rule");
+
+    let err = rulemorph::transform(
+        &rule,
+        r#"<div class="item"><span class="id">1</span></div>"#,
+        None,
+    )
+    .expect_err("html input should fail when html feature is disabled");
+
+    assert_eq!(err.kind, rulemorph::TransformErrorKind::InvalidInput);
+    assert_eq!(
+        err.message,
+        "input format html is not enabled in this build"
+    );
+}
+
+#[cfg(not(feature = "excel"))]
+#[test]
+fn excel_input_returns_invalid_input_when_feature_is_disabled() {
+    let rule = rulemorph::parse_rule_file(
+        r#"
+version: 2
+input:
+  format: excel
+  excel:
+    has_header: true
+mappings:
+  - target: "id"
+    source: "id"
+"#,
+    )
+    .expect("parse excel rule");
+
+    let err = rulemorph::transform_input(&rule, rulemorph::InputData::Bytes(b"not xlsx"), None)
+        .expect_err("excel input should fail when excel feature is disabled");
+
+    assert_eq!(err.kind, rulemorph::TransformErrorKind::InvalidInput);
+    assert_eq!(
+        err.message,
+        "input format excel is not enabled in this build"
+    );
+}

--- a/crates/rulemorph/tests/transform_golden.rs
+++ b/crates/rulemorph/tests/transform_golden.rs
@@ -1,16 +1,20 @@
 use std::fs;
 
+#[cfg(feature = "excel")]
+use rulemorph::preflight_validate_input;
 use rulemorph::{
     InputData, NormalizationOptions, RuleFormat, TransformErrorKind,
-    normalize_records_with_options, parse_rule_file, preflight_validate_input, transform,
-    transform_input,
+    normalize_records_with_options, parse_rule_file, transform, transform_input,
 };
 mod common;
 
+#[cfg(feature = "excel")]
+use common::golden::assert_xlsx_fixture;
 use common::golden::{
-    assert_json_fixture, assert_text_fixture, assert_transform_error_fixture, assert_xlsx_fixture,
-    fixtures_dir, load_json, load_optional_json, load_rule, load_rule_with_format,
+    assert_json_fixture, assert_text_fixture, assert_transform_error_fixture, fixtures_dir,
+    load_json, load_optional_json, load_rule, load_rule_with_format,
 };
+#[cfg(feature = "excel")]
 use common::xlsx::{
     XlsxFixtureOptions, build_dynamodb_users_xlsx, build_string_table_xlsx, build_test_xlsx,
 };
@@ -29,9 +33,11 @@ include!("transform_golden/input_limits.rs");
 
 include!("transform_golden/input_formats.rs");
 
+#[cfg(feature = "excel")]
 include!("transform_golden/excel.rs");
 
 include!("transform_golden/xml.rs");
+#[cfg(feature = "html")]
 include!("transform_golden/html.rs");
 
 include!("transform_golden/structured_inputs.rs");

--- a/crates/rulemorph/tests/transform_golden/input_formats.rs
+++ b/crates/rulemorph/tests/transform_golden/input_formats.rs
@@ -24,21 +24,25 @@ fn t33_xml_input_transform_golden() {
 }
 
 #[test]
+#[cfg(feature = "html")]
 fn t35_html_input_transform_golden() {
     assert_text_fixture("t35_html_input", "input.html");
 }
 
 #[test]
+#[cfg(feature = "excel")]
 fn t36_spreadsheets_plugin_products() {
     assert_xlsx_fixture("t36_spreadsheets_plugin_products");
 }
 
 #[test]
+#[cfg(feature = "excel")]
 fn t37_spreadsheets_plugin_orders() {
     assert_xlsx_fixture("t37_spreadsheets_plugin_orders");
 }
 
 #[test]
+#[cfg(feature = "excel")]
 fn t38_spreadsheets_plugin_survey() {
     assert_xlsx_fixture("t38_spreadsheets_plugin_survey");
 }

--- a/docs/rules_spec_ja.md
+++ b/docs/rules_spec_ja.md
@@ -109,6 +109,21 @@ mappings:
 - `steps`（任意）: 段階実行（`mappings` / `record_when` と併用不可）
 - `finalize`（任意）: 出力配列の最終加工（`mappings` / `steps` どちらでも利用可）
 
+### DTO 型推論
+
+`generate_dto` は `mapping.type` がある場合、その明示型を最優先します。
+`mapping.type` がない場合は、literal value、v2 pipe の終端 op、object/array 操作から
+`string` / `int` / `float` / `bool` / array / map / nested object を静的に推測します。
+推測できない dynamic reference、v1 expr、互換性のない union は各言語の JSON fallback 型
+（Rust `serde_json::Value`、TypeScript `unknown` など）として出力します。
+
+推論は untrusted rule input に対して bounded に実行されます。過度に深い object、巨大な array、
+大量 field、または生成 type 数の上限を超える shape は、狭い型にせず JSON fallback 型へ戻します。
+巨大な path や dynamic path を含む `get` / `pick` / `omit` も JSON fallback 型へ戻します。
+`default` / `coalesce` は dynamic/unknown input を具体型へ狭める根拠には使いません。
+
+`optional` は field が省略される可能性、`nullable` は field 値が `null` になり得る可能性を表します。
+
 ## Input
 
 `input` は raw input を Rulemorph の共通データモデルである JSON record 配列へ変換します。


### PR DESCRIPTION
## Summary
- Add bounded DTO type inference for literal values, scalar terminal ops, arrays, maps, nullable values, nested objects, object projection, and merge/deep_merge shapes.
- Extend DTO renderers across Rust, TypeScript, Python, Go, Java, Kotlin, and Swift for recursive structured types while avoiding TypeScript `Record<string, ...>` shadowing.
- Add security-focused fallback behavior for unknown/default narrowing, dynamic or huge paths, indexed `@out` refs, generated type budget, and structured key escaping.

## Validation
- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p rulemorph --test dto_inference`
- `cargo test -p rulemorph --test dto_security`
- `cargo test -p rulemorph --test dto_golden`
- `cargo test -p rulemorph`
- `cargo test`

## Security Review
- Codex Security sub-agent reviewed the updated diff and reported P1/P2なし.