### PR TITLE
Add direct mode NDJSON output

### DIFF
--- a/crates/rulemorph_cli/src/direct.rs
+++ b/crates/rulemorph_cli/src/direct.rs
@@ -1,15 +1,19 @@
 use std::collections::HashSet;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use csv::ReaderBuilder;
 use rulemorph::{
-    InputData, RuleFormat, parse_rule_file_with_format,
+    InputData, NormalizationOptions, RuleFile, RuleFormat, parse_rule_file_with_format,
     transform_input_with_warnings_with_base_dir_and_options,
+    transform_stream_input_with_base_dir_and_options,
 };
 
 use super::emit::{emit_transform_error, emit_transform_warnings};
 use super::input::{load_context, load_input_bytes_from_path_or_stdin, load_normalization_options};
-use super::output::{emit_text_output, serialize_json_output};
+use super::output::{
+    create_output_writer, emit_text_output, serialize_json_output, write_json_line,
+};
 use super::{DirectFormatArg, ErrorFormat, LimitsProfileArg};
 
 mod output_spec;
@@ -35,6 +39,7 @@ pub(crate) struct DirectArgs {
     pub(crate) excel_sheet: Option<String>,
     pub(crate) excel_sheet_index: Option<usize>,
     pub(crate) output: Option<PathBuf>,
+    pub(crate) ndjson: bool,
     pub(crate) error_format: Option<ErrorFormat>,
     pub(crate) limits: Vec<String>,
     pub(crate) limits_profile: Option<LimitsProfileArg>,
@@ -97,6 +102,18 @@ pub(crate) fn run(args: DirectArgs) -> i32 {
         Err(code) => return code,
     };
 
+    if args.ndjson {
+        return run_direct_ndjson(
+            &rule,
+            &input,
+            context.as_ref(),
+            args.output,
+            args.error_format.unwrap_or(ErrorFormat::Text),
+            &options,
+            output_spec.output_mode(),
+        );
+    }
+
     let (output, warnings) = match transform_input_with_warnings_with_base_dir_and_options(
         &rule,
         InputData::Bytes(&input),
@@ -124,6 +141,63 @@ pub(crate) fn run(args: DirectArgs) -> i32 {
     emit_transform_warnings(&warnings, args.error_format.unwrap_or(ErrorFormat::Text));
 
     if emit_text_output(&output_text, args.output.as_ref()).is_err() {
+        return 1;
+    }
+
+    0
+}
+
+fn run_direct_ndjson(
+    rule: &RuleFile,
+    input: &[u8],
+    context: Option<&serde_json::Value>,
+    output: Option<PathBuf>,
+    error_format: ErrorFormat,
+    options: &NormalizationOptions,
+    output_mode: DirectOutputMode,
+) -> i32 {
+    let stream = match transform_stream_input_with_base_dir_and_options(
+        rule,
+        InputData::Bytes(input),
+        context,
+        Path::new("."),
+        options,
+    ) {
+        Ok(stream) => stream,
+        Err(err) => {
+            emit_transform_error(&err, error_format);
+            return 3;
+        }
+    };
+
+    let mut writer = match create_output_writer(output.as_ref()) {
+        Ok(writer) => writer,
+        Err(()) => return 1,
+    };
+
+    for item in stream {
+        let item = match item {
+            Ok(item) => item,
+            Err(err) => {
+                emit_transform_error(&err, error_format);
+                return 3;
+            }
+        };
+
+        emit_transform_warnings(&item.warnings, error_format);
+
+        let output = match item.output {
+            Some(output) => output,
+            None => continue,
+        };
+        let output = unwrap_direct_record(output, output_mode);
+        if write_json_line(&mut writer, &output).is_err() {
+            return 1;
+        }
+    }
+
+    if let Err(err) = writer.flush() {
+        eprintln!("failed to write output: {}", err);
         return 1;
     }
 

--- a/crates/rulemorph_cli/src/main.rs
+++ b/crates/rulemorph_cli/src/main.rs
@@ -40,6 +40,11 @@ struct Cli {
     excel_sheet_index: Option<usize>,
     #[arg(short = 'o', long)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Emit one JSON value per line in direct mode. Each input record produces one line."
+    )]
+    ndjson: bool,
     #[arg(short = 'e', long)]
     error_format: Option<ErrorFormat>,
     #[arg(long = "limit")]
@@ -115,6 +120,7 @@ fn main() {
         excel_sheet,
         excel_sheet_index,
         output,
+        ndjson,
         error_format,
         limits,
         limits_profile,
@@ -138,6 +144,7 @@ fn main() {
             excel_sheet,
             excel_sheet_index,
             output,
+            ndjson,
             error_format,
             limits,
             limits_profile,
@@ -158,6 +165,7 @@ fn main() {
                 &excel_sheet,
                 &excel_sheet_index,
                 &output,
+                &ndjson,
                 &error_format,
                 &limits,
                 &limits_profile,
@@ -223,6 +231,7 @@ fn has_direct_options(
     excel_sheet: &Option<String>,
     excel_sheet_index: &Option<usize>,
     output: &Option<PathBuf>,
+    ndjson: &bool,
     error_format: &Option<ErrorFormat>,
     limits: &[String],
     limits_profile: &Option<LimitsProfileArg>,
@@ -237,6 +246,7 @@ fn has_direct_options(
         || excel_sheet.is_some()
         || excel_sheet_index.is_some()
         || output.is_some()
+        || *ndjson
         || error_format.is_some()
         || !limits.is_empty()
         || limits_profile.is_some()

--- a/crates/rulemorph_cli/tests/cli/direct_rule.rs
+++ b/crates/rulemorph_cli/tests/cli/direct_rule.rs
@@ -179,6 +179,19 @@ fn direct_rule_outputs_multi_row_inferred_csv_as_array() {
 }
 
 #[test]
+fn direct_rule_outputs_ndjson_for_json_array_input() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--ndjson")
+            .arg("--rule")
+            .arg("@input.id")
+            .write_stdin(r#"[{ "id": "u1" }, { "id": "u2" }]"#);
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout_string(output), "\"u1\"\n\"u2\"\n");
+}
+
+#[test]
 fn direct_rule_supports_pipe_expr_for_headerless_csv_numeric_fields() {
     let output = rulemorph_output(|cmd| {
         cmd.arg("--rule")
@@ -329,6 +342,24 @@ fn direct_output_map_outputs_object_array_for_json_array_input() {
             { "id": "u1", "age": 42 },
             { "id": "u2", "age": 7 }
         ])
+    );
+}
+
+#[test]
+fn direct_output_map_outputs_ndjson_for_multi_row_csv() {
+    let output = rulemorph_output(|cmd| {
+        cmd.arg("--ndjson")
+            .arg("-H")
+            .arg("id,name,age")
+            .arg("--output-map")
+            .arg(r#"{"id":"@input.id","age":["@input.age","int"]}"#)
+            .write_stdin("u1,Alice,42\nu2,Bob,7\n");
+    });
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(
+        stdout_string(output),
+        "{\"age\":42,\"id\":\"u1\"}\n{\"age\":7,\"id\":\"u2\"}\n"
     );
 }
 

--- a/docs/rules_spec_en.md
+++ b/docs/rules_spec_en.md
@@ -856,6 +856,30 @@ echo 'u1,Alice,42' | rulemorph -H 'id,name,age' \
 # => {"kind":"user","user":{"id":"u1","name":"ALICE"}}
 ```
 
+When processing multiple records, the default output is a JSON array.
+
+```sh
+echo '[{"id":"u1"},{"id":"u2"}]' | rulemorph --rule '@input.id'
+# => ["u1","u2"]
+
+printf 'u1,Alice,42\nu2,Bob,7\n' | rulemorph -H 'id,name,age' \
+  --output-map '{"id":"@input.id","age":["@input.age","int"]}'
+# => [{"age":42,"id":"u1"},{"age":7,"id":"u2"}]
+```
+
+Use `--ndjson` when each record should be emitted as one line. `--rule` emits the direct value, while `-F/--field` and `--output-map` emit one object per line.
+
+```sh
+echo '[{"id":"u1"},{"id":"u2"}]' | rulemorph --ndjson --rule '@input.id'
+# => "u1"
+# => "u2"
+
+printf 'u1,Alice,42\nu2,Bob,7\n' | rulemorph --ndjson -H 'id,name,age' \
+  --output-map '{"id":"@input.id","age":["@input.age","int"]}'
+# => {"age":42,"id":"u1"}
+# => {"age":7,"id":"u2"}
+```
+
 `-F/--field` preserves CLI argument order as mapping order, so a later field can reference an earlier field through `@out.*`. `--output-map` does not assign meaning to JSON object key order, so evaluated `@out.*` references are rejected there. `--output-map` is not a recursive template. The key is the target and the value is the expr. Therefore `--output-map '{"user":{"id":"@input.id"}}'` assigns an object literal expr to the `user` field; it does not create a mapping for the `user.id` target.
 
 Direct mode also accepts `-c/--context <JSON_FILE>`. `--rule`, `-F/--field`, and `--output-map` expressions can reference `@context.*`.
@@ -877,7 +901,7 @@ rulemorph -rule '["@input.score", {"+": [7.5]}, "round"]' -i users.xlsx --excel-
 # => 50
 ```
 
-For `--rule`, CSV / Excel direct convenience mode outputs `[]` for zero records, the direct value for one record, and an array of direct values for multiple records. For `-F/--field` and `--output-map`, it outputs an object for one record and an object array for multiple records. For compatibility, explicit `-f csv` without the new tabular options keeps the legacy array output even for one record. `--limit`, `--limits-profile`, and `--limits-file` apply the same resource limits as `transform`. `--rule` / `-F/--field` / `--output-map` cannot be used with a subcommand, and direct-mode top-level options placed before a subcommand are rejected.
+For `--rule`, CSV / Excel direct convenience mode outputs `[]` for zero records, the direct value for one record, and an array of direct values for multiple records. For `-F/--field` and `--output-map`, it outputs an object for one record and an object array for multiple records. With `--ndjson`, direct mode emits one JSON line per record and does not wrap records in an array. For compatibility, explicit `-f csv` without the new tabular options keeps the legacy array output even for one record. `--limit`, `--limits-profile`, and `--limits-file` apply the same resource limits as `transform`. `--rule` / `-F/--field` / `--output-map` cannot be used with a subcommand, and direct-mode top-level options placed before a subcommand are rejected.
 
 ## Resource limits
 

--- a/docs/rules_spec_ja.md
+++ b/docs/rules_spec_ja.md
@@ -860,6 +860,30 @@ echo 'u1,Alice,42' | rulemorph -H 'id,name,age' \
 # => {"kind":"user","user":{"id":"u1","name":"ALICE"}}
 ```
 
+複数 record を処理する場合、通常出力は JSON 配列になります。
+
+```sh
+echo '[{"id":"u1"},{"id":"u2"}]' | rulemorph --rule '@input.id'
+# => ["u1","u2"]
+
+printf 'u1,Alice,42\nu2,Bob,7\n' | rulemorph -H 'id,name,age' \
+  --output-map '{"id":"@input.id","age":["@input.age","int"]}'
+# => [{"age":42,"id":"u1"},{"age":7,"id":"u2"}]
+```
+
+1 record ずつ扱いたい場合は `--ndjson` を指定します。`--rule` は direct value を、`-F/--field` / `--output-map` は object を 1 行ずつ出力します。
+
+```sh
+echo '[{"id":"u1"},{"id":"u2"}]' | rulemorph --ndjson --rule '@input.id'
+# => "u1"
+# => "u2"
+
+printf 'u1,Alice,42\nu2,Bob,7\n' | rulemorph --ndjson -H 'id,name,age' \
+  --output-map '{"id":"@input.id","age":["@input.age","int"]}'
+# => {"age":42,"id":"u1"}
+# => {"age":7,"id":"u2"}
+```
+
 `-F/--field` は CLI 指定順を mapping の評価順として維持するため、後続 field から先行 field を `@out.*` で参照できます。`--output-map` は JSON object の key order に意味を持たせないため、評価される `@out.*` 参照を拒否します。`--output-map` は recursive template ではありません。key が target、value が expr です。したがって `--output-map '{"user":{"id":"@input.id"}}'` は `user` field に object literal expr を入れる指定であり、`user.id` target への mapping ではありません。
 
 direct mode でも `-c/--context <JSON_FILE>` を指定でき、`--rule`、`-F/--field`、`--output-map` の expr から `@context.*` を参照できます。
@@ -881,7 +905,7 @@ rulemorph -rule '["@input.score", {"+": [7.5]}, "round"]' -i users.xlsx --excel-
 # => 50
 ```
 
-CSV / Excel direct convenience mode は、`--rule` では 0 record なら `[]`、1 record なら direct value、2 record 以上なら direct value の配列を出力します。`-F/--field` / `--output-map` では 1 record なら object、2 record 以上なら object array を出力します。既存互換のため、`-f csv` だけを明示して新しい tabular option を使わない場合は、1 record でも従来どおり配列を維持します。`--limit` / `--limits-profile` / `--limits-file` は `transform` と同じ resource limit として適用されます。`--rule` / `-F/--field` / `--output-map` は subcommand と同時には使えず、direct mode 用の top-level option を subcommand 前に置くとエラーになります。
+CSV / Excel direct convenience mode は、`--rule` では 0 record なら `[]`、1 record なら direct value、2 record 以上なら direct value の配列を出力します。`-F/--field` / `--output-map` では 1 record なら object、2 record 以上なら object array を出力します。`--ndjson` 指定時は record ごとに 1 行の JSON を出力し、配列には包みません。既存互換のため、`-f csv` だけを明示して新しい tabular option を使わない場合は、1 record でも従来どおり配列を維持します。`--limit` / `--limits-profile` / `--limits-file` は `transform` と同じ resource limit として適用されます。`--rule` / `-F/--field` / `--output-map` は subcommand と同時には使えず、direct mode 用の top-level option を subcommand 前に置くとエラーになります。
 
 ## Resource limits
 


### PR DESCRIPTION
## Summary
- Add direct mode `--ndjson` output for one JSON line per input record
- Reuse the existing streaming transform/output writer path for direct mode
- Document multi-record JSON array output and NDJSON examples in both Japanese and English specs

## Tests
- `cargo fmt`
- `cargo test -p rulemorph_cli --test cli ndjson`
- `cargo test`

## Security
- Reviewed with Codex Security diff review; no blocking findings.