### PR TITLE
Add direct tabular input support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "clap",
+ "csv",
  "predicates",
  "rulemorph",
  "rulemorph_server",

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ For a quick one-off expression without a rule file, use direct mode:
 ```sh
 echo '{ "test": 1 }' | rulemorph -rule '@input.test'
 echo '{ "a": 1, "b": 2 }' | rulemorph --rule '["@input.a", {"+": ["@input.b"]}]'
+echo 'a,test,1' | rulemorph -rule '@input.0'
+echo 'a,test,1' | rulemorph -H 'id,name,age' -rule '@input.id'
+echo 'u1,Alice,42' | rulemorph -H 'id,name,age' -F id='@input.id' -F age='["@input.age","int"]'
+echo 'u1,Alice,42' | rulemorph -H 'id,name,age' --output-map '{"user.id":"@input.id","age":["@input.age","int"]}'
+rulemorph -rule '@input.id' -i users.xlsx --excel-header-row 1 --excel-data-range A2:D2
 ```
 
 **Output**

--- a/crates/rulemorph_cli/Cargo.toml
+++ b/crates/rulemorph_cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+csv = "1.3"
 serde_json = "1.0"
 toml = "0.8"
 rulemorph = { path = "../rulemorph" }

--- a/crates/rulemorph_cli/src/direct.rs
+++ b/crates/rulemorph_cli/src/direct.rs
@@ -1,26 +1,45 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use csv::ReaderBuilder;
 use rulemorph::{
-    InputData, RuleFormat, parse_rule_file_with_format, serde_guard::parse_json_value_strict,
+    InputData, RuleFormat, parse_rule_file_with_format,
     transform_input_with_warnings_with_base_dir_and_options,
 };
 
 use super::emit::{emit_transform_error, emit_transform_warnings};
-use super::input::{load_input_bytes_from_path_or_stdin, load_normalization_options};
+use super::input::{load_context, load_input_bytes_from_path_or_stdin, load_normalization_options};
 use super::output::{emit_text_output, serialize_json_output};
-use super::{ErrorFormat, FormatOverride, LimitsProfileArg};
+use super::{DirectFormatArg, ErrorFormat, LimitsProfileArg};
+
+mod output_spec;
+
+use output_spec::{
+    DirectOutputMode, DirectOutputSpec, expr_has_evaluated_root_ref, parse_direct_output_spec,
+};
 
 const DIRECT_VALUE_TARGET: &str = "__rulemorph_direct_value";
+const MAX_DIRECT_TABULAR_FIELDS: usize = 10_000;
+const MAX_DIRECT_TABULAR_HEADER_BYTES: usize = 256 * 1024;
+const MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL: usize = 8 * 1024 * 1024;
 
 pub(crate) struct DirectArgs {
-    pub(crate) rule: String,
+    pub(crate) rule: Option<String>,
+    pub(crate) fields: Vec<String>,
+    pub(crate) output_map: Option<String>,
     pub(crate) input: Option<PathBuf>,
-    pub(crate) format: Option<FormatOverride>,
+    pub(crate) format: Option<DirectFormatArg>,
+    pub(crate) headers: Option<String>,
+    pub(crate) excel_data_range: Option<String>,
+    pub(crate) excel_header_row: Option<usize>,
+    pub(crate) excel_sheet: Option<String>,
+    pub(crate) excel_sheet_index: Option<usize>,
     pub(crate) output: Option<PathBuf>,
     pub(crate) error_format: Option<ErrorFormat>,
     pub(crate) limits: Vec<String>,
     pub(crate) limits_profile: Option<LimitsProfileArg>,
     pub(crate) limits_file: Option<PathBuf>,
+    pub(crate) context: Option<PathBuf>,
 }
 
 pub(crate) fn run(args: DirectArgs) -> i32 {
@@ -41,9 +60,31 @@ pub(crate) fn run(args: DirectArgs) -> i32 {
             Ok(value) => value,
             Err(code) => return code,
         };
-    let unwrap_single_output = should_unwrap_single_output(&input, args.format);
 
-    let rule = match build_direct_rule(&args.rule, args.format) {
+    let input_format = resolve_direct_input_format(args.format, args.input.as_ref(), &input);
+    if let Err(message) = validate_direct_options(&args, input_format) {
+        eprintln!("{}", message);
+        return 2;
+    }
+
+    let output_cell_record_budget =
+        output_cell_record_budget(input_format, &input, options.max_records);
+    let output_spec = match parse_direct_output_spec(&args, &options, output_cell_record_budget) {
+        Ok(output_spec) => output_spec,
+        Err(err) => {
+            eprintln!("{}", err.message);
+            return err.exit_code;
+        }
+    };
+    let input_config = match build_direct_input_config(&args, input_format, &input, &output_spec) {
+        Ok(config) => config,
+        Err(message) => {
+            eprintln!("{}", message);
+            return 2;
+        }
+    };
+
+    let rule = match build_direct_rule(&output_spec, input_format, input_config.rule_config) {
         Ok(rule) => rule,
         Err(message) => {
             eprintln!("{}", message);
@@ -51,10 +92,15 @@ pub(crate) fn run(args: DirectArgs) -> i32 {
         }
     };
 
+    let context = match load_context(&args.context) {
+        Ok(context) => context,
+        Err(code) => return code,
+    };
+
     let (output, warnings) = match transform_input_with_warnings_with_base_dir_and_options(
         &rule,
         InputData::Bytes(&input),
-        None,
+        context.as_ref(),
         Path::new("."),
         &options,
     ) {
@@ -65,7 +111,11 @@ pub(crate) fn run(args: DirectArgs) -> i32 {
         }
     };
 
-    let output = unwrap_direct_output(output, unwrap_single_output);
+    let output = unwrap_direct_output(
+        output,
+        output_spec.output_mode(),
+        input_config.unwrap_single_output,
+    );
     let output_text = match serialize_json_output(&output) {
         Ok(text) => text,
         Err(()) => return 1,
@@ -80,27 +130,53 @@ pub(crate) fn run(args: DirectArgs) -> i32 {
     0
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DirectInputFormat {
+    Csv,
+    Json,
+    Excel,
+}
+
+struct DirectInputConfig {
+    rule_config: serde_json::Value,
+    unwrap_single_output: bool,
+}
+
 fn build_direct_rule(
-    inline_rule: &str,
-    format: Option<FormatOverride>,
+    output_spec: &DirectOutputSpec,
+    input_format: DirectInputFormat,
+    input_config: serde_json::Value,
 ) -> Result<rulemorph::RuleFile, String> {
-    let input_format = match format.unwrap_or(FormatOverride::Json) {
-        FormatOverride::Csv => "csv",
-        FormatOverride::Json => "json",
+    let input_format_name = match input_format {
+        DirectInputFormat::Csv => "csv",
+        DirectInputFormat::Json => "json",
+        DirectInputFormat::Excel => "excel",
     };
-    let expr = parse_inline_expr(inline_rule)?;
+    let mut input = serde_json::Map::new();
+    input.insert(
+        "format".to_string(),
+        serde_json::Value::String(input_format_name.to_string()),
+    );
+    input.insert(input_format_name.to_string(), input_config);
+    let mappings = match output_spec {
+        DirectOutputSpec::Rule(expr) => vec![serde_json::json!({
+            "target": DIRECT_VALUE_TARGET,
+            "expr": expr.clone()
+        })],
+        DirectOutputSpec::Fields(fields) | DirectOutputSpec::OutputMap(fields) => fields
+            .iter()
+            .map(|field| {
+                serde_json::json!({
+                    "target": field.target,
+                    "expr": field.expr
+                })
+            })
+            .collect(),
+    };
     let rule_json = serde_json::json!({
         "version": 2,
-        "input": {
-            "format": input_format,
-            input_format: {}
-        },
-        "mappings": [
-            {
-                "target": DIRECT_VALUE_TARGET,
-                "expr": expr
-            }
-        ]
+        "input": serde_json::Value::Object(input),
+        "mappings": mappings
     });
     let source = serde_json::to_string(&rule_json)
         .map_err(|err| format!("failed to encode inline rule: {}", err))?;
@@ -108,25 +184,361 @@ fn build_direct_rule(
         .map_err(|err| format!("failed to parse inline rule: {}", err))
 }
 
-fn parse_inline_expr(inline_rule: &str) -> Result<serde_json::Value, String> {
-    match parse_json_value_strict(inline_rule) {
-        Ok(value) => Ok(value),
-        Err(err) if serde_json::from_str::<serde_json::Value>(inline_rule).is_ok() => {
-            Err(format!("failed to parse inline JSON rule: {}", err))
+fn resolve_direct_input_format(
+    override_format: Option<DirectFormatArg>,
+    input_path: Option<&PathBuf>,
+    input: &[u8],
+) -> DirectInputFormat {
+    if let Some(format) = override_format {
+        return match format {
+            DirectFormatArg::Csv => DirectInputFormat::Csv,
+            DirectFormatArg::Json => DirectInputFormat::Json,
+            DirectFormatArg::Excel => DirectInputFormat::Excel,
+        };
+    }
+
+    if let Some(path) = input_path {
+        if path == Path::new("-") {
+            return detect_stdin_format(input);
         }
-        Err(_) => Ok(serde_json::Value::String(inline_rule.to_string())),
+
+        return match path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("csv") => DirectInputFormat::Csv,
+            Some("xlsx") => DirectInputFormat::Excel,
+            Some("json") => DirectInputFormat::Json,
+            _ => DirectInputFormat::Json,
+        };
+    }
+
+    detect_stdin_format(input)
+}
+
+fn detect_stdin_format(input: &[u8]) -> DirectInputFormat {
+    match first_meaningful_byte(input) {
+        Some(b'{') | Some(b'[') => DirectInputFormat::Json,
+        _ => DirectInputFormat::Csv,
     }
 }
 
-fn should_unwrap_single_output(input: &[u8], format: Option<FormatOverride>) -> bool {
-    match format.unwrap_or(FormatOverride::Json) {
-        FormatOverride::Csv => false,
-        FormatOverride::Json => std::str::from_utf8(strip_utf8_bom(input))
-            .ok()
-            .and_then(|text| parse_json_value_strict(text).ok())
-            .map(|value| matches!(value, serde_json::Value::Object(_)))
-            .unwrap_or(false),
+fn output_cell_record_budget(
+    input_format: DirectInputFormat,
+    input: &[u8],
+    max_records: usize,
+) -> usize {
+    match input_format {
+        DirectInputFormat::Json if matches!(first_meaningful_byte(input), Some(b'{')) => 1,
+        _ => max_records,
     }
+}
+
+fn validate_direct_options(
+    args: &DirectArgs,
+    input_format: DirectInputFormat,
+) -> Result<(), String> {
+    if args.headers.is_some() && input_format != DirectInputFormat::Csv {
+        return Err("--headers requires CSV direct input; pass -f csv when the input should be parsed as CSV".to_string());
+    }
+    if has_excel_options(args) && input_format != DirectInputFormat::Excel {
+        return Err("--excel-* options require Excel direct input; pass -f excel or use an .xlsx input file".to_string());
+    }
+    if args.excel_sheet.is_some() && args.excel_sheet_index.is_some() {
+        return Err("--excel-sheet and --excel-sheet-index cannot be used together".to_string());
+    }
+    Ok(())
+}
+
+fn has_excel_options(args: &DirectArgs) -> bool {
+    args.excel_data_range.is_some()
+        || args.excel_header_row.is_some()
+        || args.excel_sheet.is_some()
+        || args.excel_sheet_index.is_some()
+}
+
+fn build_direct_input_config(
+    args: &DirectArgs,
+    input_format: DirectInputFormat,
+    input: &[u8],
+    output_spec: &DirectOutputSpec,
+) -> Result<DirectInputConfig, String> {
+    match input_format {
+        DirectInputFormat::Json => Ok(DirectInputConfig {
+            rule_config: serde_json::json!({}),
+            unwrap_single_output: matches!(first_meaningful_byte(input), Some(b'{')),
+        }),
+        DirectInputFormat::Csv => Ok(DirectInputConfig {
+            rule_config: build_csv_config(args, input, output_spec)?,
+            unwrap_single_output: should_unwrap_tabular_output(args, input_format),
+        }),
+        DirectInputFormat::Excel => Ok(DirectInputConfig {
+            rule_config: build_excel_config(args)?,
+            unwrap_single_output: should_unwrap_tabular_output(args, input_format),
+        }),
+    }
+}
+
+fn should_unwrap_tabular_output(args: &DirectArgs, input_format: DirectInputFormat) -> bool {
+    args.format.is_none()
+        || args.headers.is_some()
+        || has_excel_options(args)
+        || matches!(
+            (args.format, input_format),
+            (Some(DirectFormatArg::Excel), DirectInputFormat::Excel)
+        )
+}
+
+fn build_csv_config(
+    args: &DirectArgs,
+    input: &[u8],
+    output_spec: &DirectOutputSpec,
+) -> Result<serde_json::Value, String> {
+    if let Some(headers) = args.headers.as_deref() {
+        return csv_config_from_headers_arg(headers);
+    }
+    if output_spec
+        .exprs()
+        .iter()
+        .any(|expr| expr_uses_root_numeric_input_ref(expr))
+    {
+        return csv_config_from_first_record(input);
+    }
+    Ok(serde_json::json!({
+        "has_header": true
+    }))
+}
+
+fn csv_config_from_headers_arg(headers: &str) -> Result<serde_json::Value, String> {
+    if headers.len() > MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL {
+        return Err(format!(
+            "--headers total size must be at most {} bytes",
+            MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL
+        ));
+    }
+
+    let mut reader = ReaderBuilder::new()
+        .has_headers(false)
+        .from_reader(headers.as_bytes());
+    let mut records = reader.records();
+    let record = match records.next() {
+        Some(Ok(record)) => record,
+        Some(Err(err)) => return Err(format!("failed to parse --headers as CSV: {}", err)),
+        None => return Err("--headers must contain at least one field".to_string()),
+    };
+    if let Some(result) = records.next() {
+        return match result {
+            Ok(_) => Err("--headers must contain exactly one CSV record".to_string()),
+            Err(err) => Err(format!("failed to parse --headers as CSV: {}", err)),
+        };
+    }
+    let field_names = record.iter().map(str::to_string).collect::<Vec<_>>();
+    csv_config_from_field_names(field_names, "--headers")
+}
+
+fn csv_config_from_first_record(input: &[u8]) -> Result<serde_json::Value, String> {
+    let mut reader = ReaderBuilder::new().has_headers(false).from_reader(input);
+    let mut records = reader.records();
+    let record = match records.next() {
+        Some(Ok(record)) => record,
+        Some(Err(err)) => return Err(format!("failed to infer CSV columns: {}", err)),
+        None => return Err("failed to infer CSV columns: input has no records".to_string()),
+    };
+    if record.is_empty() {
+        return Err("failed to infer CSV columns: first record has no fields".to_string());
+    }
+    let field_names = (0..record.len())
+        .map(|index| index.to_string())
+        .collect::<Vec<_>>();
+    csv_config_from_field_names(field_names, "inferred CSV columns")
+}
+
+fn csv_config_from_field_names(
+    field_names: Vec<String>,
+    source_label: &str,
+) -> Result<serde_json::Value, String> {
+    validate_tabular_field_names(&field_names, source_label)?;
+    let columns = field_names
+        .into_iter()
+        .map(|name| serde_json::json!({ "name": name }))
+        .collect::<Vec<_>>();
+    Ok(serde_json::json!({
+        "has_header": false,
+        "columns": columns
+    }))
+}
+
+fn validate_tabular_field_names(field_names: &[String], source_label: &str) -> Result<(), String> {
+    if field_names.len() > MAX_DIRECT_TABULAR_FIELDS {
+        return Err(format!(
+            "{} has too many fields; maximum is {}",
+            source_label, MAX_DIRECT_TABULAR_FIELDS
+        ));
+    }
+
+    let mut seen = HashSet::new();
+    let mut total_bytes = 0usize;
+    for field_name in field_names {
+        if field_name.trim().is_empty() {
+            return Err(format!(
+                "{} must not contain blank field names",
+                source_label
+            ));
+        }
+        let field_bytes = field_name.len();
+        if field_bytes > MAX_DIRECT_TABULAR_HEADER_BYTES {
+            return Err(format!(
+                "{} field names must be at most {} bytes each",
+                source_label, MAX_DIRECT_TABULAR_HEADER_BYTES
+            ));
+        }
+        total_bytes = total_bytes
+            .checked_add(field_bytes)
+            .ok_or_else(|| format!("{} total size is too large", source_label))?;
+        if total_bytes > MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL {
+            return Err(format!(
+                "{} total size must be at most {} bytes",
+                source_label, MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL
+            ));
+        }
+        if !seen.insert(field_name.clone()) {
+            return Err(format!("{} must be unique", source_label));
+        }
+    }
+    Ok(())
+}
+
+fn expr_uses_root_numeric_input_ref(expr: &serde_json::Value) -> bool {
+    expr_has_evaluated_root_ref(expr, "input")
+}
+
+fn build_excel_config(args: &DirectArgs) -> Result<serde_json::Value, String> {
+    let header_row = args
+        .excel_header_row
+        .ok_or_else(|| "--excel-header-row is required for Excel direct input".to_string())?;
+    if header_row == 0 {
+        return Err("--excel-header-row must be 1-based".to_string());
+    }
+    let data_range = args
+        .excel_data_range
+        .as_deref()
+        .ok_or_else(|| "--excel-data-range is required for Excel direct input".to_string())?;
+    let data_range = parse_excel_data_range(data_range)?;
+    if header_row >= data_range.start_row {
+        return Err("--excel-data-range is the data range and must start after --excel-header-row; use A2:C100 when --excel-header-row is 1".to_string());
+    }
+
+    let core_range = format!(
+        "{}{}:{}{}",
+        data_range.start_col, header_row, data_range.end_col, data_range.end_row
+    );
+    let mut excel = serde_json::Map::new();
+    excel.insert("has_header".to_string(), serde_json::Value::Bool(true));
+    excel.insert(
+        "header_row".to_string(),
+        serde_json::Value::Number(header_row.into()),
+    );
+    excel.insert(
+        "data_start_row".to_string(),
+        serde_json::Value::Number(data_range.start_row.into()),
+    );
+    excel.insert("range".to_string(), serde_json::Value::String(core_range));
+    if let Some(sheet) = args.excel_sheet.as_deref() {
+        excel.insert(
+            "sheet".to_string(),
+            serde_json::Value::String(sheet.to_string()),
+        );
+    }
+    if let Some(sheet_index) = args.excel_sheet_index {
+        excel.insert(
+            "sheet".to_string(),
+            serde_json::Value::Number(sheet_index.into()),
+        );
+    }
+    Ok(serde_json::Value::Object(excel))
+}
+
+struct ParsedExcelDataRange {
+    start_col: String,
+    start_row: usize,
+    end_col: String,
+    end_row: usize,
+}
+
+fn parse_excel_data_range(value: &str) -> Result<ParsedExcelDataRange, String> {
+    let (start, end) = value
+        .split_once(':')
+        .ok_or_else(|| "--excel-data-range must use A2:D10 form".to_string())?;
+    let (start_col, start_col_index, start_row) =
+        parse_excel_cell_ref(start, "--excel-data-range")?;
+    let (end_col, end_col_index, end_row) = parse_excel_cell_ref(end, "--excel-data-range")?;
+    if start_col_index > end_col_index {
+        return Err("--excel-data-range start column is after end column".to_string());
+    }
+    if start_row > end_row {
+        return Err("--excel-data-range start row is after end row".to_string());
+    }
+    Ok(ParsedExcelDataRange {
+        start_col,
+        start_row,
+        end_col,
+        end_row,
+    })
+}
+
+fn parse_excel_cell_ref(value: &str, label: &str) -> Result<(String, usize, usize), String> {
+    let mut letters = String::new();
+    let mut digits = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphabetic() && digits.is_empty() {
+            letters.push(ch.to_ascii_uppercase());
+        } else if ch.is_ascii_digit() {
+            digits.push(ch);
+        } else {
+            return Err(format!("{} contains an invalid cell reference", label));
+        }
+    }
+    if letters.is_empty() || digits.is_empty() {
+        return Err(format!(
+            "{} must include column letters and row numbers",
+            label
+        ));
+    }
+    let column_index = excel_column_letters_to_index(&letters, label)?;
+    let row = digits
+        .parse::<usize>()
+        .map_err(|_| format!("{} row is invalid", label))?;
+    if row == 0 {
+        return Err(format!("{} row must be 1-based", label));
+    }
+    Ok((letters, column_index, row))
+}
+
+fn excel_column_letters_to_index(value: &str, label: &str) -> Result<usize, String> {
+    let mut index = 0usize;
+    for ch in value.chars() {
+        if !ch.is_ascii_alphabetic() {
+            return Err(format!("{} column is invalid", label));
+        }
+        let value = (ch.to_ascii_uppercase() as u8 - b'A' + 1) as usize;
+        index = index
+            .checked_mul(26)
+            .and_then(|index| index.checked_add(value))
+            .ok_or_else(|| format!("{} column is too large", label))?;
+    }
+    if index == 0 {
+        return Err(format!("{} column is required", label));
+    }
+    Ok(index)
+}
+
+fn first_meaningful_byte(input: &[u8]) -> Option<u8> {
+    strip_utf8_bom(input)
+        .iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
 }
 
 fn strip_utf8_bom(input: &[u8]) -> &[u8] {
@@ -135,24 +547,34 @@ fn strip_utf8_bom(input: &[u8]) -> &[u8] {
 
 fn unwrap_direct_output(
     output: serde_json::Value,
+    output_mode: DirectOutputMode,
     unwrap_single_output: bool,
 ) -> serde_json::Value {
     match output {
         serde_json::Value::Array(records) if unwrap_single_output && records.len() == 1 => {
-            unwrap_direct_record(records.into_iter().next().unwrap())
+            unwrap_direct_record(records.into_iter().next().unwrap(), output_mode)
         }
-        serde_json::Value::Array(records) => {
-            serde_json::Value::Array(records.into_iter().map(unwrap_direct_record).collect())
-        }
+        serde_json::Value::Array(records) => serde_json::Value::Array(
+            records
+                .into_iter()
+                .map(|record| unwrap_direct_record(record, output_mode))
+                .collect(),
+        ),
         value => value,
     }
 }
 
-fn unwrap_direct_record(record: serde_json::Value) -> serde_json::Value {
-    match record {
-        serde_json::Value::Object(mut object) => object
-            .remove(DIRECT_VALUE_TARGET)
-            .unwrap_or(serde_json::Value::Null),
-        value => value,
+fn unwrap_direct_record(
+    record: serde_json::Value,
+    output_mode: DirectOutputMode,
+) -> serde_json::Value {
+    match output_mode {
+        DirectOutputMode::RecordObject => record,
+        DirectOutputMode::Value => match record {
+            serde_json::Value::Object(mut object) => object
+                .remove(DIRECT_VALUE_TARGET)
+                .unwrap_or(serde_json::Value::Null),
+            value => value,
+        },
     }
 }

--- a/crates/rulemorph_cli/src/direct/output_spec.rs
+++ b/crates/rulemorph_cli/src/direct/output_spec.rs
@@ -1,0 +1,518 @@
+use std::collections::HashSet;
+
+use rulemorph::{
+    Expr, ExprChain, ExprOp, ExprRef, NormalizationOptions, PathToken, parse_path,
+    serde_guard::parse_json_value_strict,
+    v2_model::{V2CallArg, V2Comparison, V2Condition, V2Expr, V2Pipe, V2Ref, V2Start, V2Step},
+    v2_parser::parse_v2_expr,
+};
+
+use super::DirectArgs;
+
+const MAX_DIRECT_OUTPUT_FIELDS: usize = 10_000;
+const MAX_DIRECT_OUTPUT_SPEC_BYTES: usize = 8 * 1024 * 1024;
+const MAX_DIRECT_OUTPUT_TARGET_BYTES: usize = 256 * 1024;
+const MAX_DIRECT_OUTPUT_TARGET_BYTES_TOTAL: usize = 8 * 1024 * 1024;
+const MAX_DIRECT_OUTPUT_TARGET_DEPTH: usize = 256;
+const MAX_DIRECT_OUTPUT_TARGET_TOKENS_TOTAL: usize = 1_000_000;
+const MAX_DIRECT_OUTPUT_EXPR_DEPTH: usize = 256;
+const MAX_DIRECT_OUTPUT_EXPR_NODES: usize = 1_000_000;
+const MAX_DIRECT_OUTPUT_EXPR_STRING_BYTES: usize = 8 * 1024 * 1024;
+const MAX_DIRECT_OUTPUT_CELLS: usize = 10_000_000;
+
+pub(super) struct DirectCliError {
+    pub(super) message: String,
+    pub(super) exit_code: i32,
+}
+
+impl DirectCliError {
+    fn validation(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            exit_code: 2,
+        }
+    }
+
+    fn parse(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            exit_code: 1,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct FieldSpec {
+    pub(super) target: String,
+    pub(super) expr: serde_json::Value,
+    tokens: Vec<PathToken>,
+}
+
+pub(super) enum DirectOutputSpec {
+    Rule(serde_json::Value),
+    Fields(Vec<FieldSpec>),
+    OutputMap(Vec<FieldSpec>),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum DirectOutputMode {
+    Value,
+    RecordObject,
+}
+
+impl DirectOutputSpec {
+    pub(super) fn output_mode(&self) -> DirectOutputMode {
+        match self {
+            DirectOutputSpec::Rule(_) => DirectOutputMode::Value,
+            DirectOutputSpec::Fields(_) | DirectOutputSpec::OutputMap(_) => {
+                DirectOutputMode::RecordObject
+            }
+        }
+    }
+
+    pub(super) fn exprs(&self) -> Vec<&serde_json::Value> {
+        match self {
+            DirectOutputSpec::Rule(expr) => vec![expr],
+            DirectOutputSpec::Fields(fields) | DirectOutputSpec::OutputMap(fields) => {
+                fields.iter().map(|field| &field.expr).collect()
+            }
+        }
+    }
+
+    fn output_field_count(&self) -> usize {
+        match self {
+            DirectOutputSpec::Rule(_) => 1,
+            DirectOutputSpec::Fields(fields) | DirectOutputSpec::OutputMap(fields) => fields.len(),
+        }
+    }
+}
+
+pub(super) fn parse_direct_output_spec(
+    args: &DirectArgs,
+    options: &NormalizationOptions,
+    output_cell_record_budget: usize,
+) -> Result<DirectOutputSpec, DirectCliError> {
+    let spec_count = usize::from(args.rule.is_some())
+        + usize::from(!args.fields.is_empty())
+        + usize::from(args.output_map.is_some());
+    if spec_count != 1 {
+        return Err(DirectCliError::validation(
+            "exactly one of --rule, --output-map, or --field is required",
+        ));
+    }
+
+    if let Some(rule) = args.rule.as_deref() {
+        return parse_inline_expr(rule)
+            .map(DirectOutputSpec::Rule)
+            .map_err(DirectCliError::parse);
+    }
+
+    let spec = if !args.fields.is_empty() {
+        let fields = parse_field_specs(&args.fields)?;
+        DirectOutputSpec::Fields(fields)
+    } else if let Some(output_map) = args.output_map.as_deref() {
+        let fields = parse_output_map_specs(output_map)?;
+        DirectOutputSpec::OutputMap(fields)
+    } else {
+        unreachable!("spec_count verified exactly one direct output spec");
+    };
+    validate_direct_output_cells(&spec, options, output_cell_record_budget)?;
+    Ok(spec)
+}
+
+fn parse_field_specs(items: &[String]) -> Result<Vec<FieldSpec>, DirectCliError> {
+    let spec_bytes = items
+        .iter()
+        .try_fold(0usize, |sum, item| checked_add_limit(sum, item.len()))
+        .map_err(DirectCliError::validation)?;
+    validate_output_spec_size(spec_bytes).map_err(DirectCliError::validation)?;
+
+    let mut fields = Vec::with_capacity(items.len());
+    for item in items {
+        let (target, expr) = item
+            .split_once('=')
+            .ok_or_else(|| DirectCliError::validation("--field must be TARGET=EXPR"))?;
+        if target.is_empty() {
+            return Err(DirectCliError::validation(
+                "--field target must not be blank",
+            ));
+        }
+        if expr.is_empty() {
+            return Err(DirectCliError::validation("--field expr must not be blank"));
+        }
+        let expr = parse_field_expr(expr).map_err(DirectCliError::validation)?;
+        validate_expr_limits(&expr).map_err(DirectCliError::validation)?;
+        fields.push(FieldSpec {
+            target: target.to_string(),
+            expr,
+            tokens: validate_target(target).map_err(DirectCliError::validation)?,
+        });
+    }
+    validate_field_specs(&fields).map_err(DirectCliError::validation)?;
+    Ok(fields)
+}
+
+fn parse_output_map_specs(output_map: &str) -> Result<Vec<FieldSpec>, DirectCliError> {
+    validate_output_spec_size(output_map.len()).map_err(DirectCliError::validation)?;
+    let value = parse_json_value_strict(output_map).map_err(|err| {
+        DirectCliError::validation(format!("failed to parse --output-map JSON: {}", err))
+    })?;
+    let serde_json::Value::Object(object) = value else {
+        return Err(DirectCliError::validation(
+            "--output-map must be a JSON object",
+        ));
+    };
+    if object.is_empty() {
+        return Err(DirectCliError::validation(
+            "--output-map must define at least one field",
+        ));
+    }
+    let mut fields = Vec::with_capacity(object.len());
+    for (target, expr) in object {
+        validate_expr_limits(&expr).map_err(DirectCliError::validation)?;
+        if expr_has_evaluated_root_ref(&expr, "out") {
+            return Err(DirectCliError::validation(
+                "--output-map does not support @out references; use --field for ordered mappings",
+            ));
+        }
+        fields.push(FieldSpec {
+            tokens: validate_target(&target).map_err(DirectCliError::validation)?,
+            target,
+            expr,
+        });
+    }
+    validate_field_specs(&fields).map_err(DirectCliError::validation)?;
+    Ok(fields)
+}
+
+fn parse_field_expr(expr: &str) -> Result<serde_json::Value, String> {
+    match parse_json_value_strict(expr) {
+        Ok(value) => Ok(value),
+        Err(err) if looks_like_json(expr) => Err(format!(
+            "--field expr looks like JSON but failed to parse: {}",
+            err
+        )),
+        Err(_) => Ok(serde_json::Value::String(expr.to_string())),
+    }
+}
+
+fn looks_like_json(value: &str) -> bool {
+    matches!(
+        strip_utf8_bom(value.as_bytes())
+            .iter()
+            .copied()
+            .find(|byte| !byte.is_ascii_whitespace()),
+        Some(b'{') | Some(b'[')
+    )
+}
+
+fn validate_output_spec_size(bytes: usize) -> Result<(), String> {
+    if bytes > MAX_DIRECT_OUTPUT_SPEC_BYTES {
+        return Err(format!(
+            "direct output spec must be at most {} bytes",
+            MAX_DIRECT_OUTPUT_SPEC_BYTES
+        ));
+    }
+    Ok(())
+}
+
+fn validate_target(target: &str) -> Result<Vec<PathToken>, String> {
+    if target.len() > MAX_DIRECT_OUTPUT_TARGET_BYTES {
+        return Err(format!(
+            "direct output target names must be at most {} bytes each",
+            MAX_DIRECT_OUTPUT_TARGET_BYTES
+        ));
+    }
+    let tokens = parse_path(target)
+        .map_err(|err| format!("direct output target path is invalid: {}", err.message()))?;
+    if tokens
+        .iter()
+        .any(|token| matches!(token, PathToken::Index(_)))
+    {
+        return Err("direct output target path must not include indexes".to_string());
+    }
+    if tokens.len() > MAX_DIRECT_OUTPUT_TARGET_DEPTH {
+        return Err(format!(
+            "direct output target path exceeds configured depth limit ({})",
+            MAX_DIRECT_OUTPUT_TARGET_DEPTH
+        ));
+    }
+    Ok(tokens)
+}
+
+fn validate_field_specs(fields: &[FieldSpec]) -> Result<(), String> {
+    if fields.len() > MAX_DIRECT_OUTPUT_FIELDS {
+        return Err(format!(
+            "direct output has too many fields; maximum is {}",
+            MAX_DIRECT_OUTPUT_FIELDS
+        ));
+    }
+    let mut total_target_bytes = 0usize;
+    let mut total_tokens = 0usize;
+    let mut seen = HashSet::new();
+    for field in fields {
+        total_target_bytes = checked_add_limit(total_target_bytes, field.target.len())?;
+        if total_target_bytes > MAX_DIRECT_OUTPUT_TARGET_BYTES_TOTAL {
+            return Err(format!(
+                "direct output target names total size must be at most {} bytes",
+                MAX_DIRECT_OUTPUT_TARGET_BYTES_TOTAL
+            ));
+        }
+        total_tokens = checked_add_limit(total_tokens, field.tokens.len())?;
+        if total_tokens > MAX_DIRECT_OUTPUT_TARGET_TOKENS_TOTAL {
+            return Err(format!(
+                "direct output target paths have too many tokens; maximum is {}",
+                MAX_DIRECT_OUTPUT_TARGET_TOKENS_TOTAL
+            ));
+        }
+        if !seen.insert(field.tokens.clone()) {
+            return Err("direct output target is duplicated".to_string());
+        }
+    }
+    for (index, field) in fields.iter().enumerate() {
+        if fields.iter().enumerate().any(|(other_index, other)| {
+            index != other_index
+                && (is_path_prefix(&field.tokens, &other.tokens)
+                    || is_path_prefix(&other.tokens, &field.tokens))
+        }) {
+            return Err("direct output target conflicts with another target".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn is_path_prefix(prefix: &[PathToken], tokens: &[PathToken]) -> bool {
+    prefix.len() < tokens.len() && tokens.starts_with(prefix)
+}
+
+fn validate_direct_output_cells(
+    spec: &DirectOutputSpec,
+    options: &NormalizationOptions,
+    output_cell_record_budget: usize,
+) -> Result<(), DirectCliError> {
+    if spec.output_mode() != DirectOutputMode::RecordObject {
+        return Ok(());
+    }
+    let records = output_cell_record_budget.min(options.max_records);
+    let cells = records
+        .checked_mul(spec.output_field_count())
+        .ok_or_else(|| DirectCliError::validation("direct output cells are too large"))?;
+    if cells > MAX_DIRECT_OUTPUT_CELLS {
+        return Err(DirectCliError::validation(format!(
+            "direct output cells must be at most {}",
+            MAX_DIRECT_OUTPUT_CELLS
+        )));
+    }
+    Ok(())
+}
+
+fn validate_expr_limits(expr: &serde_json::Value) -> Result<(), String> {
+    let mut stats = ExprStats::default();
+    collect_expr_stats(expr, 0, &mut stats)?;
+    if stats.max_depth > MAX_DIRECT_OUTPUT_EXPR_DEPTH {
+        return Err(format!(
+            "direct output expr exceeds configured depth limit ({})",
+            MAX_DIRECT_OUTPUT_EXPR_DEPTH
+        ));
+    }
+    if stats.nodes > MAX_DIRECT_OUTPUT_EXPR_NODES {
+        return Err(format!(
+            "direct output expr has too many nodes; maximum is {}",
+            MAX_DIRECT_OUTPUT_EXPR_NODES
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct ExprStats {
+    max_depth: usize,
+    nodes: usize,
+}
+
+fn collect_expr_stats(
+    value: &serde_json::Value,
+    depth: usize,
+    stats: &mut ExprStats,
+) -> Result<(), String> {
+    stats.nodes = checked_add_limit(stats.nodes, 1)?;
+    stats.max_depth = stats.max_depth.max(depth);
+    match value {
+        serde_json::Value::String(text) if text.len() > MAX_DIRECT_OUTPUT_EXPR_STRING_BYTES => {
+            Err(format!(
+                "direct output expr string values must be at most {} bytes each",
+                MAX_DIRECT_OUTPUT_EXPR_STRING_BYTES
+            ))
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_expr_stats(item, depth + 1, stats)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::Object(object) => {
+            for value in object.values() {
+                collect_expr_stats(value, depth + 1, stats)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn checked_add_limit(left: usize, right: usize) -> Result<usize, String> {
+    left.checked_add(right)
+        .ok_or_else(|| "direct output spec is too large".to_string())
+}
+
+fn parse_inline_expr(inline_rule: &str) -> Result<serde_json::Value, String> {
+    match parse_json_value_strict(inline_rule) {
+        Ok(value) => Ok(value),
+        Err(err) if serde_json::from_str::<serde_json::Value>(inline_rule).is_ok() => {
+            Err(format!("failed to parse inline JSON rule: {}", err))
+        }
+        Err(_) => Ok(serde_json::Value::String(inline_rule.to_string())),
+    }
+}
+
+pub(super) fn expr_has_evaluated_root_ref(expr: &serde_json::Value, root: &str) -> bool {
+    scan_expr_refs(expr, root)
+}
+
+fn scan_expr_refs(expr: &serde_json::Value, root: &str) -> bool {
+    if let Some(expr) = parse_v1_expr_ref_shape(expr) {
+        return scan_v1_expr_refs(&expr, root);
+    }
+    parse_v2_expr(expr)
+        .ok()
+        .is_some_and(|expr| scan_v2_expr_refs(&expr, root))
+}
+
+fn parse_v1_expr_ref_shape(expr: &serde_json::Value) -> Option<Expr> {
+    match expr {
+        serde_json::Value::Object(values)
+            if values.contains_key("ref")
+                || values.contains_key("op")
+                || values.contains_key("chain") =>
+        {
+            serde_json::from_value(expr.clone()).ok()
+        }
+        _ => None,
+    }
+}
+
+fn scan_v1_expr_refs(expr: &Expr, root: &str) -> bool {
+    match expr {
+        Expr::Ref(ExprRef { ref_path }) => is_v1_root_ref(ref_path, root),
+        Expr::Op(ExprOp { args, .. }) => args.iter().any(|expr| scan_v1_expr_refs(expr, root)),
+        Expr::Chain(ExprChain { chain }) => chain.iter().any(|expr| scan_v1_expr_refs(expr, root)),
+        Expr::Literal(_) => false,
+    }
+}
+
+fn scan_v2_expr_refs(expr: &V2Expr, root: &str) -> bool {
+    match expr {
+        V2Expr::Pipe(pipe) => scan_v2_pipe_refs(pipe, root),
+        V2Expr::V1Fallback(expr) => scan_v1_expr_refs(expr, root),
+    }
+}
+
+fn scan_v2_pipe_refs(pipe: &V2Pipe, root: &str) -> bool {
+    scan_v2_start_refs(&pipe.start, root)
+        || pipe.steps.iter().any(|step| scan_v2_step_refs(step, root))
+}
+
+fn scan_v2_start_refs(start: &V2Start, root: &str) -> bool {
+    match start {
+        V2Start::Ref(reference) => is_v2_root_ref(reference, root),
+        V2Start::V1Expr(expr) => scan_v1_expr_refs(expr, root),
+        V2Start::PipeValue | V2Start::ImplicitPipeValue | V2Start::Literal(_) => false,
+    }
+}
+
+fn scan_v2_step_refs(step: &V2Step, root: &str) -> bool {
+    match step {
+        V2Step::Ref(reference) => is_v2_root_ref(reference, root),
+        V2Step::Op(op) => op.args.iter().any(|expr| scan_v2_expr_refs(expr, root)),
+        V2Step::CustomCall(call) => call.with.as_ref().is_some_and(|args| {
+            args.iter().any(|(_, arg)| match arg {
+                V2CallArg::Expr(expr) => scan_v2_expr_refs(expr, root),
+                V2CallArg::Value(_) => false,
+            })
+        }),
+        V2Step::Let(let_step) => let_step
+            .bindings
+            .iter()
+            .any(|(_, expr)| scan_v2_expr_refs(expr, root)),
+        V2Step::If(if_step) => {
+            scan_v2_condition_refs(&if_step.cond, root)
+                || scan_v2_pipe_refs(&if_step.then_branch, root)
+                || if_step
+                    .else_branch
+                    .as_ref()
+                    .is_some_and(|pipe| scan_v2_pipe_refs(pipe, root))
+        }
+        V2Step::Map(map_step) => map_step
+            .steps
+            .iter()
+            .any(|step| scan_v2_step_refs(step, root)),
+    }
+}
+
+fn scan_v2_condition_refs(condition: &V2Condition, root: &str) -> bool {
+    match condition {
+        V2Condition::All(conditions) | V2Condition::Any(conditions) => conditions
+            .iter()
+            .any(|condition| scan_v2_condition_refs(condition, root)),
+        V2Condition::Comparison(V2Comparison { args, .. }) => {
+            args.iter().any(|expr| scan_v2_expr_refs(expr, root))
+        }
+        V2Condition::Expr(expr) => scan_v2_expr_refs(expr, root),
+    }
+}
+
+fn is_v2_root_ref(reference: &V2Ref, root: &str) -> bool {
+    match (reference, root) {
+        (V2Ref::Input(path), "input") => is_canonical_numeric_root_path(path),
+        (V2Ref::Out(_), "out") => true,
+        (V2Ref::Context(_), "context") => true,
+        _ => false,
+    }
+}
+
+fn is_v1_root_ref(value: &str, root: &str) -> bool {
+    if value == root {
+        return root != "input";
+    }
+    let prefix = format!("{}.", root);
+    let Some(rest) = value.strip_prefix(&prefix) else {
+        return false;
+    };
+    if root == "input" {
+        return is_canonical_numeric_root_path(rest);
+    }
+    !rest.is_empty()
+}
+
+fn is_canonical_numeric_root_path(rest: &str) -> bool {
+    let digit_count = rest
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_count == 0 {
+        return false;
+    }
+    let digits = &rest[..digit_count];
+    if digits.len() > 1 && digits.starts_with('0') {
+        return false;
+    }
+    matches!(
+        rest.as_bytes().get(digit_count),
+        None | Some(b'.') | Some(b'[')
+    )
+}
+
+fn strip_utf8_bom(input: &[u8]) -> &[u8] {
+    input.strip_prefix(b"\xef\xbb\xbf").unwrap_or(input)
+}

--- a/crates/rulemorph_cli/src/direct/output_spec.rs
+++ b/crates/rulemorph_cli/src/direct/output_spec.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashSet;
 
 use rulemorph::{
@@ -269,20 +270,40 @@ fn validate_field_specs(fields: &[FieldSpec]) -> Result<(), String> {
             return Err("direct output target is duplicated".to_string());
         }
     }
-    for (index, field) in fields.iter().enumerate() {
-        if fields.iter().enumerate().any(|(other_index, other)| {
-            index != other_index
-                && (is_path_prefix(&field.tokens, &other.tokens)
-                    || is_path_prefix(&other.tokens, &field.tokens))
-        }) {
-            return Err("direct output target conflicts with another target".to_string());
-        }
+    if has_parent_child_target_conflict(fields) {
+        return Err("direct output target conflicts with another target".to_string());
     }
     Ok(())
 }
 
-fn is_path_prefix(prefix: &[PathToken], tokens: &[PathToken]) -> bool {
-    prefix.len() < tokens.len() && tokens.starts_with(prefix)
+fn has_parent_child_target_conflict(fields: &[FieldSpec]) -> bool {
+    let mut paths = fields
+        .iter()
+        .map(|field| field.tokens.as_slice())
+        .collect::<Vec<_>>();
+    paths.sort_unstable_by(|left, right| compare_path_tokens(left, right));
+    paths
+        .windows(2)
+        .any(|pair| pair[0].len() < pair[1].len() && pair[1].starts_with(pair[0]))
+}
+
+fn compare_path_tokens(left: &[PathToken], right: &[PathToken]) -> Ordering {
+    for (left_token, right_token) in left.iter().zip(right.iter()) {
+        let ordering = compare_path_token(left_token, right_token);
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    left.len().cmp(&right.len())
+}
+
+fn compare_path_token(left: &PathToken, right: &PathToken) -> Ordering {
+    match (left, right) {
+        (PathToken::Key(left), PathToken::Key(right)) => left.cmp(right),
+        (PathToken::Index(left), PathToken::Index(right)) => left.cmp(right),
+        (PathToken::Key(_), PathToken::Index(_)) => Ordering::Less,
+        (PathToken::Index(_), PathToken::Key(_)) => Ordering::Greater,
+    }
 }
 
 fn validate_direct_output_cells(
@@ -515,4 +536,36 @@ fn is_canonical_numeric_root_path(rest: &str) -> bool {
 
 fn strip_utf8_bom(input: &[u8]) -> &[u8] {
     input.strip_prefix(b"\xef\xbb\xbf").unwrap_or(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_field_specs_rejects_large_parent_child_conflict() {
+        let shared_prefix = (0..255)
+            .map(|index| PathToken::Key(format!("p{}", index)))
+            .collect::<Vec<_>>();
+        let mut fields = (0..1000)
+            .map(|index| {
+                let mut tokens = shared_prefix.clone();
+                tokens.push(PathToken::Key(format!("k{}", index)));
+                FieldSpec {
+                    target: format!("t{}", index),
+                    expr: serde_json::Value::Null,
+                    tokens,
+                }
+            })
+            .collect::<Vec<_>>();
+        fields.push(FieldSpec {
+            target: "parent".to_string(),
+            expr: serde_json::Value::Null,
+            tokens: shared_prefix,
+        });
+
+        let error = validate_field_specs(&fields).unwrap_err();
+
+        assert_eq!(error, "direct output target conflicts with another target");
+    }
 }

--- a/crates/rulemorph_cli/src/main.rs
+++ b/crates/rulemorph_cli/src/main.rs
@@ -20,10 +20,24 @@ mod server_commands;
 struct Cli {
     #[arg(long = "rule")]
     rule: Option<String>,
+    #[arg(short = 'F', long = "field")]
+    fields: Vec<String>,
+    #[arg(long = "output-map")]
+    output_map: Option<String>,
     #[arg(short = 'i', long)]
     input: Option<PathBuf>,
     #[arg(short = 'f', long)]
-    format: Option<FormatOverride>,
+    format: Option<DirectFormatArg>,
+    #[arg(short = 'H', long = "headers")]
+    headers: Option<String>,
+    #[arg(long = "excel-data-range")]
+    excel_data_range: Option<String>,
+    #[arg(long)]
+    excel_header_row: Option<usize>,
+    #[arg(long)]
+    excel_sheet: Option<String>,
+    #[arg(long)]
+    excel_sheet_index: Option<usize>,
     #[arg(short = 'o', long)]
     output: Option<PathBuf>,
     #[arg(short = 'e', long)]
@@ -34,6 +48,8 @@ struct Cli {
     limits_profile: Option<LimitsProfileArg>,
     #[arg(long)]
     limits_file: Option<PathBuf>,
+    #[arg(short = 'c', long)]
+    context: Option<PathBuf>,
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -66,6 +82,13 @@ enum FormatOverride {
     Json,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum DirectFormatArg {
+    Csv,
+    Json,
+    Excel,
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum RulesFormatArg {
     Yaml,
@@ -82,61 +105,87 @@ fn main() {
     let cli = Cli::parse_from(normalize_rule_alias(std::env::args_os()));
     let Cli {
         rule,
+        fields,
+        output_map,
         input,
         format,
+        headers,
+        excel_data_range,
+        excel_header_row,
+        excel_sheet,
+        excel_sheet_index,
         output,
         error_format,
         limits,
         limits_profile,
         limits_file,
+        context,
         command,
     } = cli;
 
-    let exit_code = match (rule, command) {
-        (Some(rule), None) => direct::run(direct::DirectArgs {
+    let has_direct_output_spec = rule.is_some() || !fields.is_empty() || output_map.is_some();
+
+    let exit_code = match (has_direct_output_spec, command) {
+        (true, None) => direct::run(direct::DirectArgs {
             rule,
+            fields,
+            output_map,
             input,
             format,
+            headers,
+            excel_data_range,
+            excel_header_row,
+            excel_sheet,
+            excel_sheet_index,
             output,
             error_format,
             limits,
             limits_profile,
             limits_file,
+            context,
         }),
-        (Some(_), Some(_)) => {
-            eprintln!("--rule cannot be used with a subcommand");
+        (true, Some(_)) => {
+            eprintln!("--rule, --output-map, and --field cannot be used with a subcommand");
             2
         }
-        (None, Some(command))
+        (false, Some(command))
             if has_direct_options(
                 &input,
                 &format,
+                &headers,
+                &excel_data_range,
+                &excel_header_row,
+                &excel_sheet,
+                &excel_sheet_index,
                 &output,
                 &error_format,
                 &limits,
                 &limits_profile,
                 &limits_file,
+                &context,
             ) =>
         {
-            eprintln!("direct-mode options require --rule and cannot be used before a subcommand");
+            eprintln!(
+                "direct-mode options require --rule, --output-map, or --field and cannot be used before a subcommand"
+            );
             let _ = command;
             2
         }
-        (None, Some(Commands::Validate(args))) => core_commands::run_validate(args),
+        (false, Some(Commands::Validate(args))) => core_commands::run_validate(args),
         #[cfg(feature = "server")]
-        (None, Some(Commands::ValidateRulesDir(args))) => {
+        (false, Some(Commands::ValidateRulesDir(args))) => {
             server_commands::run_validate_rules_dir(args)
         }
-        (None, Some(Commands::Preflight(args))) => core_commands::run_preflight(args),
-        (None, Some(Commands::Transform(args))) => core_commands::run_transform(args),
-        (None, Some(Commands::Generate(args))) => generate::run(args),
+        (false, Some(Commands::Preflight(args))) => core_commands::run_preflight(args),
+        (false, Some(Commands::Transform(args))) => core_commands::run_transform(args),
+        (false, Some(Commands::Generate(args))) => generate::run(args),
         #[cfg(feature = "server")]
-        (None, Some(Commands::Ui(args))) => server_commands::run_ui(args),
+        (false, Some(Commands::Ui(args))) => server_commands::run_ui(args),
         #[cfg(feature = "server")]
-        (None, Some(Commands::PurgeTraces(args))) => server_commands::run_purge_traces(args),
+        (false, Some(Commands::PurgeTraces(args))) => server_commands::run_purge_traces(args),
         #[cfg(feature = "server")]
-        (None, Some(Commands::ApiKeys(args))) => api_keys::run(args),
-        (None, None) => {
+        (false, Some(Commands::ApiKeys(args))) => api_keys::run(args),
+        (false, None) => {
             let _ = Cli::command().print_help();
             eprintln!();
             2
@@ -167,20 +216,32 @@ fn normalize_rule_alias(args: impl IntoIterator<Item = OsString>) -> Vec<OsStrin
 
 fn has_direct_options(
     input: &Option<PathBuf>,
-    format: &Option<FormatOverride>,
+    format: &Option<DirectFormatArg>,
+    headers: &Option<String>,
+    excel_range: &Option<String>,
+    excel_header_row: &Option<usize>,
+    excel_sheet: &Option<String>,
+    excel_sheet_index: &Option<usize>,
     output: &Option<PathBuf>,
     error_format: &Option<ErrorFormat>,
     limits: &[String],
     limits_profile: &Option<LimitsProfileArg>,
     limits_file: &Option<PathBuf>,
+    context: &Option<PathBuf>,
 ) -> bool {
     input.is_some()
         || format.is_some()
+        || headers.is_some()
+        || excel_range.is_some()
+        || excel_header_row.is_some()
+        || excel_sheet.is_some()
+        || excel_sheet_index.is_some()
         || output.is_some()
         || error_format.is_some()
         || !limits.is_empty()
         || limits_profile.is_some()
         || limits_file.is_some()
+        || context.is_some()
 }
 
 #[cfg(test)]

--- a/crates/rulemorph_cli/tests/cli/direct_rule.rs
+++ b/crates/rulemorph_cli/tests/cli/direct_rule.rs
@@ -96,6 +96,8 @@ fn direct_options_cannot_be_ignored_before_subcommand() {
     let output = rulemorph_output(|cmd| {
         cmd.arg("-i")
             .arg("input.json")
+            .arg("-H")
+            .arg("id")
             .arg("transform")
             .arg("-r")
             .arg("rules.yaml");
@@ -103,4 +105,748 @@ fn direct_options_cannot_be_ignored_before_subcommand() {
 
     assert_eq!(output.status.code(), Some(2));
     assert!(stderr_string(output).contains("direct-mode options require --rule"));
+}
+
+#[test]
+fn direct_rule_infers_headerless_csv_numeric_fields_from_stdin() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.0")
+            .write_stdin("a,test,1\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"a\"\n");
+}
+
+#[test]
+fn direct_rule_applies_csv_headers_from_stdin() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-H")
+            .arg("id,name,age")
+            .arg("--rule")
+            .arg("@input.id")
+            .write_stdin("a,test,1\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"a\"\n");
+}
+
+#[test]
+fn direct_rule_reads_headerless_csv_file_with_headers() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_path = temp_dir.path().join("non_header.csv");
+    fs::write(&input_path, "a,test,1\n").unwrap();
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-H")
+            .arg("id,name,age")
+            .arg("--rule")
+            .arg("@input.id")
+            .arg("-i")
+            .arg(&input_path);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"a\"\n");
+}
+
+#[test]
+fn direct_rule_reads_headered_csv_file_by_extension() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_path = temp_dir.path().join("with_header.csv");
+    fs::write(&input_path, "id,name,age\na,test,1\n").unwrap();
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule").arg("@input.id").arg("-i").arg(&input_path);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"a\"\n");
+}
+
+#[test]
+fn direct_rule_outputs_multi_row_inferred_csv_as_array() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.0")
+            .write_stdin("a,test,1\nb,demo,2\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "[\"a\",\"b\"]\n");
+}
+
+#[test]
+fn direct_rule_supports_pipe_expr_for_headerless_csv_numeric_fields() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg(r#"["@input.0", {"concat": ["-", "@input.1"]}]"#)
+            .write_stdin("a,test,1\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"a-test\"\n");
+}
+
+#[test]
+fn direct_rule_supports_pipe_expr_for_csv_headers() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-H")
+            .arg("id,name,age")
+            .arg("--rule")
+            .arg(r#"["@input.name", "trim", "uppercase"]"#)
+            .write_stdin("u1, Alice ,42\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"ALICE\"\n");
+}
+
+#[test]
+fn direct_field_outputs_object_for_json_object_input() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-F")
+            .arg("id=@input.id")
+            .arg("-F")
+            .arg(r#"name=["@input.name","trim","uppercase"]"#)
+            .arg("-F")
+            .arg("kind=lit:user")
+            .write_stdin(r#"{ "id": "u1", "name": " Alice " }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "id": "u1",
+            "name": "ALICE",
+            "kind": "user"
+        })
+    );
+}
+
+#[test]
+fn direct_field_outputs_object_array_for_json_array_input() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-F")
+            .arg("id=@input.id")
+            .arg("-F")
+            .arg(r#"age=["@input.age","int"]"#)
+            .write_stdin(r#"[{ "id": "u1", "age": "42" }, { "id": "u2", "age": "7" }]"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([
+            { "id": "u1", "age": 42 },
+            { "id": "u2", "age": 7 }
+        ])
+    );
+}
+
+#[test]
+fn direct_field_infers_headerless_csv_numeric_fields_from_stdin() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-F")
+            .arg("id=@input.0")
+            .arg("-F")
+            .arg(r#"name=["@input.1","uppercase"]"#)
+            .write_stdin("u1,Alice,42\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "id": "u1",
+            "name": "ALICE"
+        })
+    );
+}
+
+#[test]
+fn direct_field_preserves_ordered_out_references() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-F")
+            .arg(r#"name=["@input.name","trim"]"#)
+            .arg("-F")
+            .arg(r##"label=["@out.name",{"concat":["#","@input.id"]}]"##)
+            .write_stdin(r#"{ "id": "u1", "name": " Alice " }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "name": "Alice",
+            "label": "Alice#u1"
+        })
+    );
+}
+
+#[test]
+fn direct_output_map_outputs_nested_object_for_json_object_input() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"user.id":"@input.id","user.name":["@input.name","trim"],"kind":"lit:user"}"#)
+            .write_stdin(r#"{ "id": "u1", "name": " Alice " }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "user": {
+                "id": "u1",
+                "name": "Alice"
+            },
+            "kind": "user"
+        })
+    );
+}
+
+#[test]
+fn direct_output_map_outputs_object_array_for_json_array_input() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"id":"@input.id","age":["@input.age","int"]}"#)
+            .write_stdin(r#"[{ "id": "u1", "age": "42" }, { "id": "u2", "age": "7" }]"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([
+            { "id": "u1", "age": 42 },
+            { "id": "u2", "age": 7 }
+        ])
+    );
+}
+
+#[test]
+fn direct_output_map_infers_headerless_csv_numeric_fields_from_stdin() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"id":"@input.0","name":["@input.1","uppercase"]}"#)
+            .write_stdin("u1,Alice,42\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "id": "u1",
+            "name": "ALICE"
+        })
+    );
+}
+
+#[test]
+fn direct_output_map_infers_headerless_csv_numeric_fields_inside_if_step() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(
+                r#"{"label":["lit:x",{"if":{"cond":{"eq":["@input.0","u1"]},"then":["@input.1"],"else":["lit:no"]}}]}"#,
+            )
+            .write_stdin("u1,Alice\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "label": "Alice"
+        })
+    );
+}
+
+#[test]
+fn direct_output_map_literal_object_does_not_trigger_headerless_numeric_inference() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"copy":{"value":"@input.0"}}"#)
+            .write_stdin("id,name\nu1,Alice\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "copy": {
+                "value": "@input.0"
+            }
+        })
+    );
+}
+
+#[test]
+fn direct_output_map_literal_pipe_start_does_not_trigger_headerless_numeric_inference() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"copy":[{"value":"@input.0"}]}"#)
+            .write_stdin("id,name\nu1,Alice\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "copy": {
+                "value": "@input.0"
+            }
+        })
+    );
+}
+
+#[test]
+fn direct_rule_reads_context() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let context_path = temp_dir.path().join("context.json");
+    fs::write(&context_path, r#"{ "tenant_id": "t1" }"#).unwrap();
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@context.tenant_id")
+            .arg("-c")
+            .arg(context_path)
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"t1\"\n");
+}
+
+#[test]
+fn direct_field_reads_context() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let context_path = temp_dir.path().join("context.json");
+    fs::write(&context_path, r#"{ "tenant_id": "t1" }"#).unwrap();
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-F")
+            .arg("id=@input.id")
+            .arg("-F")
+            .arg("tenant=@context.tenant_id")
+            .arg("-c")
+            .arg(context_path)
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "id": "u1",
+            "tenant": "t1"
+        })
+    );
+}
+
+#[test]
+fn direct_output_map_reads_context() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let context_path = temp_dir.path().join("context.json");
+    fs::write(&context_path, r#"{ "tenant_id": "t1" }"#).unwrap();
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"id":"@input.id","tenant":"@context.tenant_id"}"#)
+            .arg("-c")
+            .arg(context_path)
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!({
+            "id": "u1",
+            "tenant": "t1"
+        })
+    );
+}
+
+#[test]
+fn direct_output_specs_are_mutually_exclusive() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.id")
+            .arg("-F")
+            .arg("id=@input.id")
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("exactly one of --rule, --output-map, or --field"));
+}
+
+#[test]
+fn direct_field_rejects_json_looking_malformed_rhs() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-F")
+            .arg(r#"age=["@input.age","int""#)
+            .write_stdin(r#"{ "age": "42" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--field expr looks like JSON but failed to parse"));
+}
+
+#[test]
+fn direct_output_map_rejects_evaluated_out_reference() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"id":"@input.id","label":"@out.id"}"#)
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--output-map does not support @out references"));
+}
+
+#[test]
+fn direct_output_map_rejects_evaluated_root_out_reference() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"id":"@input.id","copy":"@out"}"#)
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--output-map does not support @out references"));
+}
+
+#[test]
+fn direct_output_map_rejects_evaluated_v1_root_out_reference() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"id":"@input.id","copy":{"ref":"out"}}"#)
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--output-map does not support @out references"));
+}
+
+#[test]
+fn direct_output_map_rejects_evaluated_out_reference_inside_if_step() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(
+                r#"{"zid":"@input.id","label":["lit:x",{"if":{"cond":{"eq":["@out.zid","u1"]},"then":["lit:yes"],"else":["lit:no"]}}]}"#,
+            )
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--output-map does not support @out references"));
+}
+
+#[test]
+fn direct_output_map_allows_literal_out_string() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--output-map")
+            .arg(r#"{"label":"lit:@out.id"}"#)
+            .write_stdin(r#"{ "id": "u1" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    let actual: serde_json::Value = serde_json::from_str(&stdout_string(output)).unwrap();
+    assert_eq!(actual, serde_json::json!({ "label": "@out.id" }));
+}
+
+#[test]
+fn direct_field_rejects_output_cell_limit_for_large_record_budget() {
+    let mut fields = Vec::new();
+    for index in 0..101 {
+        fields.push(("-F".to_string(), format!("f{}=@input.0", index)));
+    }
+
+    let output = rulemorph_output(|cmd| {
+        for (flag, value) in fields {
+            cmd.arg(flag).arg(value);
+        }
+        cmd.write_stdin("a\n");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("direct output cells must be at most 10000000"));
+}
+
+#[test]
+fn direct_rule_preserves_legacy_explicit_csv_array_shape() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-f")
+            .arg("csv")
+            .arg("--rule")
+            .arg("@input.id")
+            .write_stdin("id\na\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "[\"a\"]\n");
+}
+
+#[test]
+fn direct_rule_uses_json_default_for_unknown_extension_input_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_path = temp_dir.path().join("input.txt");
+    fs::write(&input_path, r#"{ "id": "a" }"#).unwrap();
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule").arg("@input.id").arg("-i").arg(&input_path);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"a\"\n");
+}
+
+#[test]
+fn direct_rule_rejects_json_looking_malformed_stdin_as_transform_error() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule").arg("@input.id").write_stdin("{not-json\n");
+    });
+
+    assert_eq!(output.status.code(), Some(3));
+}
+
+#[test]
+fn direct_rule_treats_dash_input_as_stdin_for_detection() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-i")
+            .arg("-")
+            .arg("--rule")
+            .arg("@input.0")
+            .write_stdin("a,b\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"a\"\n");
+}
+
+#[test]
+fn direct_rule_rejects_headers_for_json_input() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-H")
+            .arg("id")
+            .arg("--rule")
+            .arg("@input.id")
+            .write_stdin(r#"{ "id": "a" }"#);
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--headers requires CSV direct input"));
+}
+
+#[test]
+fn direct_rule_rejects_excel_options_for_csv_input() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--excel-header-row")
+            .arg("1")
+            .arg("--excel-data-range")
+            .arg("A2:D2")
+            .arg("--rule")
+            .arg("@input.id")
+            .write_stdin("id,name\na,test\n");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--excel-* options require Excel direct input"));
+}
+
+#[test]
+fn direct_rule_rejects_duplicate_csv_headers() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-H")
+            .arg("id,id")
+            .arg("--rule")
+            .arg("@input.id")
+            .write_stdin("a,b\n");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--headers must be unique"));
+}
+
+#[test]
+fn direct_rule_rejects_too_many_csv_headers() {
+    let headers = (0..10_001)
+        .map(|index| format!("c{}", index))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("-H")
+            .arg(headers)
+            .arg("--rule")
+            .arg("@input.c0")
+            .write_stdin("a\n");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--headers has too many fields"));
+}
+
+#[test]
+fn direct_rule_rejects_malformed_csv_when_inferring_numeric_fields() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.0")
+            .write_stdin(Vec::from(b"a,\xff\n".as_slice()));
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("failed to infer CSV columns"));
+}
+
+#[test]
+fn direct_rule_reads_excel_single_row_range() {
+    let input_path = fixtures_dir().join("t34_excel_input").join("input.xlsx");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.id")
+            .arg("-i")
+            .arg(input_path)
+            .arg("--excel-header-row")
+            .arg("1")
+            .arg("--excel-data-range")
+            .arg("A2:D2");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "1\n");
+}
+
+#[test]
+fn direct_rule_reads_excel_multi_row_range() {
+    let input_path = fixtures_dir().join("t34_excel_input").join("input.xlsx");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.id")
+            .arg("-i")
+            .arg(input_path)
+            .arg("--excel-header-row")
+            .arg("1")
+            .arg("--excel-data-range")
+            .arg("A2:D3");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "[1,2]\n");
+}
+
+#[test]
+fn direct_rule_supports_numeric_pipe_expr_for_excel_range() {
+    let input_path = fixtures_dir().join("t34_excel_input").join("input.xlsx");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg(r#"["@input.score", {"+": [7.5]}, "round"]"#)
+            .arg("-i")
+            .arg(input_path)
+            .arg("--excel-header-row")
+            .arg("1")
+            .arg("--excel-data-range")
+            .arg("A2:D2");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "50\n");
+}
+
+#[test]
+fn direct_rule_rejects_excel_input_without_required_range() {
+    let input_path = fixtures_dir().join("t34_excel_input").join("input.xlsx");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.id")
+            .arg("-i")
+            .arg(input_path)
+            .arg("--excel-header-row")
+            .arg("1");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--excel-data-range is required"));
+}
+
+#[test]
+fn direct_rule_rejects_excel_input_without_required_header_row() {
+    let input_path = fixtures_dir().join("t34_excel_input").join("input.xlsx");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.id")
+            .arg("-i")
+            .arg(input_path)
+            .arg("--excel-data-range")
+            .arg("A2:D2");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_string(output).contains("--excel-header-row is required"));
+}
+
+#[test]
+fn direct_rule_rejects_excel_range_starting_on_header_row() {
+    let input_path = fixtures_dir().join("t34_excel_input").join("input.xlsx");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.id")
+            .arg("-i")
+            .arg(input_path)
+            .arg("--excel-header-row")
+            .arg("1")
+            .arg("--excel-data-range")
+            .arg("A1:D2");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr_string(output).contains("--excel-data-range is the data range and must start after --excel-header-row")
+    );
+}
+
+#[test]
+fn direct_rule_rejects_excel_sheet_selector_conflict() {
+    let input_path = fixtures_dir().join("t34_excel_input").join("input.xlsx");
+
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--rule")
+            .arg("@input.id")
+            .arg("-i")
+            .arg(input_path)
+            .arg("--excel-header-row")
+            .arg("1")
+            .arg("--excel-data-range")
+            .arg("A2:D2")
+            .arg("--excel-sheet")
+            .arg("Users")
+            .arg("--excel-sheet-index")
+            .arg("0");
+    });
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr_string(output).contains("--excel-sheet and --excel-sheet-index cannot be used together")
+    );
 }

--- a/docs/cli-direct-tabular-input-design.md
+++ b/docs/cli-direct-tabular-input-design.md
@@ -1,0 +1,981 @@
+# CLI direct mode の CSV / Excel 入力と複数出力詳細設計
+
+## 目的
+
+`rulemorph --rule` の direct mode で、rule file を作らずに CSV / Excel を扱えるようにする。あわせて、複数の出力フィールドを rule file なしで定義できる `-F/--field` と `--output-map` を追加する。
+
+現在の core library は `input.format=csv` / `input.format=excel` の normalization を持つが、CLI direct mode は synthetic rule を `json` / `csv` の最小設定でしか生成できない。そのため headerless CSV、CSV header 付与、Excel sheet / header row / range 指定を direct mode から扱えない。
+
+また、既存 direct mode の `--rule <EXPR>` は 1 つの expr の評価結果だけを返す。object を返すことはできるが、複数 target を作るには `from_entries` / `merge` などを組み合わせる必要があり、CLI の一時変換としては書きづらい。
+
+この設計では core normalization / expr / mappings の契約を変えず、CLI layer だけで direct mode 用の入力設定と mappings を生成する。
+
+## スコープ
+
+対象:
+
+- `rulemorph --rule <EXPR>` / `rulemorph -rule <EXPR>` の direct mode
+- CSV direct input
+- Excel `.xlsx` direct input
+- direct mode の入力形式推定
+- direct mode の context JSON
+- direct mode の複数 target 出力 sugar
+- direct mode docs / tests
+
+対象外:
+
+- `rulemorph transform -r ...` / `preflight` の rule file override 拡張
+- core normalization の挙動変更
+- CSV / Excel cell の自動型推論
+- Excel formula evaluation
+- raw string output の導入
+- `@input.age|int` のような CLI 独自ショートハンド
+- `--output-map` の再帰テンプレート展開
+- literal array 専用 sugar
+
+## 受け入れ条件
+
+以下を満たす。
+
+```sh
+echo "a,test,1" | rulemorph -rule "@input.0"
+# => "a"
+
+echo "a,test,1" | rulemorph -H "id,name,age" -rule "@input.id"
+# => "a"
+
+rulemorph -H "id,name,age" -rule "@input.id" -i non_header.csv
+# => "a"
+
+rulemorph -rule "@input.id" -i with_header.csv
+# => "a"
+
+rulemorph -rule "@input.id" -i users.xlsx --excel-header-row 1 --excel-data-range A2:D2
+# => 1
+
+rulemorph -rule "@input.id" -i users.xlsx --excel-header-row 1 --excel-data-range A2:D3
+# => [1,2]
+
+echo "u1,Alice,42" | rulemorph -H "id,name,age" \
+  -F id="@input.id" \
+  -F name='["@input.name","trim","uppercase"]' \
+  -F kind="lit:user"
+# => {"id":"u1","name":"ALICE","kind":"user"}
+
+echo "u1,Alice,42" | rulemorph -H "id,name,age" \
+  --output-map '{"user.id":"@input.id","user.name":["@input.name","trim"],"kind":"lit:user"}'
+# => {"user":{"id":"u1","name":"Alice"},"kind":"user"}
+
+echo '{"tenant_id":"t1"}' > context.json
+echo "u1,Alice" | rulemorph -H "id,name" -c context.json \
+  -F id="@input.id" \
+  -F tenant="@context.tenant_id"
+# => {"id":"u1","tenant":"t1"}
+```
+
+出力は既存 direct mode と同じ JSON serialization を維持する。したがって string は raw `a` ではなく `"a"` として出力される。raw 出力が必要な場合は、別機能として `--raw-output` を追加する。
+
+## CLI surface
+
+direct mode の output spec として以下を追加する。
+
+```text
+-F, --field <TARGET=EXPR>
+    1 つの output mapping を追加する。複数指定可。
+
+--output-map <JSON_OBJECT>
+    JSON object の key を output target path、value を rulemorph expr として mappings を生成する。
+    再帰的 JSON template ではない。
+```
+
+direct mode の入力 option として以下を追加する。
+
+```text
+-H, --headers <CSV_HEADERS>
+    Headerless CSV に与える field name。1 つの CSV record として parse する。
+
+-c, --context <JSON_FILE>
+    @context として参照する JSON file。既存 transform と同じ読み込み規則を使う。
+
+--excel-data-range <RANGE>
+    Excel の data range。例: A2:C100。header row は含めない。
+
+--excel-header-row <ROW>
+    Excel header row。1-based。Excel direct input では必須。
+
+--excel-sheet <NAME>
+    Excel sheet name。省略時は最初の sheet。
+
+--excel-sheet-index <INDEX>
+    Excel sheet index。0-based。--excel-sheet と同時指定不可。
+```
+
+`-h` は clap の help と衝突するため、headers の short option は `-H` とする。
+
+direct mode は `--rule`、`--output-map`、`-F/--field` のいずれか 1 種類だけを受け付ける。併用した場合は CLI validation error とする。`-F/--field` は同じ option の繰り返しだけを許可する。
+
+`echo non_header.csv | rulemorph ...` はファイルパス扱いにしない。stdin は常に入力データ本体として読む。ファイル入力は `-i non_header.csv` を使う。
+
+`-i` / `-o` / `-c` は通常の local file path として扱う。これはローカル CLI として自然な挙動だが、CI / server / MCP / Web UI などで第三者が path を制御できる運用では、呼び出し側で sandbox / allowlist / stdin 経由入力を使い、任意 local file read/write surface にしない。
+
+## 入力形式推定
+
+direct mode では `DirectInputFormat` を新設し、`transform` / `preflight` で使う `FormatOverride` とは分ける。
+
+推定順:
+
+1. `-f/--format` があればそれを使う。
+2. `-i -` は stdin と同じ扱いにする。
+3. `-i` の拡張子で判定する。
+   - `.csv` -> `csv`
+   - `.xlsx` -> `excel`
+   - `.json` -> `json`
+4. `-i` があり、拡張子が未知または拡張子なしの場合は、既存互換のため `json` とする。
+5. stdin の場合:
+   - UTF-8 BOM と ASCII whitespace を読み飛ばした最初のバイトが `{` または `[` なら `json`
+   - それ以外なら `csv`
+
+stdin の Excel bytes は拡張子がないため、`-f excel` を必須にする。`-f excel` で stdin を読む場合は `InputData::Bytes` として core に渡す。
+
+stdin の自動判定では JSON 全体を parse しない。判定は先頭バイトの分類だけに留める。JSON 形式に見える stdin input が parse に失敗した場合は CSV fallback せず、既存 JSON parser の error を返す。CSV が `{` または `[` で始まる場合は `-f csv` を明示する。
+
+`transform` / `preflight` の `-f` は既存どおり `csv` / `json` のままにする。direct mode 側だけ `excel` を受け付ける。
+
+CSV / Excel 専用 option は対象 format と一致しない場合に拒否する。たとえば `--headers` は CSV direct input 以外では使えず、`--excel-data-range` / `--excel-header-row` / `--excel-sheet` / `--excel-sheet-index` は Excel direct input 以外では使えない。指定を無視する fallback は作らない。
+
+## context 設計
+
+direct mode でも既存 `transform` / `preflight` と同じ `-c, --context <JSON_FILE>` を受け付ける。context file は `crates/rulemorph_cli/src/input/files.rs` の既存 `load_context` を再利用して JSON として読み込む。
+
+`@context` は通常の expr 参照として扱う。したがって以下のすべてで利用できる。
+
+- `--rule '@context.tenant_id'`
+- `-F tenant='@context.tenant_id'`
+- `--output-map '{"tenant":"@context.tenant_id"}'`
+
+context は synthetic rule には埋め込まない。`transform_input_with_warnings_with_base_dir_and_options` の context 引数に `context_value.as_ref()` を渡す。context が指定されない場合は既存 direct mode と同じく `None` を渡す。
+
+`@context` は `@out` と違って mapping order に依存しないため、`--output-map` でも禁止しない。headerless CSV の numeric field reference detection では `@context.*` を入力列推定に使わない。
+
+context file の read / parse error は既存 `transform -c` と同じ扱いにする。`load_context` の現行 contract に合わせ、read error と JSON parse error は exit code `1` で返し、代表メッセージも既存の `failed to read context: ...` / `failed to parse context JSON: ...` を維持する。
+
+context file については MVP では direct mode 専用の size limit や strict JSON parser を追加しない。これは `transform -c/--context` と direct mode の parse behavior / error message を揃えるためであり、context だけ direct mode で異なる duplicate key handling や size error を持たせない。一般的なローカル CLI と同じく、ユーザー自身が明示した local file の大きさは基本的に OS / runner の resource limit に委ねる。
+
+ただし、rulemorph CLI を CI、server、MCP、Web UI などから呼び出し、第三者が context path または context file content を制御できる運用では、巨大 context による memory DoS や duplicate key による解釈差が security risk になりうる。その hardening は direct mode 専用ではなく、既存 `transform -c` も含めた共有 `load_context` contract の変更として扱う。将来対応する場合は `MAX_CONTEXT_BYTES` と strict JSON duplicate-key rejection を shared helper に追加し、direct / transform の両方で同じ error contract に更新する。
+
+## direct rule 生成
+
+`crates/rulemorph_cli/src/direct.rs` の `build_direct_rule` を、入力形式、direct input option、direct output spec を受け取る形に拡張する。
+
+direct output spec は内部的に次の 3 種類として扱う。
+
+- `Rule(expr)`: 既存 `--rule <EXPR>`
+- `Fields(Vec<FieldSpec>)`: `-F/--field <TARGET=EXPR>` の繰り返し
+- `OutputMap(Vec<FieldSpec>)`: `--output-map <JSON_OBJECT>` を key/value から展開したもの
+
+### `--rule`
+
+既存互換のため、`--rule` は synthetic target `__rulemorph_direct_value` に 1 mapping だけを書き込む。
+
+```json
+{
+  "version": 2,
+  "input": {
+    "format": "<format>",
+    "<format>": { "...": "..." }
+  },
+  "mappings": [
+    {
+      "target": "__rulemorph_direct_value",
+      "expr": "<parsed inline expr>"
+    }
+  ]
+}
+```
+
+`parse_rule_file_with_format(..., RuleFormat::Json)` は継続利用する。これにより validation / serde の `deny_unknown_fields` を通した同じ rule contract を使える。
+
+### `-F/--field`
+
+`-F/--field` は `TARGET=EXPR` を受け取る。split は最初の `=` だけで行う。
+
+例:
+
+```sh
+rulemorph -H "id,name,age" \
+  -F id="@input.id" \
+  -F name='["@input.name","trim","uppercase"]' \
+  -F age='["@input.age","int"]'
+```
+
+生成する mappings:
+
+```json
+[
+  { "target": "id", "expr": "@input.id" },
+  { "target": "name", "expr": ["@input.name", "trim", "uppercase"] },
+  { "target": "age", "expr": ["@input.age", "int"] }
+]
+```
+
+RHS は既存 `--rule` と同じ inline expr semantics に寄せる。つまり、JSON として parse できる値は JSON expr として扱い、JSON でなければ文字列 expr として扱う。`@input.age|int` のような CLI 独自ショートハンドは導入しない。
+
+ただし `-F/--field` の RHS が BOM / whitespace 後に `{` または `[` で始まる場合は JSON-looking expr とみなし、strict JSON parse に失敗したら literal string fallback せず CLI validation error にする。`["@input.age","int"` のような typo が文字列 literal として silently 出力されるのを避けるためである。`{` または `[` で始まる literal string が必要な場合は、既存 expr と同じく `lit:{...` / `lit:[...]` を使う。
+
+target に `=` を含めたい場合、`-F` では separator と衝突するため `--output-map` を使う。
+
+```sh
+rulemorph --output-map '{"user[\"a=b\"]":"@input.value"}'
+```
+
+`-F/--field` の指定順は synthetic `mappings` の評価順として維持する。したがって `@out` 参照を使う場合は、先に指定した field だけを参照できる。
+
+```sh
+rulemorph \
+  -F subtotal='["@input.items",{"map":["@item.price"]},"sum"]' \
+  -F total='["@out.subtotal",{"*":[1.1]}]'
+```
+
+文字列の扱いも既存 v2 expr に合わせる。
+
+- `@input.id` は参照
+- `["@input.age","int"]` は pipe
+- `lit:@input.id` は文字列リテラル `@input.id`
+- `lit:$` は文字列リテラル `$`
+- plain string は既存 expr の literal string として扱う
+
+### `--output-map`
+
+`--output-map` は strict JSON object を受け取り、object の key を `target`、value を `expr` として mappings を生成する。これは再帰的 JSON template ではなく、通常の `mappings` を短く書くための target-to-expr map である。
+
+例:
+
+```sh
+rulemorph -H "id,name,age" \
+  --output-map '{"user.id":"@input.id","user.name":["@input.name","trim"],"kind":"lit:user"}'
+```
+
+生成する mappings:
+
+```json
+[
+  { "target": "user.id", "expr": "@input.id" },
+  { "target": "user.name", "expr": ["@input.name", "trim"] },
+  { "target": "kind", "expr": "lit:user" }
+]
+```
+
+ネスト出力は既存 `target` path で表現する。たとえば `user.id` は `{ "user": { "id": ... } }` を作る。ドットを含む key を出力したい場合は既存 path と同じ bracket quote を使う。
+
+```json
+{
+  "user[\"full.name\"]": "@input.name"
+}
+```
+
+`--output-map` の value は通常の `expr` contract で解釈する。plain object は literal object として扱われるが、既存 `Expr` の shape に一致する `{"ref":"..."}` / `{"op":"...","args":[...]}` / `{"chain":[...]}` は v1 expr として扱われる。したがって `{"user":{"id":"@input.id"}}` は nested template ではなく、top-level target `user` の plain object literal expr であり、内部の `"@input.id"` は参照評価されず文字列値として出力される。混乱を避けるため、docs では nested output は target path で書くことを推奨する。
+
+expr shape に一致する object 自体を literal object として出力する direct sugar は今回追加しない。たとえば `{"ref":"input.id"}` という object literal をそのまま出したい場合は、direct mode の `--output-map` では表現せず、rule file の正式な mapping / expr 表現で扱う。将来必要になった場合は `--value TARGET=JSON` のような別 surface か、core expr 側の literal object 表現として設計する。
+
+top-level array は既存 v2 expr では pipe として解釈される。したがって `--output-map '{"tags":["a","b"]}'` は literal array ではなく pipe expr として扱われる。literal array 専用 sugar は今回追加しない。literal array が必要な場合は、既存 v2 expr の正式形として literal array を pipe start に置く。
+
+```json
+{
+  "tags": [["a", "b"]]
+}
+```
+
+### output spec validation
+
+CLI 側で以下を fail-closed にする。
+
+- `--rule`、`--output-map`、`-F/--field` の併用
+- `-F/--field` の `=` 不足
+- 空 target
+- 空 expr
+- `--output-map` が JSON object ではない
+- `--output-map` の空 object
+- strict JSON parse で拒否される output-map
+- output field 数の上限超過
+- output spec byte 数の上限超過
+- target byte 数の上限超過
+- target byte 数合計の上限超過
+- target path depth / target token 総数の上限超過
+- direct output cell 数の上限超過
+- expr JSON depth / node / string byte 数の上限超過
+- canonical target の重複
+- target の親子衝突
+- `--output-map` value 内の評価される `@out` 参照
+
+target の parse は core の `parse_path` と同じ規則を使う。array index を含む target は通常 mapping と同じく拒否する。`user.name` と `user["name"]` のように表記が違っても同じ path tokens になる場合は duplicate として拒否する。`user` と `user.name` のような親子関係は、評価順に依存する上書きや `target path conflicts with non-object value` を避けるため、CLI の synthetic rule 生成前に拒否する。
+
+output spec にも direct mode 専用上限を適用する。初期値は `MAX_DIRECT_OUTPUT_FIELDS = 10_000`、`MAX_DIRECT_OUTPUT_SPEC_BYTES = 8 MiB`、`MAX_DIRECT_OUTPUT_TARGET_BYTES = 256 KiB`、`MAX_DIRECT_OUTPUT_TARGET_BYTES_TOTAL = 8 MiB`、`MAX_DIRECT_OUTPUT_TARGET_DEPTH = 256`、`MAX_DIRECT_OUTPUT_TARGET_TOKENS_TOTAL = 1_000_000`、`MAX_DIRECT_OUTPUT_EXPR_DEPTH = 256`、`MAX_DIRECT_OUTPUT_EXPR_NODES = 1_000_000`、`MAX_DIRECT_OUTPUT_EXPR_STRING_BYTES = 8 MiB`、`MAX_DIRECT_OUTPUT_CELLS = 10_000_000` とする。これは巨大な `-F` 繰り返しや巨大 output-map key / expr から synthetic rule JSON / nested output path validation / `records * mappings` 評価を過剰に肥大化させないための guard である。
+
+`MAX_DIRECT_OUTPUT_CELLS` は record object output、つまり `-F/--field` と `--output-map` にだけ適用する。transform 前に、resolved input format と既存 `NormalizationOptions` の effective record limit から `effective_max_records * output_field_count` を見積もり、上限を超える場合は CLI validation error とする。JSON object input のように 1 record と判定できる入力は `1 * output_field_count` として扱う。MVP では output byte 数の精密な上限は追加せず、必要になった場合は shared `max_output_bytes` として別途設計する。
+
+`--output-map` は JSON object なので、target-to-expr map 自体に評価順の意味を持たせない。既存 `mappings` の `@out` は「前の mapping」への参照であり、object key order に依存させると validation / runtime の意味が揺れる。そのため `--output-map` value 内で評価される `@out` 参照は CLI 側で拒否する。順序依存が必要な場合は `-F/--field` を使う。plain literal object 内の文字列 `"@out.x"` は評価される ref ではないため、この禁止の対象外である。
+
+## CSV 設計
+
+### header あり CSV
+
+条件:
+
+- `--headers` がない
+- direct output spec の expr 群に root numeric field reference がない
+
+生成する input:
+
+```json
+{
+  "format": "csv",
+  "csv": {
+    "has_header": true
+  }
+}
+```
+
+例:
+
+```sh
+rulemorph -rule "@input.id" -i with_header.csv
+```
+
+### headerless CSV + 明示 headers
+
+条件:
+
+- `--headers id,name,age` がある
+
+生成する input:
+
+```json
+{
+  "format": "csv",
+  "csv": {
+    "has_header": false,
+    "columns": [
+      { "name": "id" },
+      { "name": "name" },
+      { "name": "age" }
+    ]
+  }
+}
+```
+
+validation:
+
+- `--headers` は 1 つの CSV record として parse する。空白は field name の一部として扱い、trim しない。たとえば `-H "id, name, age"` は `id` / ` name` / ` age` になるため、通常は `-H "id,name,age"` を使う。
+- header 名に comma を含めたい場合は CSV と同じ quote を使う。例: `-H 'id,"display,name",age'`
+- 空 header は CLI 側で拒否する。
+- 重複 header は CLI 側でも拒否してよいが、core validation / normalization でも拒否される。
+- header 数は direct mode 専用上限 `MAX_DIRECT_TABULAR_FIELDS` 以下でなければならない。
+- header 名は 1 個あたり `MAX_DIRECT_TABULAR_HEADER_BYTES` 以下、合計で `MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL` 以下でなければならない。
+- delimiter は今回 CLI surface に追加しない。既存 default `,` を使う。
+
+### headerless CSV + numeric field 推定
+
+条件:
+
+- `--headers` がない
+- direct output spec の expr 群に root numeric field reference がある
+
+例:
+
+- `@input.0`
+- `["@input.0", { "concat": ["-", "@input.1"] }]`
+
+この場合、input bytes の先頭 CSV record を読み、field 数から `"0"`, `"1"`, ... の columns を生成する。
+
+先頭 record の読み取りは core CSV normalization と同じ `csv` crate semantics を使う。実装は、`rulemorph_cli` に `csv = "1.3"` を追加して direct mode の推定にだけ使う。CSV reader が record を読めない入力は推定成功として扱わず、transform 前の入力エラーとして fail-closed にする。
+
+生成例:
+
+```json
+{
+  "format": "csv",
+  "csv": {
+    "has_header": false,
+    "columns": [
+      { "name": "0" },
+      { "name": "1" },
+      { "name": "2" }
+    ]
+  }
+}
+```
+
+`@input.0` は path parser 上は key `"0"` への参照になるため、既存 evaluator を変更せず動作する。
+
+先頭 record が読めない、または field 数が 0 の場合は direct mode の入力エラーとして終了する。
+
+推定した field 数が direct mode 専用上限 `MAX_DIRECT_TABULAR_FIELDS` を超える場合も入力エラーとして終了する。これは大量 delimiter を含む 1 行入力から巨大な synthetic rule / `columns` vector を生成しないための fail-closed guard である。
+
+`MAX_DIRECT_TABULAR_FIELDS` は初期実装では `10_000` とする。これは public API には出さず、`crates/rulemorph_cli/src/direct.rs` の direct mode guard として持つ。将来、core normalization 全体の CSV field 数上限が必要になった場合は `NormalizationOptions` 側に `max_csv_fields` を追加して統合する。
+
+`MAX_DIRECT_TABULAR_HEADER_BYTES` は初期実装では `256 KiB`、`MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL` は `8 MiB` とする。これらも direct mode guard として持ち、synthetic rule JSON の過剰な肥大化を防ぐ。
+
+### numeric field reference の検出
+
+direct output spec に含まれる expr から、実際に評価される root numeric input reference だけを検出する。
+
+- `--rule` は 1 つの expr
+- `-F/--field` は各 field RHS の expr
+- `--output-map` は各 target value の expr
+
+検出は raw JSON string の再帰走査ではなく、既存 expr semantics に寄せる。実装では、expr value を `rulemorph::Expr` として読める場合は `Expr` を走査し、v2-looking literal は `rulemorph::v2_parser::parse_v2_expr` で `V2Expr` にしてから参照を走査する。plain literal object の内側にある `"@input.0"` のような文字列は評価される ref ではないため、numeric field inference には使わない。
+
+検出対象:
+
+- v2 `@input.<digits>`
+- v2 `@input.<digits>.` で始まる参照
+- v2 `@input.<digits>[` で始まる参照
+- v1 `{"ref":"input.<digits>"}` 系の input ref
+
+`<digits>` は canonical decimal とし、`0` または non-zero digit で始まる digit sequence だけを numeric field inference 対象にする。`@input.01` のような leading zero は列名 `"01"` への通常参照として扱い、headerless numeric inference は起動しない。
+
+`@input["0"]` は今回の必須条件には含めない。ただし将来拡張してもよい。
+
+この検出は headerless 推定のためだけに使い、実際の参照解決は既存 parser/evaluator に任せる。
+
+## Excel 設計
+
+Excel direct input では以下を必須にする。
+
+- `--excel-header-row <ROW>`
+- `--excel-data-range <RANGE>`
+
+`--excel-data-range` はユーザー向けには data range として定義する。たとえば `--excel-header-row 1 --excel-data-range A2:C100` は「1 行目を header、2-100 行目を data」と読む。
+
+core の `input.excel.range` は header row を含む selected cell window として扱われるため、CLI では data range を core range に変換する。
+
+例:
+
+```sh
+rulemorph -i users.xlsx -rule "@input.id" \
+  --excel-header-row 1 \
+  --excel-data-range A2:C100
+```
+
+生成する input:
+
+```json
+{
+  "format": "excel",
+  "excel": {
+    "has_header": true,
+    "header_row": 1,
+    "data_start_row": 2,
+    "range": "A1:C100"
+  }
+}
+```
+
+sheet 指定:
+
+- `--excel-sheet Users` -> `"sheet": "Users"`
+- `--excel-sheet-index 0` -> `"sheet": 0`
+- 両方指定された場合は CLI parse / validation error
+- どちらもない場合は core default の最初の sheet
+
+### Excel data range 変換
+
+CLI は `A2:C100` 形式を受ける。列だけの `A:C` は data start row が決まらないため direct mode では拒否する。
+
+変換:
+
+1. data range を start column / start row / end column / end row に parse する。
+2. `header_row` が 1-based positive であることを確認する。
+3. `header_row < data_start_row` であることを確認する。
+4. core range を `<start_col><header_row>:<end_col><end_row>` にする。
+5. `data_start_row` に data range の start row を入れる。
+
+`--excel-data-range A2:C100 --excel-header-row 1` は core range `A1:C100` に変換される。
+
+`--excel-data-range B5:F20 --excel-header-row 4` は core range `B4:F20` に変換される。
+
+`--excel-data-range A1:C100 --excel-header-row 1` は header row と data start row が同じなので拒否する。
+
+## direct output unwrap
+
+既存 direct mode は JSON object input だけ単一出力を unwrap し、array input は配列を維持する。
+
+`--rule` は既存 direct value output として扱う。CSV / Excel direct convenience mode では、tabular input の結果を以下のようにする。
+
+- 0 records -> `[]`
+- 1 record -> direct value に unwrap
+- 2 records 以上 -> direct value の配列
+
+convenience mode とは、以下のいずれかに該当する場合を指す。
+
+- `-f` なしで CSV / Excel と推定された場合
+- `--headers` を指定した CSV direct input
+- `--excel-*` を指定した Excel direct input
+- `-f excel` を指定した Excel direct input
+
+既存互換のため、`-f csv` だけを指定し、新しい tabular option を指定しない direct mode は legacy CSV mode として扱い、現行どおり単一 record でも配列を維持する。
+
+例:
+
+```sh
+echo "a,test,1" | rulemorph -rule "@input.0"
+# => "a"
+
+printf "a,test,1\nb,demo,2\n" | rulemorph -rule "@input.0"
+# => ["a","b"]
+
+printf "id\na\n" | rulemorph -f csv -rule "@input.id"
+# => ["a"]
+```
+
+`-F/--field` と `--output-map` は record object output として扱う。この場合、synthetic target `__rulemorph_direct_value` は使わず、通常 mappings の出力 object をそのまま返す。
+
+convenience mode では以下を返す。
+
+- 0 records -> `[]`
+- 1 record -> object
+- 2 records 以上 -> object array
+
+legacy CSV mode、つまり `-f csv` だけを指定し、新しい tabular input option を指定しない direct mode では、`-F/--field` / `--output-map` でも単一 record を unwrap せず object array を維持する。これは `--rule` の legacy CSV presentation と揃え、出力 shape を安定させたい場合の逃げ道にする。
+
+例:
+
+```sh
+printf "u1,Alice,42\nu2,Bob,30\n" | rulemorph -H "id,name,age" \
+  -F id="@input.id" \
+  -F name="@input.name"
+# => [{"id":"u1","name":"Alice"},{"id":"u2","name":"Bob"}]
+
+printf "id,name\nu1,Alice\n" | rulemorph -f csv \
+  -F id="@input.id" \
+  -F name="@input.name"
+# => [{"id":"u1","name":"Alice"}]
+```
+
+JSON array input に対する `-F/--field` / `--output-map` も record object array を返す。JSON object input は 1 record として object を返す。
+
+この unwrap は direct mode の presentation layer のみで行い、core transform result は変更しない。
+
+## エラー設計
+
+CLI option validation のエラーは exit code `2` とする。
+
+互換性維持のため、既存 `--rule` inline expr parse failure は現行 direct mode と同じ exit code `1` を維持する。一方、`-F/--field` と `--output-map` の output spec validation、format-specific option mismatch、Excel data range validation は exit code `2` とする。
+
+代表的なメッセージ:
+
+- `exactly one of --rule, --output-map, or --field is required`
+- `--field must be TARGET=EXPR`
+- `--field target must not be blank`
+- `--field expr must not be blank`
+- `--output-map must be a JSON object`
+- `--output-map must define at least one field`
+- `direct output target is duplicated`
+- `direct output target conflicts with another target`
+- `direct output has too many fields`
+- `direct output spec must be at most ... bytes`
+- `direct output target path is invalid`
+- `direct output target path must not include indexes`
+- `direct output target names must be at most ... bytes each`
+- `direct output target names total size must be at most ... bytes`
+- `direct output target path exceeds configured depth limit`
+- `direct output target paths have too many tokens`
+- `direct output cells must be at most ...`
+- `direct output expr exceeds configured depth limit`
+- `direct output expr has too many nodes`
+- `direct output expr string values must be at most ... bytes each`
+- `--field expr looks like JSON but failed to parse`
+- `--output-map does not support @out references; use --field for ordered mappings`
+- `--headers must not contain blank field names`
+- `--headers must be unique`
+- `--headers requires CSV direct input`
+- `--headers has too many fields`
+- `--headers field names must be at most ... bytes each`
+- `--headers total size must be at most ... bytes`
+- `--excel-data-range is required for Excel direct input`
+- `--excel-header-row is required for Excel direct input`
+- `--excel-data-range is the data range and must start after --excel-header-row; use A2:C100 when --excel-header-row is 1`
+- `--excel-* options require Excel direct input`
+- `--excel-sheet and --excel-sheet-index cannot be used together`
+- `failed to infer CSV columns: input has no records`
+- `failed to infer CSV columns: ...`
+
+core normalization / transform のエラーは既存どおり `emit_transform_error` を通す。JSON 形式に見える stdin input が parse に失敗した場合は、形式推定後に JSON normalization が失敗するため、既存の transform error として exit code `3` で返す。`-f csv` を明示すれば CSV として処理できることは docs に明記する。
+
+context file の read / parse error は既存 `transform -c` と同じく exit code `1` とする。代表メッセージは `failed to read context: ...` / `failed to parse context JSON: ...` を維持する。
+
+## 実装手順
+
+1. direct mode 専用 option 型を追加する。
+   - `DirectInputFormat`: `Json` / `Csv` / `Excel`
+   - `DirectInputOptions`: headers / excel data range / header row / sheet
+   - `DirectOutputSpec`: rule / fields / output-map
+   - `DirectArgs`: context path を追加する。
+   - top-level `Cli` に direct-only options を追加する。
+
+2. `has_direct_options` を更新する。
+   - 新 direct-only options が subcommand 前に置かれた場合、`direct-mode options require --rule, --output-map, or --field and cannot be used before a subcommand` のように direct output spec を要求する message で拒否する。
+   - `--output-map` / `-F/--field` / `-c/--context` も direct mode 判定に含める。
+   - top-level dispatch は `rule: Option<String>` だけでなく `DirectOutputSpec` の有無で direct mode に入る。`-F` または `--output-map` 単独でも direct mode として処理し、direct-only option だけで output spec がない場合は help fallback ではなく validation error にする。
+
+3. direct output spec parser を追加する。
+   - `direct.rs` 本体が入力検出 / 実行 / presentation を持ち、`direct/output_spec.rs` が output spec の parsing / validation / evaluated-ref scan を持つ構成にする。
+   - `--rule` / `--output-map` / `-F` の排他 validation
+   - `-F TARGET=EXPR` parser
+   - `--output-map` strict JSON object parser
+   - target parse / duplicate / parent-child conflict validation
+   - output spec / target byte / target path depth / target token total / output cell / expr の direct mode 専用 resource guard
+   - `--output-map` の評価される `@out` 参照拒否
+   - `scan_evaluated_refs(expr) -> { input_numeric_refs, out_refs }` のような helper を作り、CSV numeric inference と `--output-map` の `@out` rejection で共有する。raw JSON string の再帰走査には戻さない。
+   - `--rule` は既存 inline expr parser を再利用する。
+   - `-F` RHS は inline expr semantics に寄せつつ、`{` / `[` で始まる JSON-looking value の strict parse failure は literal fallback せず error にする。
+   - `--output-map` value は strict JSON parse 済みの `serde_json::Value` をそのまま expr value として使う。
+
+4. direct rule builder を output spec 対応にする。
+   - `--rule` は `__rulemorph_direct_value` target を生成する。
+   - `-F` / `--output-map` は通常 mappings を生成する。
+   - `DirectOutputMode::Value` / `DirectOutputMode::RecordObject` を分け、unwrap に渡す。
+
+5. direct mode context loading を追加する。
+   - top-level `-c/--context` を `DirectArgs` に渡す。
+   - 既存 `load_context` を再利用する。
+   - `transform_input_with_warnings_with_base_dir_and_options` に `context_value.as_ref()` を渡す。
+   - context 未指定時は `None` を維持する。
+   - MVP では direct mode 専用の context size limit / strict JSON duplicate-key rejection は追加しない。将来 hardening は `load_context` の共有 contract 変更として direct / transform の両方に適用する。
+
+6. format 推定を `direct.rs` に寄せる。
+   - 明示 `-f`
+   - `-i -` は stdin 扱い
+   - `-i` extension
+   - unknown extension / no extension は JSON default
+   - stdin leading-token classification
+   - JSON-looking stdin input は parse failure で fail-closed
+   - CSV / Excel 専用 option と resolved format の不一致は fail-closed
+
+7. CSV rule config builder を追加する。
+   - `--headers` parser
+   - `MAX_DIRECT_TABULAR_FIELDS` guard
+   - `MAX_DIRECT_TABULAR_HEADER_BYTES` / `MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL` guard
+   - `Expr` / `V2Expr` semantics に沿った root numeric field reference detector
+   - headerless numeric columns inference
+   - core と同じ CSV parser semantics で先頭 record を読む
+
+8. Excel rule config builder を追加する。
+   - Excel direct input required options validation
+   - data range parser
+   - core range conversion
+   - sheet / sheet index serialization
+
+9. direct output unwrap を tabular input と object output spec に拡張する。
+   - JSON object は既存どおり unwrap
+   - CSV / Excel convenience mode は transform output record 数で unwrap
+   - legacy `-f csv` は単一 record でも配列を維持
+   - `-F` / `--output-map` は 1 record object、multi record object array を返す。
+
+10. docs を更新する。
+   - `README.md`
+   - `docs/rules_spec_ja.md`
+   - `docs/rules_spec_en.md`
+   - `-F/--field`、`--output-map`、direct `-c/--context`、`--output-map` での `@out` 禁止、literal array の正式形、JSON/CSV/Excel の output shape を同期する。
+
+## テスト計画
+
+Rust 実装を変更するため、最終確認は以下を実行する。
+
+```sh
+cargo fmt
+cargo test
+```
+
+追加する CLI integration tests:
+
+- stdin headerless CSV:
+  - `echo "a,test,1" | rulemorph -rule "@input.0"` -> `"a"`
+  - `echo "a,test,1" | rulemorph -F id=@input.0` -> `{"id":"a"}`
+  - `echo "a,test,1" | rulemorph --output-map '{"id":"@input.0"}'` -> `{"id":"a"}`
+  - v1 ref expr `{"ref":"input.0"}` also triggers headerless inference
+  - `@input.01` does not trigger headerless inference and remains a normal key ref
+- stdin CSV with explicit headers:
+  - `echo "a,test,1" | rulemorph -H "id,name,age" -rule "@input.id"` -> `"a"`
+- `-i` CSV with explicit headers:
+  - headerless temp file + `-H` -> `"a"`
+- `-i` CSV with file header:
+  - header temp file without `-H` -> `"a"`
+- multiple CSV rows:
+  - output is array
+- legacy explicit `-f csv`:
+  - `printf "id\na\n" | rulemorph -f csv -rule "@input.id"` -> `["a"]`
+- unknown extension / no extension `-i`:
+  - `-i data.txt` without `-f` uses JSON default
+  - `-i data` without `-f` uses JSON default
+- `-i -`:
+  - uses stdin leading-token classification
+- JSON-looking malformed stdin:
+  - returns transform error exit code `3`
+- invalid `--headers`:
+  - blank name
+  - duplicate name
+  - too many names
+  - oversized name / total header bytes
+  - spaces are significant: `-H "id, name"` does not trim the second field
+  - quoted comma is parsed as one header name
+- format-specific option mismatch:
+  - `--headers` with JSON / Excel is rejected
+  - `--excel-*` with JSON / CSV is rejected
+- headerless CSV inference with too many fields:
+  - excessive comma count is rejected before synthetic rule generation
+- malformed CSV headerless inference:
+  - CSV reader が先頭 record を読めない入力は synthetic rule generation 前に拒否する
+- `.xlsx` direct input with header row / data range:
+  - existing `t34_excel_input/input.xlsx` fixture with a single-row data range returns scalar
+  - existing `t34_excel_input/input.xlsx` fixture with a multi-row data range returns array
+  - stdin Excel bytes require explicit `-f excel`
+  - sheet selection by name works
+  - sheet selection by index works
+  - offset data range such as `B5:F20` converts to the expected core range
+  - column-only range such as `A:C` is rejected
+  - reversed range such as `C2:A10` or `A10:C2` is rejected
+- direct context:
+  - `--rule '@context.tenant_id' -c context.json` -> context value
+  - `-F tenant=@context.tenant_id -c context.json` -> object with context value
+  - `--output-map '{"tenant":"@context.tenant_id"}' -c context.json` -> object with context value
+  - `@context.*` does not trigger headerless CSV numeric inference
+  - invalid context JSON returns existing `failed to parse context JSON:` error and exit code `1`
+  - missing context file returns existing `failed to read context:` error and exit code `1`
+  - duplicate-key context JSON follows existing `load_context` behavior in MVP and observes the same value as `transform -c`
+  - context size limit is not added in direct mode only
+  - `-c/--context` before a subcommand without direct output spec is rejected as a direct-only option placement error
+- `-F/--field` output:
+  - single CSV row + `-F id=@input.id -F name=@input.name` -> object
+  - multiple CSV rows + repeated `-F` -> object array
+  - JSON object input + `-F` -> object
+  - JSON array input + `-F` -> object array
+  - pipe expr RHS: `-F name='["@input.name","trim","uppercase"]'`
+  - JSON-looking malformed RHS such as `-F name='["@input.name","trim"'` is rejected instead of emitted as a literal string
+  - literal string starting with `{` or `[` is represented through `lit:` and is not rejected
+  - literal string escape: `-F label=lit:@input.id` -> `"@input.id"`
+  - ordered `@out` dependency: second `-F` can read first `-F`
+  - nested target path: `-F user.id=@input.id`
+  - bracket-quoted target path: `-F 'user["full.name"]=@input.name'`
+  - target containing `=` is represented through `--output-map`, not `-F`
+  - explicit `-f csv` without new tabular input option returns object array even for one record
+- `--output-map` output:
+  - target-to-expr map with scalar refs -> object
+  - target-to-expr map with pipe array -> object
+  - JSON object input + `--output-map` -> object
+  - JSON array input + `--output-map` -> object array
+  - nested output via target path key: `"user.id"`
+  - bracket-quoted target path key: `"user[\"full.name\"]"`
+  - plain object value is literal expr, not nested template:
+    `--output-map '{"user":{"id":"@input.id"}}'` outputs `{"user":{"id":"@input.id"}}`
+  - expr-shaped object values follow existing expr contract:
+    `{"ref":"input.id"}` and `{"op":"uppercase","args":[{"ref":"input.name"}]}` are evaluated as expr shapes, not plain literal objects
+  - expr-shaped object literal collision is documented as unsupported in direct sugar
+  - literal array uses existing pipe-start form:
+    `--output-map '{"tags":[["a","b"]]}'` outputs `{"tags":["a","b"]}`
+  - evaluated `@out` reference is rejected in `--output-map`
+  - evaluated `@out` rejection covers v1 `{"ref":"out.x"}` and v2 nested pipe / condition / map argument positions
+  - evaluated `@context` reference is allowed in `--output-map`
+  - literal object containing `"@out.x"` as plain string is not rejected as an evaluated ref
+  - literal object containing `"@input.0"` as plain string does not trigger headerless numeric inference
+- direct output spec conflicts:
+  - `--rule` + `-F` is rejected
+  - `--rule` + `--output-map` is rejected
+  - `--output-map` + `-F` is rejected
+  - no `--rule` / `--output-map` / `-F` before direct-only input options is rejected
+- invalid `-F/--field`:
+  - missing `=`
+  - blank target
+  - blank expr
+  - duplicate canonical target
+  - parent-child target conflict
+  - array index target
+  - too many fields
+  - oversized output spec bytes
+  - oversized target / total target bytes
+  - excessive target path depth / target token total
+  - excessive direct output cells
+  - excessive expr depth / nodes / string bytes
+- invalid `--output-map`:
+  - invalid JSON
+  - non-object JSON
+  - empty object
+  - duplicate key rejected by strict JSON parser
+  - duplicate canonical target
+  - parent-child target conflict
+  - array index target
+  - too many fields
+  - oversized output spec bytes
+  - oversized target / total target bytes
+  - excessive target path depth / target token total
+  - excessive direct output cells
+  - excessive expr depth / nodes / string bytes
+- Excel missing required option:
+  - missing `--excel-data-range`
+  - missing `--excel-header-row`
+- Excel invalid range/header combination:
+  - header row is same as data start row
+- Excel invalid range parser inputs:
+  - huge column letters / row numbers are rejected without panic
+- `--excel-sheet` and `--excel-sheet-index` conflict
+- direct-only options before subcommand are rejected
+
+## 互換性
+
+- 既存 direct JSON behavior は維持する。
+- 既存 `--rule` behavior は維持する。`--output-map` / `-F` は新しい output spec として追加する。
+- 既存 `-f csv` direct behavior は維持する。`-f csv` だけを指定し、新しい tabular option を指定しない場合は、1 row でも配列を出す。
+- `--output-map` は既存 `mappings` の target / expr contract に寄せる。key は `target`、value は `expr` であり、再帰的 JSON template ではない。
+- plain string は既存 expr と同じく literal string として扱う。`@...` や `$` を literal string にしたい場合は既存 v2 expr の `lit:` を使う。`$literal` / `$expr` のような direct mode 専用 wrapper は追加しない。
+- direct mode の `-c/--context` は既存 `transform -c/--context` と同じ JSON file 読み込みを使う。context の parse behavior や error message は既存 helper に揃え、direct mode 専用の strict JSON parser は導入しない。
+- direct mode の `-c/--context` に direct 専用 size limit は追加しない。context hardening が必要になった場合は、既存 `transform -c` との挙動差を作らず、共有 `load_context` の contract として導入する。
+- `-F` RHS だけは typo が output value に silent fallback しやすいため、`{` / `[` で始まる JSON-looking malformed value を新規 error として扱う。`--rule` の既存 inline expr 互換は維持する。
+- `@input.age|int` のような CLI 独自ショートハンドは追加しない。
+- `-f` なし stdin で JSON 形式に見えない入力は、従来の JSON parse error ではなく CSV direct convenience mode として処理される。これは今回の受け入れ条件に含める。
+- `-i` の未知拡張子 / 拡張子なしは既存互換のため JSON default を維持する。`-i -` は stdin と同じ判定を使う。
+- `transform` / `preflight` の `-f` は変更しないため、rule file based workflow への影響はない。
+- raw output は追加しないため、string output は JSON string のまま。
+
+## リスクと対策
+
+### stdin auto-detect が JSON typo を CSV と誤認する
+
+JSON parse の成否で形式判定すると、JSON typo や limit 超過を CSV として処理してしまう可能性がある。また、判定目的の全体 parse が本処理とは別の CPU / memory 消費を作る。
+
+対策:
+
+- stdin auto-detect は全体 parse ではなく、BOM / whitespace 後の先頭バイトだけを見る。
+- `{` または `[` で始まる入力は JSON として扱い、parse failure 時は CSV fallback せず error にする。
+- CSV が `{` または `[` で始まる場合は `-f csv` を明示する。
+
+### headerless CSV inference が巨大な synthetic rule を作る
+
+headerless CSV の numeric field 推定では、先頭 record の field 数から `columns` を生成する。大量 delimiter を含む 1 行入力を許すと、巨大な synthetic rule / `columns` vector を作る可能性がある。
+
+対策:
+
+- `--headers` の header 数と inferred field 数に direct mode 専用上限 `MAX_DIRECT_TABULAR_FIELDS` を適用する。
+- header 名 1 個あたりの byte 数と header 名合計 byte 数にも direct mode 専用上限を適用する。
+- 初期値は `MAX_DIRECT_TABULAR_FIELDS = 10_000`、`MAX_DIRECT_TABULAR_HEADER_BYTES = 256 KiB`、`MAX_DIRECT_TABULAR_HEADER_BYTES_TOTAL = 8 MiB` とし、超過時は transform 前の CLI validation error とする。
+- テストに excessive field count、oversized header、malformed first CSV record の拒否を追加する。
+
+### `-F` / `--output-map` が巨大な synthetic mappings を作る
+
+大量の `-F` や巨大な output-map key を許すと、core validation 前に synthetic rule JSON / mappings vector が肥大化する。
+
+対策:
+
+- output field 数に `MAX_DIRECT_OUTPUT_FIELDS = 10_000` を適用する。
+- output spec 全体に `MAX_DIRECT_OUTPUT_SPEC_BYTES = 8 MiB` を適用する。
+- target 名 1 個あたり `MAX_DIRECT_OUTPUT_TARGET_BYTES = 256 KiB`、target 名合計 `MAX_DIRECT_OUTPUT_TARGET_BYTES_TOTAL = 8 MiB` を適用する。
+- target path 1 個あたり `MAX_DIRECT_OUTPUT_TARGET_DEPTH = 256`、target path token 合計 `MAX_DIRECT_OUTPUT_TARGET_TOKENS_TOTAL = 1_000_000` を適用する。
+- direct output cell 数に `MAX_DIRECT_OUTPUT_CELLS = 10_000_000` を適用する。これは `effective_max_records * output_field_count` で見積もる。
+- expr JSON に `MAX_DIRECT_OUTPUT_EXPR_DEPTH` / `MAX_DIRECT_OUTPUT_EXPR_NODES` / `MAX_DIRECT_OUTPUT_EXPR_STRING_BYTES` を適用する。
+- 超過時は transform 前の CLI validation error とする。
+- output byte 数は実データ依存で事前見積もりしづらいため、MVP では byte 専用の新上限は追加しない。必要になった場合は shared `max_output_bytes` として設計する。
+- テストに excessive output fields、oversized spec、oversized target、total target bytes、excessive target depth / token total、excessive output cells、excessive expr shape の拒否を追加する。
+
+### context JSON の size / duplicate key は MVP では既存互換を優先する
+
+一般的なローカル CLI では、ユーザーが明示した file の大きさを必ず application-level limit で拒否するとは限らない。`rulemorph` direct mode でも、context file はユーザーが `-c/--context` で明示する local file であり、MVP では既存 `transform -c` と同じ `load_context` behavior を使う。
+
+対策:
+
+- direct mode 専用の context size limit / duplicate-key rejection は追加しない。
+- この判断は「ローカル CLI で本人が実行する」前提では主に robustness / UX の問題であり、ただちに高 severity の脆弱性とは扱わない。
+- CI、server、MCP、Web UI などで第三者が context path または context content を制御できる場合は DoS / parser ambiguity risk になりうるため、運用側では OS / runner の memory / file size 制限を併用する。
+- 将来 hardening する場合は direct mode だけでなく `transform -c` も含め、共有 `load_context` に `MAX_CONTEXT_BYTES` と strict JSON duplicate-key rejection を追加する。
+
+### `-i` / `-o` / `-c` path を未信頼入力として渡す
+
+ローカル CLI では `-i` / `-o` / `-c` が local file path を読む / 書くのは期待どおりである。一方、CI、server、MCP、Web UI などの wrapper が第三者入力をそのまま path option に渡すと、任意 local file read や意図しない output overwrite の surface になる。
+
+対策:
+
+- stdin の内容は file path として扱わない。`echo non_header.csv | rulemorph ...` はあくまで文字列 input であり、file read しない。
+- 未信頼ユーザーに path option を直接渡させる運用は scope 外とする。
+- wrapper 経由で使う場合は stdin / temporary sandbox file / allowlist path に限定する。
+- output path も sandbox 内に制限し、既存 file 上書きの扱いは呼び出し側 policy で決める。
+
+### JSON-looking な `-F` RHS typo が literal string に fallback する
+
+既存 inline expr parser と完全に同じ fallback を `-F` RHS に適用すると、`["@input.age","int"` のような壊れた JSON array が literal string として出力され、変換漏れに気づきにくい。
+
+対策:
+
+- `-F/--field` の RHS は BOM / whitespace 後の先頭 byte が `{` または `[` の場合、strict JSON parse failure を CLI validation error とする。
+- `--rule` は既存互換のため現行 inline expr parser behavior を維持する。
+- `{` または `[` で始まる literal string は `lit:{...` / `lit:[...]` と書く。
+- テストに malformed JSON-looking RHS の拒否と `lit:` による literal escape を追加する。
+
+### headerless numeric detection が literal 文字列を ref と誤認する
+
+numeric field reference detection が raw JSON string を再帰走査すると、plain literal object 内の `"@input.0"` まで評価される ref と誤認し、header あり CSV を headerless として扱う可能性がある。
+
+対策:
+
+- detection は `Expr` / `V2Expr` semantics に寄せ、評価される参照だけを見る。
+- plain literal object の内側にある ref 風文字列は検出対象外にする。
+- 実際の rule parse / eval は既存 parser/evaluator に任せる。
+- detection 対象は `@input.0` 系と v1 `input.0` 系に限定し、曖昧な構文には踏み込まない。
+
+### Excel CLI range と core range の意味が違う
+
+CLI の `--excel-data-range` は data range、core の `input.excel.range` は selected cell window である。
+
+対策:
+
+- CLI builder で必ず core range に変換する。
+- docs では direct mode の `--excel-data-range` を data range と明記する。
+
+### `--output-map` が nested template と誤読される
+
+`--output-map '{"user":{"id":"@input.id"}}'` を `{ "user": { "id": "u1" } }` と期待する可能性がある。しかし、既存構文に寄せるなら `--output-map` の key は target、value は expr であり、plain object value は object literal expr である。
+
+対策:
+
+- docs / examples では nested output を `"user.id": "@input.id"` と書く。
+- `--output-map` は「JSON template」ではなく「target-to-expr map」と説明する。
+- 再帰テンプレート展開は今回入れない。
+
+### `--output-map` で `@out` の順序依存が発生する
+
+既存 `mappings` の `@out` は「前に評価済みの output」だけを参照できる。`--output-map` は JSON object の target-to-expr map であり、object key order を評価順として意味づけると、parser / serializer / 将来実装の差で挙動が揺れる。
+
+対策:
+
+- `--output-map` value 内の評価される `@out` 参照は拒否する。
+- 順序依存が必要な場合は `-F/--field` を使い、CLI 指定順を mappings order として維持する。
+- plain literal object 内の `"@out.x"` は評価される ref ではないため拒否対象外とする。
+
+### literal array と pipe array が衝突する
+
+既存 v2 expr では top-level array は pipe として解釈される。そのため `--output-map '{"tags":["a","b"]}'` は literal array ではなく pipe expr になる。
+
+対策:
+
+- 今回は literal array 専用 sugar を追加しない。
+- array literal が必要な場合は、既存 v2 expr の正式形として `{"tags":[["a","b"]]}` のように literal array を pipe start に置く。
+- 将来より読みやすい記法を入れる場合は、CLI 独自 wrapper より先に core expr 側の literal array 表現を設計する。
+
+### target 表記ゆれで duplicate / conflict が見えづらい
+
+`user.name` と `user["name"]` は同じ target だが、単純な文字列比較では重複を検出できない。また `user` と `user.name` は実行順で挙動が変わる。
+
+対策:
+
+- CLI output spec parser で target を `PathToken` に正規化して比較する。
+- duplicate canonical target はエラーにする。
+- 親子 target conflict もエラーにする。
+- array index target は既存 mapping と同じく拒否する。
+
+## 将来拡張
+
+- `--raw-output` による raw string output
+- `--delimiter` による CSV delimiter 指定
+- headerless Excel direct input
+- `@input["0"]` を含めた numeric field detector 拡張
+- `transform` / `preflight` への input option override
+- `--output-map` の再帰テンプレート展開
+- literal array を安全に表す expr / output-map 記法
+- `@input.age|int` などの CLI shorthand

--- a/docs/rules_spec_en.md
+++ b/docs/rules_spec_en.md
@@ -821,7 +821,63 @@ Direct mode uses the normal v2 `expr` syntax. Use a pipe array when chaining ope
 echo '{ "a": 1, "b": 2 }' | rulemorph --rule '["@input.a", {"+": ["@input.b"]}]'
 ```
 
-Direct mode defaults to JSON input. Pass `-f csv` for CSV input. `--limit`, `--limits-profile`, and `--limits-file` apply the same resource limits as `transform`. `--rule` cannot be used with a subcommand, and direct-mode top-level options placed before a subcommand are rejected.
+Direct mode resolves the input format from `-f/--format`, then the `-i` extension, then the first stdin token. Stdin is JSON when the first byte after UTF-8 BOM and ASCII whitespace is `{` or `[`; otherwise it is CSV. Unknown or missing `-i` extensions stay JSON for compatibility. If CSV data starts with `{` or `[`, pass `-f csv`.
+
+For CSV direct input, a headered `.csv` file can be referenced by field name. Headerless CSV can either infer numeric fields from references such as `@input.0`, or receive field names with `-H/--headers`. `-h` remains the help option, so the short headers option is `-H`.
+
+```sh
+echo 'a,test,1' | rulemorph -rule '@input.0'
+echo 'a,test,1' | rulemorph -H 'id,name,age' -rule '@input.id'
+rulemorph -H 'id,name,age' -rule '@input.id' -i non_header.csv
+rulemorph -rule '@input.id' -i with_header.csv
+```
+
+Direct mode can use the same pipe operators as normal `expr`.
+
+```sh
+echo 'a,test,1' | rulemorph -rule '["@input.0", {"concat": ["-", "@input.1"]}]'
+# => "a-test"
+
+echo 'u1, Alice ,42' | rulemorph -H 'id,name,age' -rule '["@input.name", "trim", "uppercase"]'
+# => "ALICE"
+```
+
+For multiple output fields in direct mode, repeat `-F/--field <TARGET=EXPR>` or pass `--output-map <JSON_OBJECT>`. Both are sugar for normal `mappings`: the target is the output path, and the expr is the same v2 `expr` value used elsewhere. `--rule`, `-F/--field`, and `--output-map` are mutually exclusive.
+
+```sh
+echo 'u1,Alice,42' | rulemorph -H 'id,name,age' \
+  -F id='@input.id' \
+  -F name='["@input.name","uppercase"]' \
+  -F kind='lit:user'
+# => {"id":"u1","kind":"user","name":"ALICE"}
+
+echo 'u1,Alice,42' | rulemorph -H 'id,name,age' \
+  --output-map '{"user.id":"@input.id","user.name":["@input.name","uppercase"],"kind":"lit:user"}'
+# => {"kind":"user","user":{"id":"u1","name":"ALICE"}}
+```
+
+`-F/--field` preserves CLI argument order as mapping order, so a later field can reference an earlier field through `@out.*`. `--output-map` does not assign meaning to JSON object key order, so evaluated `@out.*` references are rejected there. `--output-map` is not a recursive template. The key is the target and the value is the expr. Therefore `--output-map '{"user":{"id":"@input.id"}}'` assigns an object literal expr to the `user` field; it does not create a mapping for the `user.id` target.
+
+Direct mode also accepts `-c/--context <JSON_FILE>`. `--rule`, `-F/--field`, and `--output-map` expressions can reference `@context.*`.
+
+```sh
+echo '{"tenant_id":"t1"}' > context.json
+echo 'u1,Alice' | rulemorph -H 'id,name' -c context.json \
+  -F id='@input.id' \
+  -F tenant='@context.tenant_id'
+# => {"id":"u1","tenant":"t1"}
+```
+
+Excel direct input is selected for `.xlsx` files or with `-f excel`. Excel requires `--excel-header-row` and `--excel-data-range`, where `--excel-data-range` is the data range and does not include the header row. Use `--excel-sheet <NAME>` or `--excel-sheet-index <INDEX>` to select a sheet; they cannot be used together.
+
+```sh
+rulemorph -rule '@input.id' -i users.xlsx --excel-header-row 1 --excel-data-range A2:D2
+rulemorph -rule '@input.id' -i users.xlsx --excel-header-row 1 --excel-data-range A2:D3
+rulemorph -rule '["@input.score", {"+": [7.5]}, "round"]' -i users.xlsx --excel-header-row 1 --excel-data-range A2:D2
+# => 50
+```
+
+For `--rule`, CSV / Excel direct convenience mode outputs `[]` for zero records, the direct value for one record, and an array of direct values for multiple records. For `-F/--field` and `--output-map`, it outputs an object for one record and an object array for multiple records. For compatibility, explicit `-f csv` without the new tabular options keeps the legacy array output even for one record. `--limit`, `--limits-profile`, and `--limits-file` apply the same resource limits as `transform`. `--rule` / `-F/--field` / `--output-map` cannot be used with a subcommand, and direct-mode top-level options placed before a subcommand are rejected.
 
 ## Resource limits
 

--- a/docs/rules_spec_ja.md
+++ b/docs/rules_spec_ja.md
@@ -825,7 +825,63 @@ direct mode は通常の v2 `expr` 構文を使います。operator を連結す
 echo '{ "a": 1, "b": 2 }' | rulemorph --rule '["@input.a", {"+": ["@input.b"]}]'
 ```
 
-direct mode は既定で JSON 入力として扱います。CSV 入力では `-f csv` を指定します。`--limit` / `--limits-profile` / `--limits-file` は `transform` と同じ resource limit として適用されます。`--rule` は subcommand と同時には使えず、direct mode 用の top-level option を subcommand 前に置くとエラーになります。
+direct mode の入力形式は、`-f/--format`、`-i` の拡張子、stdin の先頭 token の順で決まります。stdin は UTF-8 BOM と ASCII whitespace を除いた先頭が `{` または `[` なら JSON、それ以外なら CSV として扱います。`-i` の未知拡張子 / 拡張子なしは既存互換のため JSON です。CSV が `{` または `[` で始まる場合は `-f csv` を明示してください。
+
+CSV direct input では、header 行がある `.csv` file はそのまま field 名で参照できます。headerless CSV は `@input.0` のような numeric field 参照から列数を推定するか、`-H/--headers` で field 名を与えます。`-h` は help 用のため、headers の short option は `-H` です。
+
+```sh
+echo 'a,test,1' | rulemorph -rule '@input.0'
+echo 'a,test,1' | rulemorph -H 'id,name,age' -rule '@input.id'
+rulemorph -H 'id,name,age' -rule '@input.id' -i non_header.csv
+rulemorph -rule '@input.id' -i with_header.csv
+```
+
+direct mode でも通常の `expr` と同じ pipe operator を使えます。
+
+```sh
+echo 'a,test,1' | rulemorph -rule '["@input.0", {"concat": ["-", "@input.1"]}]'
+# => "a-test"
+
+echo 'u1, Alice ,42' | rulemorph -H 'id,name,age' -rule '["@input.name", "trim", "uppercase"]'
+# => "ALICE"
+```
+
+direct mode で複数 field を出力する場合は、`-F/--field <TARGET=EXPR>` を複数指定するか、`--output-map <JSON_OBJECT>` を使います。どちらも通常の `mappings` に寄せた sugar です。target は出力先 path、expr は既存 v2 `expr` と同じ値です。`--rule`、`-F/--field`、`--output-map` は同時指定できません。
+
+```sh
+echo 'u1,Alice,42' | rulemorph -H 'id,name,age' \
+  -F id='@input.id' \
+  -F name='["@input.name","uppercase"]' \
+  -F kind='lit:user'
+# => {"id":"u1","kind":"user","name":"ALICE"}
+
+echo 'u1,Alice,42' | rulemorph -H 'id,name,age' \
+  --output-map '{"user.id":"@input.id","user.name":["@input.name","uppercase"],"kind":"lit:user"}'
+# => {"kind":"user","user":{"id":"u1","name":"ALICE"}}
+```
+
+`-F/--field` は CLI 指定順を mapping の評価順として維持するため、後続 field から先行 field を `@out.*` で参照できます。`--output-map` は JSON object の key order に意味を持たせないため、評価される `@out.*` 参照を拒否します。`--output-map` は recursive template ではありません。key が target、value が expr です。したがって `--output-map '{"user":{"id":"@input.id"}}'` は `user` field に object literal expr を入れる指定であり、`user.id` target への mapping ではありません。
+
+direct mode でも `-c/--context <JSON_FILE>` を指定でき、`--rule`、`-F/--field`、`--output-map` の expr から `@context.*` を参照できます。
+
+```sh
+echo '{"tenant_id":"t1"}' > context.json
+echo 'u1,Alice' | rulemorph -H 'id,name' -c context.json \
+  -F id='@input.id' \
+  -F tenant='@context.tenant_id'
+# => {"id":"u1","tenant":"t1"}
+```
+
+Excel direct input は `.xlsx` file または `-f excel` で扱います。Excel では `--excel-header-row` と、header 行を含まない data range としての `--excel-data-range` が必須です。`--excel-sheet <NAME>` または `--excel-sheet-index <INDEX>` で sheet を選べますが、同時指定はできません。
+
+```sh
+rulemorph -rule '@input.id' -i users.xlsx --excel-header-row 1 --excel-data-range A2:D2
+rulemorph -rule '@input.id' -i users.xlsx --excel-header-row 1 --excel-data-range A2:D3
+rulemorph -rule '["@input.score", {"+": [7.5]}, "round"]' -i users.xlsx --excel-header-row 1 --excel-data-range A2:D2
+# => 50
+```
+
+CSV / Excel direct convenience mode は、`--rule` では 0 record なら `[]`、1 record なら direct value、2 record 以上なら direct value の配列を出力します。`-F/--field` / `--output-map` では 1 record なら object、2 record 以上なら object array を出力します。既存互換のため、`-f csv` だけを明示して新しい tabular option を使わない場合は、1 record でも従来どおり配列を維持します。`--limit` / `--limits-profile` / `--limits-file` は `transform` と同じ resource limit として適用されます。`--rule` / `-F/--field` / `--output-map` は subcommand と同時には使えず、direct mode 用の top-level option を subcommand 前に置くとエラーになります。
 
 ## Resource limits
 


### PR DESCRIPTION
## Summary
- Add CSV and Excel support to CLI direct mode, including headers, Excel range/sheet options, and format detection
- Add multi-field direct output via -F/--field and --output-map, with context support and resource guards
- Update README, rule specs, design doc, and CLI integration coverage

## Verification
- cargo fmt --check
- cargo test -p rulemorph_cli --test cli direct_
- cargo test
- codex review --uncommitted

## Security review
- Codex Security review initially found scanner edge cases around evaluated refs and CSV inference; fixes and regression tests are included
- Final Codex Security review found no blocking issues