### PR TITLE
Add inline rule stdin CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ mappings:
 rulemorph transform -r rules.yaml -i input.json
 ```
 
+You can also pipe input to `transform`:
+
+```sh
+cat input.json | rulemorph transform -r rules.yaml
+cat input.json | rulemorph transform -r rules.yaml -i -
+```
+
+For a quick one-off expression without a rule file, use direct mode:
+
+```sh
+echo '{ "test": 1 }' | rulemorph -rule '@input.test'
+echo '{ "a": 1, "b": 2 }' | rulemorph --rule '["@input.a", {"+": ["@input.b"]}]'
+```
+
 **Output**
 
 ```json

--- a/crates/rulemorph_cli/src/core_commands/transform.rs
+++ b/crates/rulemorph_cli/src/core_commands/transform.rs
@@ -10,8 +10,8 @@ use rulemorph::{
 
 use super::super::emit::{emit_transform_error, emit_transform_warnings, emit_validation_errors};
 use super::super::input::{
-    apply_format_override, load_context, load_input_bytes_with_limit, load_normalization_options,
-    load_rule, rule_base_dir,
+    apply_format_override, load_context, load_input_bytes_from_path_or_stdin,
+    load_normalization_options, load_rule, rule_base_dir,
 };
 use super::super::output::{
     create_output_writer, emit_text_output, serialize_json_output, write_json_line,
@@ -25,7 +25,7 @@ pub(crate) struct TransformArgs {
     #[arg(long)]
     rules_format: Option<RulesFormatArg>,
     #[arg(short = 'i', long)]
-    input: PathBuf,
+    input: Option<PathBuf>,
     #[arg(short = 'f', long)]
     format: Option<FormatOverride>,
     #[arg(short = 'c', long)]
@@ -76,10 +76,11 @@ pub(crate) fn run_transform(args: TransformArgs) -> i32 {
         }
     };
 
-    let input = match load_input_bytes_with_limit(&args.input, options.max_input_bytes) {
-        Ok(value) => value,
-        Err(code) => return code,
-    };
+    let input =
+        match load_input_bytes_from_path_or_stdin(args.input.as_ref(), options.max_input_bytes) {
+            Ok(value) => value,
+            Err(code) => return code,
+        };
 
     let context_value = match load_context(&args.context) {
         Ok(value) => value,

--- a/crates/rulemorph_cli/src/direct.rs
+++ b/crates/rulemorph_cli/src/direct.rs
@@ -1,0 +1,147 @@
+use std::path::{Path, PathBuf};
+
+use rulemorph::{
+    InputData, RuleFormat, parse_rule_file_with_format,
+    transform_input_with_warnings_with_base_dir_and_options,
+};
+
+use super::emit::{emit_transform_error, emit_transform_warnings};
+use super::input::{load_input_bytes_from_path_or_stdin, load_normalization_options};
+use super::output::{emit_text_output, serialize_json_output};
+use super::{ErrorFormat, FormatOverride, LimitsProfileArg};
+
+const DIRECT_VALUE_TARGET: &str = "__rulemorph_direct_value";
+
+pub(crate) struct DirectArgs {
+    pub(crate) rule: String,
+    pub(crate) input: Option<PathBuf>,
+    pub(crate) format: Option<FormatOverride>,
+    pub(crate) output: Option<PathBuf>,
+    pub(crate) error_format: Option<ErrorFormat>,
+    pub(crate) limits: Vec<String>,
+    pub(crate) limits_profile: Option<LimitsProfileArg>,
+    pub(crate) limits_file: Option<PathBuf>,
+}
+
+pub(crate) fn run(args: DirectArgs) -> i32 {
+    let options = match load_normalization_options(
+        args.limits_profile,
+        args.limits_file.as_ref(),
+        &args.limits,
+    ) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{}", message);
+            return 2;
+        }
+    };
+
+    let input =
+        match load_input_bytes_from_path_or_stdin(args.input.as_ref(), options.max_input_bytes) {
+            Ok(value) => value,
+            Err(code) => return code,
+        };
+    let unwrap_single_output = should_unwrap_single_output(&input, args.format);
+
+    let rule = match build_direct_rule(&args.rule, args.format) {
+        Ok(rule) => rule,
+        Err(message) => {
+            eprintln!("{}", message);
+            return 1;
+        }
+    };
+
+    let (output, warnings) = match transform_input_with_warnings_with_base_dir_and_options(
+        &rule,
+        InputData::Bytes(&input),
+        None,
+        Path::new("."),
+        &options,
+    ) {
+        Ok(result) => result,
+        Err(err) => {
+            emit_transform_error(&err, args.error_format.unwrap_or(ErrorFormat::Text));
+            return 3;
+        }
+    };
+
+    let output = unwrap_direct_output(output, unwrap_single_output);
+    let output_text = match serialize_json_output(&output) {
+        Ok(text) => text,
+        Err(()) => return 1,
+    };
+
+    emit_transform_warnings(&warnings, args.error_format.unwrap_or(ErrorFormat::Text));
+
+    if emit_text_output(&output_text, args.output.as_ref()).is_err() {
+        return 1;
+    }
+
+    0
+}
+
+fn build_direct_rule(
+    inline_rule: &str,
+    format: Option<FormatOverride>,
+) -> Result<rulemorph::RuleFile, String> {
+    let input_format = match format.unwrap_or(FormatOverride::Json) {
+        FormatOverride::Csv => "csv",
+        FormatOverride::Json => "json",
+    };
+    let expr = parse_inline_expr(inline_rule);
+    let rule_json = serde_json::json!({
+        "version": 2,
+        "input": {
+            "format": input_format,
+            input_format: {}
+        },
+        "mappings": [
+            {
+                "target": DIRECT_VALUE_TARGET,
+                "expr": expr
+            }
+        ]
+    });
+    let source = serde_json::to_string(&rule_json)
+        .map_err(|err| format!("failed to encode inline rule: {}", err))?;
+    parse_rule_file_with_format(&source, RuleFormat::Json)
+        .map_err(|err| format!("failed to parse inline rule: {}", err))
+}
+
+fn parse_inline_expr(inline_rule: &str) -> serde_json::Value {
+    serde_json::from_str(inline_rule)
+        .unwrap_or_else(|_| serde_json::Value::String(inline_rule.to_string()))
+}
+
+fn should_unwrap_single_output(input: &[u8], format: Option<FormatOverride>) -> bool {
+    match format.unwrap_or(FormatOverride::Json) {
+        FormatOverride::Csv => false,
+        FormatOverride::Json => serde_json::from_slice::<serde_json::Value>(input)
+            .map(|value| matches!(value, serde_json::Value::Object(_)))
+            .unwrap_or(false),
+    }
+}
+
+fn unwrap_direct_output(
+    output: serde_json::Value,
+    unwrap_single_output: bool,
+) -> serde_json::Value {
+    match output {
+        serde_json::Value::Array(records) if unwrap_single_output && records.len() == 1 => {
+            unwrap_direct_record(records.into_iter().next().unwrap())
+        }
+        serde_json::Value::Array(records) => {
+            serde_json::Value::Array(records.into_iter().map(unwrap_direct_record).collect())
+        }
+        value => value,
+    }
+}
+
+fn unwrap_direct_record(record: serde_json::Value) -> serde_json::Value {
+    match record {
+        serde_json::Value::Object(mut object) => object
+            .remove(DIRECT_VALUE_TARGET)
+            .unwrap_or(serde_json::Value::Null),
+        value => value,
+    }
+}

--- a/crates/rulemorph_cli/src/direct.rs
+++ b/crates/rulemorph_cli/src/direct.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use rulemorph::{
-    InputData, RuleFormat, parse_rule_file_with_format,
+    InputData, RuleFormat, parse_rule_file_with_format, serde_guard::parse_json_value_strict,
     transform_input_with_warnings_with_base_dir_and_options,
 };
 
@@ -88,7 +88,7 @@ fn build_direct_rule(
         FormatOverride::Csv => "csv",
         FormatOverride::Json => "json",
     };
-    let expr = parse_inline_expr(inline_rule);
+    let expr = parse_inline_expr(inline_rule)?;
     let rule_json = serde_json::json!({
         "version": 2,
         "input": {
@@ -108,18 +108,29 @@ fn build_direct_rule(
         .map_err(|err| format!("failed to parse inline rule: {}", err))
 }
 
-fn parse_inline_expr(inline_rule: &str) -> serde_json::Value {
-    serde_json::from_str(inline_rule)
-        .unwrap_or_else(|_| serde_json::Value::String(inline_rule.to_string()))
+fn parse_inline_expr(inline_rule: &str) -> Result<serde_json::Value, String> {
+    match parse_json_value_strict(inline_rule) {
+        Ok(value) => Ok(value),
+        Err(err) if serde_json::from_str::<serde_json::Value>(inline_rule).is_ok() => {
+            Err(format!("failed to parse inline JSON rule: {}", err))
+        }
+        Err(_) => Ok(serde_json::Value::String(inline_rule.to_string())),
+    }
 }
 
 fn should_unwrap_single_output(input: &[u8], format: Option<FormatOverride>) -> bool {
     match format.unwrap_or(FormatOverride::Json) {
         FormatOverride::Csv => false,
-        FormatOverride::Json => serde_json::from_slice::<serde_json::Value>(input)
+        FormatOverride::Json => std::str::from_utf8(strip_utf8_bom(input))
+            .ok()
+            .and_then(|text| parse_json_value_strict(text).ok())
             .map(|value| matches!(value, serde_json::Value::Object(_)))
             .unwrap_or(false),
     }
+}
+
+fn strip_utf8_bom(input: &[u8]) -> &[u8] {
+    input.strip_prefix(b"\xef\xbb\xbf").unwrap_or(input)
 }
 
 fn unwrap_direct_output(

--- a/crates/rulemorph_cli/src/input.rs
+++ b/crates/rulemorph_cli/src/input.rs
@@ -2,6 +2,8 @@ mod files;
 mod limits;
 mod rules;
 
-pub(super) use files::{load_context, load_input_bytes_with_limit};
+pub(super) use files::{
+    load_context, load_input_bytes_from_path_or_stdin, load_input_bytes_with_limit,
+};
 pub(super) use limits::load_normalization_options;
 pub(super) use rules::{apply_format_override, load_rule, rule_base_dir};

--- a/crates/rulemorph_cli/src/input/files.rs
+++ b/crates/rulemorph_cli/src/input/files.rs
@@ -1,6 +1,23 @@
 use std::fs;
-use std::io::Read;
-use std::path::PathBuf;
+use std::io::{IsTerminal, Read};
+use std::path::{Path, PathBuf};
+
+pub(crate) fn load_input_bytes_from_path_or_stdin(
+    path: Option<&PathBuf>,
+    max_input_bytes: usize,
+) -> Result<Vec<u8>, i32> {
+    match path {
+        Some(path) if path != Path::new("-") => load_input_bytes_with_limit(path, max_input_bytes),
+        Some(_) => load_stdin_bytes_with_limit(max_input_bytes),
+        None => {
+            if std::io::stdin().is_terminal() {
+                eprintln!("input file is required unless stdin is piped");
+                return Err(1);
+            }
+            load_stdin_bytes_with_limit(max_input_bytes)
+        }
+    }
+}
 
 pub(crate) fn load_input_bytes_with_limit(
     path: &PathBuf,
@@ -30,6 +47,28 @@ fn read_file_with_limit(path: &PathBuf, max_bytes: usize) -> Result<Vec<u8>, Str
         return Err(format!("input exceeds max_input_bytes ({})", max_bytes));
     }
     Ok(bytes)
+}
+
+fn load_stdin_bytes_with_limit(max_input_bytes: usize) -> Result<Vec<u8>, i32> {
+    let mut stdin = std::io::stdin().lock();
+    let mut bytes = Vec::new();
+    match Read::by_ref(&mut stdin)
+        .take(max_input_bytes as u64 + 1)
+        .read_to_end(&mut bytes)
+    {
+        Ok(_) if bytes.len() <= max_input_bytes => Ok(bytes),
+        Ok(_) => {
+            eprintln!(
+                "failed to read input: input exceeds max_input_bytes ({})",
+                max_input_bytes
+            );
+            Err(1)
+        }
+        Err(err) => {
+            eprintln!("failed to read input: {}", err);
+            Err(1)
+        }
+    }
 }
 
 pub(crate) fn load_context(path: &Option<PathBuf>) -> Result<Option<serde_json::Value>, i32> {

--- a/crates/rulemorph_cli/src/main.rs
+++ b/crates/rulemorph_cli/src/main.rs
@@ -1,8 +1,12 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 
 #[cfg(feature = "server")]
 mod api_keys;
 mod core_commands;
+mod direct;
 mod emit;
 mod generate;
 mod input;
@@ -14,8 +18,24 @@ mod server_commands;
 #[command(name = "rulemorph")]
 #[command(version, about = "Transform CSV/JSON data using YAML rules")]
 struct Cli {
+    #[arg(long = "rule")]
+    rule: Option<String>,
+    #[arg(short = 'i', long)]
+    input: Option<PathBuf>,
+    #[arg(short = 'f', long)]
+    format: Option<FormatOverride>,
+    #[arg(short = 'o', long)]
+    output: Option<PathBuf>,
+    #[arg(short = 'e', long)]
+    error_format: Option<ErrorFormat>,
+    #[arg(long = "limit")]
+    limits: Vec<String>,
+    #[arg(long, value_enum)]
+    limits_profile: Option<LimitsProfileArg>,
+    #[arg(long)]
+    limits_file: Option<PathBuf>,
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -59,20 +79,100 @@ enum LimitsProfileArg {
 }
 
 fn main() {
-    let cli = Cli::parse();
-    let exit_code = match cli.command {
-        Commands::Validate(args) => core_commands::run_validate(args),
+    let cli = Cli::parse_from(normalize_rule_alias(std::env::args_os()));
+    let Cli {
+        rule,
+        input,
+        format,
+        output,
+        error_format,
+        limits,
+        limits_profile,
+        limits_file,
+        command,
+    } = cli;
+
+    let exit_code = match (rule, command) {
+        (Some(rule), None) => direct::run(direct::DirectArgs {
+            rule,
+            input,
+            format,
+            output,
+            error_format,
+            limits,
+            limits_profile,
+            limits_file,
+        }),
+        (Some(_), Some(_)) => {
+            eprintln!("--rule cannot be used with a subcommand");
+            2
+        }
+        (None, Some(command))
+            if has_direct_options(
+                &input,
+                &format,
+                &output,
+                &error_format,
+                &limits,
+                &limits_profile,
+                &limits_file,
+            ) =>
+        {
+            eprintln!("direct-mode options require --rule and cannot be used before a subcommand");
+            let _ = command;
+            2
+        }
+        (None, Some(Commands::Validate(args))) => core_commands::run_validate(args),
         #[cfg(feature = "server")]
-        Commands::ValidateRulesDir(args) => server_commands::run_validate_rules_dir(args),
-        Commands::Preflight(args) => core_commands::run_preflight(args),
-        Commands::Transform(args) => core_commands::run_transform(args),
-        Commands::Generate(args) => generate::run(args),
+        (None, Some(Commands::ValidateRulesDir(args))) => {
+            server_commands::run_validate_rules_dir(args)
+        }
+        (None, Some(Commands::Preflight(args))) => core_commands::run_preflight(args),
+        (None, Some(Commands::Transform(args))) => core_commands::run_transform(args),
+        (None, Some(Commands::Generate(args))) => generate::run(args),
         #[cfg(feature = "server")]
-        Commands::Ui(args) => server_commands::run_ui(args),
+        (None, Some(Commands::Ui(args))) => server_commands::run_ui(args),
         #[cfg(feature = "server")]
-        Commands::PurgeTraces(args) => server_commands::run_purge_traces(args),
+        (None, Some(Commands::PurgeTraces(args))) => server_commands::run_purge_traces(args),
         #[cfg(feature = "server")]
-        Commands::ApiKeys(args) => api_keys::run(args),
+        (None, Some(Commands::ApiKeys(args))) => api_keys::run(args),
+        (None, None) => {
+            let _ = Cli::command().print_help();
+            eprintln!();
+            2
+        }
     };
     std::process::exit(exit_code);
+}
+
+fn normalize_rule_alias(args: impl IntoIterator<Item = OsString>) -> Vec<OsString> {
+    args.into_iter()
+        .map(|arg| {
+            if arg == "-rule" {
+                OsString::from("--rule")
+            } else if let Some(value) = arg.to_str().and_then(|text| text.strip_prefix("-rule=")) {
+                OsString::from(format!("--rule={}", value))
+            } else {
+                arg
+            }
+        })
+        .collect()
+}
+
+fn has_direct_options(
+    input: &Option<PathBuf>,
+    format: &Option<FormatOverride>,
+    output: &Option<PathBuf>,
+    error_format: &Option<ErrorFormat>,
+    limits: &[String],
+    limits_profile: &Option<LimitsProfileArg>,
+    limits_file: &Option<PathBuf>,
+) -> bool {
+    input.is_some()
+        || format.is_some()
+        || output.is_some()
+        || error_format.is_some()
+        || !limits.is_empty()
+        || limits_profile.is_some()
+        || limits_file.is_some()
 }

--- a/crates/rulemorph_cli/src/main.rs
+++ b/crates/rulemorph_cli/src/main.rs
@@ -146,9 +146,15 @@ fn main() {
 }
 
 fn normalize_rule_alias(args: impl IntoIterator<Item = OsString>) -> Vec<OsString> {
+    let mut after_options_marker = false;
     args.into_iter()
         .map(|arg| {
-            if arg == "-rule" {
+            if after_options_marker {
+                arg
+            } else if arg == "--" {
+                after_options_marker = true;
+                arg
+            } else if arg == "-rule" {
                 OsString::from("--rule")
             } else if let Some(value) = arg.to_str().and_then(|text| text.strip_prefix("-rule=")) {
                 OsString::from(format!("--rule={}", value))
@@ -175,4 +181,52 @@ fn has_direct_options(
         || !limits.is_empty()
         || limits_profile.is_some()
         || limits_file.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os_args(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn normalize_rule_alias_rewrites_before_options_marker() {
+        let args = normalize_rule_alias(os_args(&[
+            "rulemorph",
+            "-rule",
+            "@input.test",
+            "-rule=@input.id",
+        ]));
+
+        assert_eq!(
+            args,
+            os_args(&["rulemorph", "--rule", "@input.test", "--rule=@input.id",])
+        );
+    }
+
+    #[test]
+    fn normalize_rule_alias_preserves_args_after_options_marker() {
+        let args = normalize_rule_alias(os_args(&[
+            "rulemorph",
+            "--rule",
+            "@input.test",
+            "--",
+            "-rule",
+            "-rule=@input.id",
+        ]));
+
+        assert_eq!(
+            args,
+            os_args(&[
+                "rulemorph",
+                "--rule",
+                "@input.test",
+                "--",
+                "-rule",
+                "-rule=@input.id",
+            ])
+        );
+    }
 }

--- a/crates/rulemorph_cli/tests/cli.rs
+++ b/crates/rulemorph_cli/tests/cli.rs
@@ -18,6 +18,8 @@ include!("cli/preflight.rs");
 
 include!("cli/transform_command.rs");
 
+include!("cli/direct_rule.rs");
+
 include!("cli/context.rs");
 
 include!("cli/validate.rs");

--- a/crates/rulemorph_cli/tests/cli/direct_rule.rs
+++ b/crates/rulemorph_cli/tests/cli/direct_rule.rs
@@ -1,0 +1,82 @@
+#[test]
+fn direct_rule_reads_json_from_stdin() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-rule")
+            .arg("@input.test")
+            .write_stdin(r#"{ "test": 1 }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "1\n");
+}
+
+#[test]
+fn direct_rule_accepts_equals_alias() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-rule=@input.test")
+            .write_stdin(r#"{ "test": 1 }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "1\n");
+}
+
+#[test]
+fn direct_rule_preserves_singleton_json_array_shape() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.test")
+            .write_stdin(r#"[{ "test": 1 }]"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "[1]\n");
+}
+
+#[test]
+fn direct_rule_outputs_null_for_missing_object_value() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.missing")
+            .write_stdin(r#"{ "test": 1 }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "null\n");
+}
+
+#[test]
+fn direct_rule_outputs_null_items_for_missing_array_values() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.missing")
+            .write_stdin(r#"[{ "test": 1 }, { "test": 2 }]"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "[null,null]\n");
+}
+
+#[test]
+fn direct_rule_distinguishes_missing_from_empty_object() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule").arg("{}").write_stdin(r#"{ "test": 1 }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "{}\n");
+}
+
+#[test]
+fn direct_options_cannot_be_ignored_before_subcommand() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-i")
+            .arg("input.json")
+            .arg("transform")
+            .arg("-r")
+            .arg("rules.yaml");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("direct-mode options require --rule"));
+}

--- a/crates/rulemorph_cli/tests/cli/direct_rule.rs
+++ b/crates/rulemorph_cli/tests/cli/direct_rule.rs
@@ -68,6 +68,30 @@ fn direct_rule_distinguishes_missing_from_empty_object() {
 }
 
 #[test]
+fn direct_rule_rejects_duplicate_keys_in_inline_json() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg(r#"{ "a": 1, "a": 2 }"#)
+            .write_stdin(r#"{ "test": 1 }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr_string(output).contains("duplicate key"));
+}
+
+#[test]
+fn direct_rule_unwraps_bom_prefixed_json_object() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.test")
+            .write_stdin(Vec::from(b"\xef\xbb\xbf{ \"test\": 1 }".as_slice()));
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "1\n");
+}
+
+#[test]
 fn direct_options_cannot_be_ignored_before_subcommand() {
     let output = rulemorph_output(|cmd| {
         cmd.arg("-i")

--- a/crates/rulemorph_cli/tests/cli/transform_command/output.rs
+++ b/crates/rulemorph_cli/tests/cli/transform_command/output.rs
@@ -21,6 +21,50 @@ fn transform_outputs_json() {
 }
 
 #[test]
+fn transform_reads_input_from_stdin_when_input_path_is_omitted() {
+    let base = fixtures_dir().join("t03_json_out_context");
+    let rules = base.join("rules.yaml");
+    let context = base.join("context.json");
+    let input = fs::read_to_string(base.join("input.json")).unwrap();
+    let expected = read_json(&base.join("expected.json"));
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("transform")
+            .arg("-r")
+            .arg(rules)
+            .arg("-c")
+            .arg(context)
+            .write_stdin(input);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_json_stdout_eq(output, &expected);
+}
+
+#[test]
+fn transform_reads_input_from_stdin_when_input_path_is_dash() {
+    let base = fixtures_dir().join("t03_json_out_context");
+    let rules = base.join("rules.yaml");
+    let context = base.join("context.json");
+    let input = fs::read_to_string(base.join("input.json")).unwrap();
+    let expected = read_json(&base.join("expected.json"));
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("transform")
+            .arg("-r")
+            .arg(rules)
+            .arg("-i")
+            .arg("-")
+            .arg("-c")
+            .arg(context)
+            .write_stdin(input);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_json_stdout_eq(output, &expected);
+}
+
+#[test]
 fn transform_accepts_json_rule_file_by_extension() {
     let base = fixtures_dir().join("t30_json_rule_file");
     let expected = read_json(&base.join("expected.json"));

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 | --- | --- |
 | 変換ルールの基本構造を理解する | [変換ルール仕様](rules_spec_ja.md) |
 | `source` / `expr` / `when` / `steps` の挙動を確認する | [変換ルール仕様](rules_spec_ja.md) |
+| CLI の stdin 入力、direct mode、resource limit を確認する | [変換ルール仕様: CLI input](rules_spec_ja.md#cli-input) / [Resource limits](rules_spec_ja.md#resource-limits) |
 | 関数OPや数値OPなどのOP一覧と書き方を確認する | [変換ルール仕様: defs](rules_spec_ja.md#defs関数op) / [オペレーション一覧](rules_spec_ja.md#オペレーション一覧v2) |
 | DTO 型推論の対象と fallback を確認する | [変換ルール仕様: DTO 型推論](rules_spec_ja.md#dto-型推論) |
 | 入力形式ごとの正規化ルールを確認する | [変換ルール仕様: Input](rules_spec_ja.md#input) |

--- a/docs/rules_spec_en.md
+++ b/docs/rules_spec_en.md
@@ -521,6 +521,32 @@ input:
 - CLI `transform --ndjson` outputs one JSON object per line (streaming)
 - If `records_path` points to an object, a single record is produced
 
+## CLI input
+
+`rulemorph transform` accepts an input file with `-i/--input`. If `-i` is omitted and stdin is piped, stdin is used as the input. Use `-i -` to request stdin explicitly.
+
+```sh
+rulemorph transform -r rules.yaml -i input.json
+cat input.json | rulemorph transform -r rules.yaml
+cat input.json | rulemorph transform -r rules.yaml -i -
+```
+
+For a one-off expression without a rule file, use direct mode. The canonical option is `--rule`; the jq-like `-rule` and `-rule=...` aliases are also accepted.
+
+```sh
+echo '{ "test": 1 }' | rulemorph --rule '@input.test'
+echo '{ "test": 1 }' | rulemorph -rule '@input.test'
+echo '{ "test": 1 }' | rulemorph -rule=@input.test
+```
+
+Direct mode uses the normal v2 `expr` syntax. Use a pipe array when chaining operators.
+
+```sh
+echo '{ "a": 1, "b": 2 }' | rulemorph --rule '["@input.a", {"+": ["@input.b"]}]'
+```
+
+Direct mode defaults to JSON input. Pass `-f csv` for CSV input. `--limit`, `--limits-profile`, and `--limits-file` apply the same resource limits as `transform`. `--rule` cannot be used with a subcommand, and direct-mode top-level options placed before a subcommand are rejected.
+
 ## Resource limits
 
 The CLI can relax finite resource limits for large local inputs:

--- a/docs/rules_spec_ja.md
+++ b/docs/rules_spec_ja.md
@@ -525,6 +525,32 @@ input:
 - CLI `transform --ndjson` は 1 行 1 JSON（ストリーミング）
 - `records_path` がオブジェクトを指す場合は単一レコード
 
+## CLI input
+
+`rulemorph transform` は `-i/--input` で入力ファイルを指定します。`-i` を省略して stdin が pipe されている場合、stdin を入力として読み込みます。明示的に stdin を使う場合は `-i -` を指定します。
+
+```sh
+rulemorph transform -r rules.yaml -i input.json
+cat input.json | rulemorph transform -r rules.yaml
+cat input.json | rulemorph transform -r rules.yaml -i -
+```
+
+rule file を作らずに 1 つの式だけを試す場合は direct mode を使えます。標準形は `--rule` です。jq 風の短縮形として `-rule` と `-rule=...` も受け付けます。
+
+```sh
+echo '{ "test": 1 }' | rulemorph --rule '@input.test'
+echo '{ "test": 1 }' | rulemorph -rule '@input.test'
+echo '{ "test": 1 }' | rulemorph -rule=@input.test
+```
+
+direct mode は通常の v2 `expr` 構文を使います。operator を連結する場合は pipe 配列で書きます。
+
+```sh
+echo '{ "a": 1, "b": 2 }' | rulemorph --rule '["@input.a", {"+": ["@input.b"]}]'
+```
+
+direct mode は既定で JSON 入力として扱います。CSV 入力では `-f csv` を指定します。`--limit` / `--limits-profile` / `--limits-file` は `transform` と同じ resource limit として適用されます。`--rule` は subcommand と同時には使えず、direct mode 用の top-level option を subcommand 前に置くとエラーになります。
+
 ## Resource limits
 
 CLI は大きなローカル入力向けに有限の resource limit を緩和できます。


### PR DESCRIPTION
## Summary

- Add direct CLI mode for one-off expressions with `--rule`, `-rule`, and `-rule=...`
- Allow `rulemorph transform -r rules.yaml` and `-i -` to read input from stdin
- Document stdin/direct mode usage in README and rule specs

## Tests

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p rulemorph_cli`
- `cargo test -p rulemorph_cli --all-features`
- `cargo test`
- Codex Security review: no reportable findings

## Docs

- Updated `README.md`
- Updated `docs/README.md`
- Updated `docs/rules_spec_ja.md`
- Updated `docs/rules_spec_en.md`
