### PR TITLE
[codex] Add v2 object builder operator

### DIFF
--- a/crates/rulemorph/src/custom_ops.rs
+++ b/crates/rulemorph/src/custom_ops.rs
@@ -7,7 +7,8 @@ use crate::locator::YamlLocator;
 use crate::model::{CustomOpDef, Mapping, RuleFile, RuleType, RuleTypeField, RuleTypeKind};
 use crate::path::{PathToken, parse_path};
 use crate::v2_model::{
-    V2CallArg, V2Condition, V2CustomCallStep, V2Expr, V2Pipe, V2Ref, V2Start, V2Step,
+    V2CallArg, V2Condition, V2CustomCallStep, V2Expr, V2ObjectFieldValue, V2Pipe, V2Ref, V2Start,
+    V2Step, object_field_rule_path,
 };
 use crate::v2_operator::is_valid_operator;
 use crate::v2_parser::{
@@ -783,6 +784,20 @@ fn validate_step_call_sites(
                 );
             }
         }
+        V2Step::Object(object_step) => {
+            for field in &object_step.fields {
+                if let V2ObjectFieldValue::Expr(expr) = &field.value {
+                    validate_v2_expr_call_sites(
+                        rule,
+                        expr,
+                        &object_field_rule_path(path, &field.key),
+                        locator,
+                        errors,
+                        in_custom_body,
+                    );
+                }
+            }
+        }
         V2Step::CustomCall(call) => {
             validate_custom_call_site(rule, call, path, locator, errors, in_custom_body);
         }
@@ -1058,6 +1073,13 @@ fn collect_step_dependencies(rule: &RuleFile, step: &V2Step, deps: &mut HashSet<
             }
             for arg in &op.args {
                 collect_expr_dependencies(rule, arg, deps);
+            }
+        }
+        V2Step::Object(object) => {
+            for field in &object.fields {
+                if let V2ObjectFieldValue::Expr(expr) = &field.value {
+                    collect_expr_dependencies(rule, expr, deps);
+                }
             }
         }
         V2Step::CustomCall(call) => {

--- a/crates/rulemorph/src/dto/infer.rs
+++ b/crates/rulemorph/src/dto/infer.rs
@@ -5,8 +5,8 @@ use serde_json::Value as JsonValue;
 use crate::model::{CustomOpDef, Expr, Mapping, RuleFile, RuleType, RuleTypeKind};
 use crate::path::{PathToken, parse_path};
 use crate::v2_model::{
-    V2CustomCallStep, V2Expr, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Pipe, V2Ref, V2Start,
-    V2Step,
+    V2CustomCallStep, V2Expr, V2IfStep, V2LetStep, V2MapStep, V2ObjectFieldValue, V2ObjectStep,
+    V2OpStep, V2Pipe, V2Ref, V2Start, V2Step,
 };
 use crate::v2_parser::{
     custom_call_step_candidate, is_literal_escape, is_pipe_value, is_v2_ref,
@@ -275,6 +275,22 @@ fn infer_expr_with_scope(
     infer_pipe(&pipe, rule, state, scope, depth + 1)
 }
 
+fn infer_v2_expr_with_scope(
+    expr: &V2Expr,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: Scope,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth) {
+        return FieldType::JsonValue;
+    }
+    match expr {
+        V2Expr::Pipe(pipe) => infer_pipe(pipe, rule, state, scope, depth + 1),
+        V2Expr::V1Fallback(expr) => infer_expr_with_scope(expr, rule, state, scope, depth + 1),
+    }
+}
+
 fn infer_pipe(
     pipe: &V2Pipe,
     rule: &RuleFile,
@@ -352,6 +368,9 @@ fn infer_step(
     }
     match step {
         V2Step::Op(op_step) => infer_op(op_step, rule, state, scope, input_type, depth + 1),
+        V2Step::Object(object_step) => {
+            infer_object_step(object_step, rule, state, scope, input_type, depth + 1)
+        }
         V2Step::CustomCall(call_step) => infer_custom_call(&call_step.op, rule, state, depth + 1),
         V2Step::Let(let_step) => {
             infer_let_step(let_step, rule, state, scope, input_type, depth + 1)
@@ -362,6 +381,45 @@ fn infer_step(
         }
         V2Step::Ref(value_ref) => infer_ref(value_ref, state, scope, depth + 1),
     }
+}
+
+fn infer_object_step(
+    object_step: &V2ObjectStep,
+    rule: &RuleFile,
+    state: &mut InferenceState,
+    scope: &Scope,
+    input_type: FieldType,
+    depth: usize,
+) -> FieldType {
+    if !state.enter_node(depth)
+        || object_step.fields.len() > DTO_INFER_MAX_OBJECT_FIELDS
+        || !state.reserve_generated_type()
+    {
+        return FieldType::JsonValue;
+    }
+
+    let mut field_scope = scope.clone();
+    field_scope.pipe = input_type;
+    let fields = object_step
+        .fields
+        .iter()
+        .map(|field| {
+            let field_type = match &field.value {
+                V2ObjectFieldValue::Expr(expr) => {
+                    infer_v2_expr_with_scope(expr, rule, state, field_scope.clone(), depth + 1)
+                }
+                V2ObjectFieldValue::Value(value) => infer_json_value(value, state, depth + 1),
+            };
+            Field {
+                key: field.key.clone(),
+                field_type,
+                optional: true,
+                synthetic: false,
+            }
+        })
+        .collect();
+
+    FieldType::Object(Box::new(SchemaNode { fields }))
 }
 
 fn infer_op(

--- a/crates/rulemorph/src/normalization/options.rs
+++ b/crates/rulemorph/src/normalization/options.rs
@@ -19,6 +19,11 @@ pub struct NormalizationOptions {
     pub max_excel_shared_string_bytes: usize,
     pub max_excel_styles: usize,
     pub max_range_items: Option<usize>,
+    pub max_object_fields: usize,
+    pub max_object_key_bytes: usize,
+    pub max_object_depth: usize,
+    pub max_generated_json_nodes: usize,
+    pub max_generated_json_bytes: usize,
 }
 
 impl Default for NormalizationOptions {
@@ -43,6 +48,11 @@ impl Default for NormalizationOptions {
             max_excel_shared_string_bytes: 64 * 1024 * 1024,
             max_excel_styles: 65_536,
             max_range_items: Some(10_000),
+            max_object_fields: 10_000,
+            max_object_key_bytes: 4 * 1024,
+            max_object_depth: 64,
+            max_generated_json_nodes: 100_000,
+            max_generated_json_bytes: 10 * 1024 * 1024,
         }
     }
 }
@@ -56,6 +66,11 @@ impl NormalizationOptions {
             max_excel_uncompressed_bytes: 1024 * 1024 * 1024,
             max_excel_rows: 1_000_000,
             max_excel_cells: 10_000_000,
+            max_object_fields: 100_000,
+            max_object_key_bytes: 16 * 1024,
+            max_object_depth: 128,
+            max_generated_json_nodes: 1_000_000,
+            max_generated_json_bytes: 128 * 1024 * 1024,
             ..Self::default()
         }
     }

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -90,8 +90,8 @@ use self::record::apply_rule_to_record;
 use self::record_trace::apply_rule_to_record_traced;
 use self::types::Namespace;
 pub(crate) use self::types::{
-    EvalItem, EvalLimits, EvalLocals, EvalValue, extend_generated_array_items,
-    push_generated_array_item,
+    EvalItem, EvalLimits, EvalLocals, EvalValue, GeneratedObjectBudget,
+    extend_generated_array_items, push_generated_array_item,
 };
 use self::v1_expr::{
     canonical_ref_path, eval_chain, eval_expr, eval_record_when, eval_record_when_traced, eval_ref,

--- a/crates/rulemorph/src/transform.rs
+++ b/crates/rulemorph/src/transform.rs
@@ -90,7 +90,7 @@ use self::record::apply_rule_to_record;
 use self::record_trace::apply_rule_to_record_traced;
 use self::types::Namespace;
 pub(crate) use self::types::{
-    EvalItem, EvalLimits, EvalLocals, EvalValue, GeneratedObjectBudget,
+    EvalItem, EvalLimits, EvalLocals, EvalValue, GeneratedArrayBudget, GeneratedObjectBudget,
     extend_generated_array_items, push_generated_array_item,
 };
 use self::v1_expr::{

--- a/crates/rulemorph/src/transform/custom_ops.rs
+++ b/crates/rulemorph/src/transform/custom_ops.rs
@@ -18,7 +18,8 @@ use crate::trace::{
 };
 use crate::v2_eval::{EvalValue as V2EvalValue, V2EvalContext, eval_v2_expr, eval_v2_pipe};
 use crate::v2_model::{
-    V2CallArg, V2Condition, V2CustomCallStep, V2Expr, V2OpStep, V2Pipe, V2Ref, V2Start, V2Step,
+    V2CallArg, V2Condition, V2CustomCallStep, V2Expr, V2ObjectFieldValue, V2OpStep, V2Pipe, V2Ref,
+    V2Start, V2Step,
 };
 use crate::v2_parser::{
     custom_call_step_candidate, parse_custom_call_step, parse_v2_pipe_from_value,
@@ -1147,6 +1148,19 @@ fn collect_v2_step_redaction_hints(
             }
             for arg in &op.args {
                 collect_v2_expr_redaction_hints(arg, hint, input_redaction_hints);
+            }
+        }
+        V2Step::Object(object) => {
+            hint.unknown_provenance = true;
+            for field in &object.fields {
+                match &field.value {
+                    V2ObjectFieldValue::Expr(expr) => {
+                        collect_v2_expr_redaction_hints(expr, hint, input_redaction_hints);
+                    }
+                    V2ObjectFieldValue::Value(value) => {
+                        collect_json_redaction_hints(value, hint, input_redaction_hints);
+                    }
+                }
             }
         }
         V2Step::CustomCall(call) => {

--- a/crates/rulemorph/src/transform/types.rs
+++ b/crates/rulemorph/src/transform/types.rs
@@ -106,7 +106,7 @@ impl EvalLimits {
         value: &JsonValue,
         path: &str,
     ) -> Result<(), TransformError> {
-        let stats = generated_json_stats(value, path)?;
+        let stats = generated_json_stats(value, self, path)?;
         if stats.nodes > self.max_generated_json_nodes {
             return Err(TransformError::new(
                 TransformErrorKind::ExprError,
@@ -160,7 +160,7 @@ impl GeneratedObjectBudget {
         limits: EvalLimits,
         path: &str,
     ) -> Result<(), TransformError> {
-        let stats = generated_json_stats(value, path)?;
+        let stats = generated_json_stats(value, limits, path)?;
         let key_bytes = serialized_json_str_bytes(key, path)?;
         let value_bytes = serialized_json_bytes(value, path)?;
         let separator_bytes = usize::from(self.fields > 0);
@@ -225,6 +225,82 @@ impl GeneratedObjectBudget {
     }
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct GeneratedArrayBudget {
+    values: usize,
+    nodes: usize,
+    object_depth: usize,
+    bytes: usize,
+}
+
+impl GeneratedArrayBudget {
+    pub(crate) fn new(limits: EvalLimits, path: &str) -> Result<Self, TransformError> {
+        let budget = Self {
+            values: 0,
+            nodes: 1,
+            object_depth: 0,
+            bytes: 2,
+        };
+        budget.check(limits, path)?;
+        Ok(budget)
+    }
+
+    pub(crate) fn try_push_value(
+        &mut self,
+        value: &JsonValue,
+        limits: EvalLimits,
+        path: &str,
+    ) -> Result<(), TransformError> {
+        let stats = generated_json_stats(value, limits, path)?;
+        let value_bytes = serialized_json_bytes(value, path)?;
+        let separator_bytes = usize::from(self.values > 0);
+        let next = Self {
+            values: self
+                .values
+                .checked_add(1)
+                .ok_or_else(|| generated_json_overflow(path))?,
+            nodes: self
+                .nodes
+                .checked_add(stats.nodes)
+                .ok_or_else(|| generated_json_overflow(path))?,
+            object_depth: self.object_depth.max(stats.object_depth),
+            bytes: self
+                .bytes
+                .checked_add(separator_bytes)
+                .and_then(|bytes| bytes.checked_add(value_bytes))
+                .ok_or_else(|| generated_json_overflow(path))?,
+        };
+        next.check(limits, path)?;
+        *self = next;
+        Ok(())
+    }
+
+    fn check(self, limits: EvalLimits, path: &str) -> Result<(), TransformError> {
+        if self.nodes > limits.max_generated_json_nodes {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "generated JSON node count exceeds configured limit",
+            )
+            .with_path(path));
+        }
+        if self.object_depth > limits.max_object_depth {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "object depth exceeds configured limit",
+            )
+            .with_path(path));
+        }
+        if self.bytes > limits.max_generated_json_bytes {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "generated JSON bytes exceed configured limit",
+            )
+            .with_path(path));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Default)]
 struct GeneratedJsonStats {
     nodes: usize,
@@ -233,10 +309,11 @@ struct GeneratedJsonStats {
 
 fn generated_json_stats(
     value: &JsonValue,
+    limits: EvalLimits,
     path: &str,
 ) -> Result<GeneratedJsonStats, TransformError> {
     let mut stats = GeneratedJsonStats::default();
-    collect_generated_json_stats(value, 0, &mut stats, path)?;
+    collect_generated_json_stats(value, 0, &mut stats, limits, path)?;
     Ok(stats)
 }
 
@@ -244,6 +321,7 @@ fn collect_generated_json_stats(
     value: &JsonValue,
     object_depth: usize,
     stats: &mut GeneratedJsonStats,
+    limits: EvalLimits,
     path: &str,
 ) -> Result<(), TransformError> {
     stats.nodes = stats
@@ -252,17 +330,21 @@ fn collect_generated_json_stats(
         .ok_or_else(|| generated_json_overflow(path))?;
     match value {
         JsonValue::Object(map) => {
+            limits.check_object_field_count(map.len(), path)?;
+            for key in map.keys() {
+                limits.check_object_key(key, path)?;
+            }
             let next_depth = object_depth
                 .checked_add(1)
                 .ok_or_else(|| generated_json_overflow(path))?;
             stats.object_depth = stats.object_depth.max(next_depth);
             for value in map.values() {
-                collect_generated_json_stats(value, next_depth, stats, path)?;
+                collect_generated_json_stats(value, next_depth, stats, limits, path)?;
             }
         }
         JsonValue::Array(items) => {
             for value in items {
-                collect_generated_json_stats(value, object_depth, stats, path)?;
+                collect_generated_json_stats(value, object_depth, stats, limits, path)?;
             }
         }
         _ => {}

--- a/crates/rulemorph/src/transform/types.rs
+++ b/crates/rulemorph/src/transform/types.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::{self, Write};
 
 use serde_json::Value as JsonValue;
 
@@ -10,6 +11,11 @@ use crate::v2_eval::EvalValue as V2EvalValue;
 pub(crate) struct EvalLimits {
     pub(crate) max_range_items: Option<usize>,
     pub(crate) max_generated_array_items: usize,
+    pub(crate) max_object_fields: usize,
+    pub(crate) max_object_key_bytes: usize,
+    pub(crate) max_object_depth: usize,
+    pub(crate) max_generated_json_nodes: usize,
+    pub(crate) max_generated_json_bytes: usize,
     pub(crate) max_custom_op_call_depth: usize,
     pub(crate) max_custom_op_calls_per_record: usize,
 }
@@ -19,6 +25,11 @@ impl Default for EvalLimits {
         Self {
             max_range_items: Some(10_000),
             max_generated_array_items: 1_000_000,
+            max_object_fields: 10_000,
+            max_object_key_bytes: 4 * 1024,
+            max_object_depth: 64,
+            max_generated_json_nodes: 100_000,
+            max_generated_json_bytes: 10 * 1024 * 1024,
             max_custom_op_call_depth: crate::custom_ops::MAX_CUSTOM_OP_CALL_DEPTH,
             max_custom_op_calls_per_record: crate::custom_ops::MAX_CUSTOM_OP_CALLS_PER_RECORD,
         }
@@ -30,6 +41,11 @@ impl From<&crate::normalization::NormalizationOptions> for EvalLimits {
         Self {
             max_range_items: options.max_range_items,
             max_generated_array_items: options.max_array_len,
+            max_object_fields: options.max_object_fields,
+            max_object_key_bytes: options.max_object_key_bytes,
+            max_object_depth: options.max_object_depth,
+            max_generated_json_nodes: options.max_generated_json_nodes,
+            max_generated_json_bytes: options.max_generated_json_bytes,
             max_custom_op_call_depth: crate::custom_ops::MAX_CUSTOM_OP_CALL_DEPTH,
             max_custom_op_calls_per_record: crate::custom_ops::MAX_CUSTOM_OP_CALLS_PER_RECORD,
         }
@@ -51,6 +67,245 @@ impl EvalLimits {
         }
         Ok(())
     }
+
+    pub(crate) fn check_object_field_count(
+        self,
+        count: usize,
+        path: &str,
+    ) -> Result<(), TransformError> {
+        if count > self.max_object_fields {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "object field count exceeds configured limit",
+            )
+            .with_path(path));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_object_key(self, key: &str, path: &str) -> Result<(), TransformError> {
+        if key.is_empty() {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "object field key must not be empty",
+            )
+            .with_path(path));
+        }
+        if key.len() > self.max_object_key_bytes {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "object key bytes exceed configured limit",
+            )
+            .with_path(path));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_generated_json_value(
+        self,
+        value: &JsonValue,
+        path: &str,
+    ) -> Result<(), TransformError> {
+        let stats = generated_json_stats(value, path)?;
+        if stats.nodes > self.max_generated_json_nodes {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "generated JSON node count exceeds configured limit",
+            )
+            .with_path(path));
+        }
+        if stats.object_depth > self.max_object_depth {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "object depth exceeds configured limit",
+            )
+            .with_path(path));
+        }
+        let bytes = serialized_json_bytes(value, path)?;
+        if bytes > self.max_generated_json_bytes {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "generated JSON bytes exceed configured limit",
+            )
+            .with_path(path));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct GeneratedObjectBudget {
+    fields: usize,
+    nodes: usize,
+    object_depth: usize,
+    bytes: usize,
+}
+
+impl GeneratedObjectBudget {
+    pub(crate) fn new(limits: EvalLimits, path: &str) -> Result<Self, TransformError> {
+        let budget = Self {
+            fields: 0,
+            nodes: 1,
+            object_depth: 1,
+            bytes: 2,
+        };
+        budget.check(limits, path)?;
+        Ok(budget)
+    }
+
+    pub(crate) fn try_push_field(
+        &mut self,
+        key: &str,
+        value: &JsonValue,
+        limits: EvalLimits,
+        path: &str,
+    ) -> Result<(), TransformError> {
+        let stats = generated_json_stats(value, path)?;
+        let key_bytes = serialized_json_str_bytes(key, path)?;
+        let value_bytes = serialized_json_bytes(value, path)?;
+        let separator_bytes = usize::from(self.fields > 0);
+        let entry_bytes = key_bytes
+            .checked_add(1)
+            .and_then(|bytes| bytes.checked_add(value_bytes))
+            .and_then(|bytes| bytes.checked_add(separator_bytes))
+            .ok_or_else(|| generated_json_overflow(path))?;
+        let next_nodes = self
+            .nodes
+            .checked_add(stats.nodes)
+            .ok_or_else(|| generated_json_overflow(path))?;
+        let nested_object_depth = if stats.object_depth == 0 {
+            1
+        } else {
+            stats
+                .object_depth
+                .checked_add(1)
+                .ok_or_else(|| generated_json_overflow(path))?
+        };
+        let next_bytes = self
+            .bytes
+            .checked_add(entry_bytes)
+            .ok_or_else(|| generated_json_overflow(path))?;
+        let next = Self {
+            fields: self
+                .fields
+                .checked_add(1)
+                .ok_or_else(|| generated_json_overflow(path))?,
+            nodes: next_nodes,
+            object_depth: self.object_depth.max(nested_object_depth),
+            bytes: next_bytes,
+        };
+        next.check(limits, path)?;
+        *self = next;
+        Ok(())
+    }
+
+    fn check(self, limits: EvalLimits, path: &str) -> Result<(), TransformError> {
+        if self.nodes > limits.max_generated_json_nodes {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "generated JSON node count exceeds configured limit",
+            )
+            .with_path(path));
+        }
+        if self.object_depth > limits.max_object_depth {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "object depth exceeds configured limit",
+            )
+            .with_path(path));
+        }
+        if self.bytes > limits.max_generated_json_bytes {
+            return Err(TransformError::new(
+                TransformErrorKind::ExprError,
+                "generated JSON bytes exceed configured limit",
+            )
+            .with_path(path));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct GeneratedJsonStats {
+    nodes: usize,
+    object_depth: usize,
+}
+
+fn generated_json_stats(
+    value: &JsonValue,
+    path: &str,
+) -> Result<GeneratedJsonStats, TransformError> {
+    let mut stats = GeneratedJsonStats::default();
+    collect_generated_json_stats(value, 0, &mut stats, path)?;
+    Ok(stats)
+}
+
+fn collect_generated_json_stats(
+    value: &JsonValue,
+    object_depth: usize,
+    stats: &mut GeneratedJsonStats,
+    path: &str,
+) -> Result<(), TransformError> {
+    stats.nodes = stats
+        .nodes
+        .checked_add(1)
+        .ok_or_else(|| generated_json_overflow(path))?;
+    match value {
+        JsonValue::Object(map) => {
+            let next_depth = object_depth
+                .checked_add(1)
+                .ok_or_else(|| generated_json_overflow(path))?;
+            stats.object_depth = stats.object_depth.max(next_depth);
+            for value in map.values() {
+                collect_generated_json_stats(value, next_depth, stats, path)?;
+            }
+        }
+        JsonValue::Array(items) => {
+            for value in items {
+                collect_generated_json_stats(value, object_depth, stats, path)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn generated_json_overflow(path: &str) -> TransformError {
+    TransformError::new(
+        TransformErrorKind::ExprError,
+        "generated JSON size is out of bounds",
+    )
+    .with_path(path)
+}
+
+struct JsonByteCounter {
+    bytes: usize,
+}
+
+impl Write for JsonByteCounter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes = self
+            .bytes
+            .checked_add(buf.len())
+            .ok_or_else(|| io::Error::other("generated JSON size is out of bounds"))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialized_json_bytes(value: &JsonValue, path: &str) -> Result<usize, TransformError> {
+    let mut counter = JsonByteCounter { bytes: 0 };
+    serde_json::to_writer(&mut counter, value).map_err(|_| generated_json_overflow(path))?;
+    Ok(counter.bytes)
+}
+
+fn serialized_json_str_bytes(value: &str, path: &str) -> Result<usize, TransformError> {
+    let mut counter = JsonByteCounter { bytes: 0 };
+    serde_json::to_writer(&mut counter, value).map_err(|_| generated_json_overflow(path))?;
+    Ok(counter.bytes)
 }
 
 pub(crate) fn generated_array_item_count(

--- a/crates/rulemorph/src/transform/v2_trace/pipe/map_step.rs
+++ b/crates/rulemorph/src/transform/v2_trace/pipe/map_step.rs
@@ -42,6 +42,16 @@ pub(super) fn eval_v2_map_step_traced<'a>(
     };
     let limits = ctx.limits();
     let mut generated_items = 0usize;
+    let mut generated_json = crate::transform::GeneratedArrayBudget::new(limits, step_path)
+        .map_err(|error| {
+            collector
+                .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                .rule_path(step_path)
+                .operator("map")
+                .input_v2_eval_value(&pipe_value, collector.options(), None)
+                .finish(collector);
+            error
+        })?;
     let mut results = Vec::with_capacity(arr.len());
     for (index, item_value) in arr.iter().enumerate() {
         let item_path = format!("{}[{}]", step_path, index);
@@ -100,6 +110,15 @@ pub(super) fn eval_v2_map_step_traced<'a>(
             .rule_path(&item_path)
             .finish_with_v2_eval_output(collector, &current, Some("@item"));
         if let V2EvalValue::Value(value) = current {
+            if let Err(error) = generated_json.try_push_value(&value, limits, step_path) {
+                collector
+                    .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+                    .rule_path(step_path)
+                    .operator("map")
+                    .input_v2_eval_value(&pipe_value, collector.options(), None)
+                    .finish(collector);
+                return Err(error);
+            }
             if let Err(error) = push_generated_array_item(
                 &mut results,
                 value,

--- a/crates/rulemorph/src/transform/v2_trace/pipe/step.rs
+++ b/crates/rulemorph/src/transform/v2_trace/pipe/step.rs
@@ -1,5 +1,8 @@
 use super::*;
 use crate::model::{CustomOpDef, RuleType, RuleTypeKind};
+use crate::trace::TraceValueMode;
+use crate::transform::GeneratedObjectBudget;
+use crate::v2_model::{V2ObjectFieldValue, object_field_rule_path};
 use crate::v2_operator::{V2OperatorTrace, operator};
 
 #[allow(clippy::too_many_arguments)]
@@ -157,6 +160,9 @@ pub(super) fn eval_v2_step_traced<'a>(
                 .finish_with_v2_eval_output(collector, &output, None);
             Ok((output, ctx.clone()))
         }
+        V2Step::Object(object) => eval_v2_object_step_traced(
+            object, pipe_value, record, context, out, step_path, ctx, collector,
+        ),
         V2Step::CustomCall(call) => {
             let def = ctx.rule().and_then(|rule| rule.defs.get(&call.op));
             let def_path = format!("defs.{}", call.op);
@@ -318,6 +324,172 @@ pub(super) fn eval_v2_step_traced<'a>(
             Ok((result, ctx.clone()))
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn eval_v2_object_step_traced<'a>(
+    object: &crate::v2_model::V2ObjectStep,
+    pipe_value: V2EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    step_path: &str,
+    ctx: &V2EvalContext<'a>,
+    collector: &mut TraceCollector,
+) -> Result<(V2EvalValue, V2EvalContext<'a>), TransformError> {
+    collector
+        .start_span(TraceEventKind::OpStart, TracePhase::Start)
+        .rule_path(step_path)
+        .operator("object")
+        .input_v2_eval_value(&pipe_value, collector.options(), None)
+        .attr_count("field_count", object.fields.len())
+        .finish(collector);
+
+    let limits = ctx.limits();
+    if let Err(error) = limits.check_object_field_count(object.fields.len(), step_path) {
+        emit_object_op_error(&pipe_value, step_path, collector);
+        return Err(error);
+    }
+    let mut budget = match GeneratedObjectBudget::new(limits, step_path) {
+        Ok(budget) => budget,
+        Err(error) => {
+            emit_object_op_error(&pipe_value, step_path, collector);
+            return Err(error);
+        }
+    };
+
+    let field_ctx = ctx.clone().with_pipe_value(pipe_value.clone());
+    let mut output = serde_json::Map::new();
+    for (index, field) in object.fields.iter().enumerate() {
+        let field_path = object_field_rule_path(step_path, &field.key);
+        if let Err(error) = limits.check_object_key(&field.key, &field_path) {
+            emit_object_op_error(&pipe_value, step_path, collector);
+            return Err(error);
+        }
+        let trace_field_path = trace_object_field_rule_path(
+            step_path,
+            index,
+            &field.key,
+            &collector.options().value_mode,
+        );
+        let value = match &field.value {
+            V2ObjectFieldValue::Expr(expr) => {
+                match eval_v2_expr_traced(
+                    expr,
+                    record,
+                    context,
+                    out,
+                    &trace_field_path,
+                    &field_ctx,
+                    collector,
+                ) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        emit_object_op_error(&pipe_value, step_path, collector);
+                        return Err(error);
+                    }
+                }
+            }
+            V2ObjectFieldValue::Value(value) => V2EvalValue::Value(value.clone()),
+        };
+        if let V2EvalValue::Value(value) = &value
+            && let Err(error) = budget.try_push_field(&field.key, value, limits, &field_path)
+        {
+            emit_object_op_error(&pipe_value, step_path, collector);
+            return Err(error);
+        }
+        emit_object_field_eval(collector, &trace_field_path, index, &field.key, &value);
+        if let V2EvalValue::Value(value) = value {
+            output.insert(field.key.clone(), value);
+        }
+    }
+
+    let output = V2EvalValue::Value(JsonValue::Object(output));
+    if let V2EvalValue::Value(value) = &output
+        && let Err(error) = limits.check_generated_json_value(value, step_path)
+    {
+        emit_object_op_error(&pipe_value, step_path, collector);
+        return Err(error);
+    }
+    collector
+        .end_span(TraceEventKind::OpEnd, TracePhase::End)
+        .rule_path(step_path)
+        .operator("object")
+        .input_v2_eval_value(&pipe_value, collector.options(), None)
+        .attr_count("field_count", object.fields.len())
+        .finish_with_v2_eval_output(collector, &output, None);
+    Ok((output, ctx.clone()))
+}
+
+fn emit_object_op_error(pipe_value: &V2EvalValue, step_path: &str, collector: &mut TraceCollector) {
+    collector
+        .error_span(TraceEventKind::OpError, "OP_ERROR", "operator failed")
+        .rule_path(step_path)
+        .operator("object")
+        .input_v2_eval_value(pipe_value, collector.options(), None)
+        .finish(collector);
+}
+
+fn emit_object_field_eval(
+    collector: &mut TraceCollector,
+    field_path: &str,
+    index: usize,
+    key: &str,
+    value: &V2EvalValue,
+) {
+    let mut event = collector
+        .emit(TraceEventKind::ArgEval, TracePhase::Instant)
+        .rule_path(field_path)
+        .operator("object")
+        .attr_index("field_index", index);
+    if trace_field_key_is_secret_like(key, &collector.options().value_mode) {
+        event = event.attr_path("field_key_redaction_reason", "secret_like_path");
+    } else {
+        event = event.attr_path("field_key", trace_field_key_display(key));
+    }
+    event.finish_with_v2_eval_output(collector, value, None);
+}
+
+fn trace_object_field_rule_path(
+    step_path: &str,
+    index: usize,
+    key: &str,
+    mode: &TraceValueMode,
+) -> String {
+    if trace_field_key_is_secret_like(key, mode) {
+        format!("{}.object[{}]", step_path, index)
+    } else {
+        object_field_rule_path(step_path, key)
+    }
+}
+
+fn trace_field_key_is_secret_like(key: &str, mode: &TraceValueMode) -> bool {
+    match mode {
+        TraceValueMode::Raw => false,
+        TraceValueMode::Redacted(redaction) => {
+            let lower = key.to_ascii_lowercase();
+            redaction
+                .secret_key_fragments
+                .iter()
+                .any(|fragment| lower.contains(fragment))
+        }
+        TraceValueMode::MetadataOnly => {
+            let lower = key.to_ascii_lowercase();
+            crate::trace::TraceRedactionOptions::default()
+                .secret_key_fragments
+                .iter()
+                .any(|fragment| lower.contains(fragment))
+        }
+    }
+}
+
+fn trace_field_key_display(key: &str) -> String {
+    let encoded = serde_json::to_string(key).unwrap_or_else(|_| "\"<invalid>\"".to_string());
+    encoded
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(&encoded)
+        .to_string()
 }
 
 fn trace_output_type_summary(def: &CustomOpDef) -> String {

--- a/crates/rulemorph/src/v2_eval.rs
+++ b/crates/rulemorph/src/v2_eval.rs
@@ -10,6 +10,7 @@ mod condition;
 mod context;
 mod control;
 mod lookup;
+mod object;
 mod operators;
 mod reference;
 #[cfg(test)]
@@ -26,6 +27,7 @@ pub use control::{
     eval_v2_expr, eval_v2_if_step, eval_v2_let_step, eval_v2_map_step, eval_v2_pipe,
 };
 use lookup::eval_lookup_op;
+pub(crate) use object::eval_v2_object_step;
 pub use operators::eval_v2_op_step;
 pub use reference::{eval_v2_ref, eval_v2_start};
 use v1_bridge::eval_v2_op_with_v1_fallback;

--- a/crates/rulemorph/src/v2_eval/control.rs
+++ b/crates/rulemorph/src/v2_eval/control.rs
@@ -8,7 +8,9 @@ pub use if_step::eval_v2_if_step;
 pub use let_step::eval_v2_let_step;
 pub use map_step::eval_v2_map_step;
 
-use super::{EvalValue, V2EvalContext, eval_v2_op_step, eval_v2_ref, eval_v2_start};
+use super::{
+    EvalValue, V2EvalContext, eval_v2_object_step, eval_v2_op_step, eval_v2_ref, eval_v2_start,
+};
 use crate::error::{TransformError, TransformErrorKind};
 use crate::transform::{eval_custom_call_step, parse_known_custom_call_literal_start};
 use crate::v2_model::{V2Expr, V2Pipe, V2Step};
@@ -44,6 +46,17 @@ pub fn eval_v2_pipe<'a>(
             V2Step::Op(op_step) => {
                 current = eval_v2_op_step(
                     op_step,
+                    current,
+                    record,
+                    context,
+                    out,
+                    &step_path,
+                    &current_ctx,
+                )?;
+            }
+            V2Step::Object(object_step) => {
+                current = eval_v2_object_step(
+                    object_step,
                     current,
                     record,
                     context,

--- a/crates/rulemorph/src/v2_eval/control/map_step.rs
+++ b/crates/rulemorph/src/v2_eval/control/map_step.rs
@@ -3,8 +3,8 @@ use serde_json::Value as JsonValue;
 use crate::error::{TransformError, TransformErrorKind};
 use crate::transform::{eval_custom_call_step, push_generated_array_item};
 use crate::v2_eval::{
-    EvalItem, EvalValue, V2EvalContext, eval_v2_if_step, eval_v2_let_step, eval_v2_op_step,
-    eval_v2_ref,
+    EvalItem, EvalValue, V2EvalContext, eval_v2_if_step, eval_v2_let_step, eval_v2_object_step,
+    eval_v2_op_step, eval_v2_ref,
 };
 use crate::v2_model::{V2MapStep, V2Step};
 
@@ -61,6 +61,17 @@ pub fn eval_v2_map_step<'a>(
                 V2Step::Op(op_step) => {
                     current = eval_v2_op_step(
                         op_step, current, record, context, out, &step_path, &step_ctx,
+                    )?;
+                }
+                V2Step::Object(object_step) => {
+                    current = eval_v2_object_step(
+                        object_step,
+                        current,
+                        record,
+                        context,
+                        out,
+                        &step_path,
+                        &step_ctx,
                     )?;
                 }
                 V2Step::CustomCall(call_step) => {

--- a/crates/rulemorph/src/v2_eval/control/map_step.rs
+++ b/crates/rulemorph/src/v2_eval/control/map_step.rs
@@ -1,7 +1,7 @@
 use serde_json::Value as JsonValue;
 
 use crate::error::{TransformError, TransformErrorKind};
-use crate::transform::{eval_custom_call_step, push_generated_array_item};
+use crate::transform::{GeneratedArrayBudget, eval_custom_call_step, push_generated_array_item};
 use crate::v2_eval::{
     EvalItem, EvalValue, V2EvalContext, eval_v2_if_step, eval_v2_let_step, eval_v2_object_step,
     eval_v2_op_step, eval_v2_ref,
@@ -36,6 +36,7 @@ pub fn eval_v2_map_step<'a>(
     // Map over each element
     let limits = ctx.limits();
     let mut generated_items = 0usize;
+    let mut generated_json = GeneratedArrayBudget::new(limits, path)?;
     let mut results = Vec::with_capacity(arr.len());
     for (index, item_value) in arr.iter().enumerate() {
         let item_path = format!("{}[{}]", path, index);
@@ -112,6 +113,7 @@ pub fn eval_v2_map_step<'a>(
 
         // Only add non-missing values to results
         if let EvalValue::Value(v) = current {
+            generated_json.try_push_value(&v, limits, path)?;
             push_generated_array_item(&mut results, v, limits, path, &mut generated_items)?;
         }
     }

--- a/crates/rulemorph/src/v2_eval/object.rs
+++ b/crates/rulemorph/src/v2_eval/object.rs
@@ -1,0 +1,43 @@
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use crate::error::TransformError;
+use crate::transform::GeneratedObjectBudget;
+use crate::v2_model::{V2ObjectFieldValue, V2ObjectStep, object_field_rule_path};
+
+use super::{EvalValue, V2EvalContext, eval_v2_expr};
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn eval_v2_object_step<'a>(
+    object: &V2ObjectStep,
+    pipe_value: EvalValue,
+    record: &'a JsonValue,
+    context: Option<&'a JsonValue>,
+    out: &'a JsonValue,
+    path: &str,
+    ctx: &V2EvalContext<'a>,
+) -> Result<EvalValue, TransformError> {
+    let limits = ctx.limits();
+    limits.check_object_field_count(object.fields.len(), path)?;
+    let mut budget = GeneratedObjectBudget::new(limits, path)?;
+    let field_ctx = ctx.clone().with_pipe_value(pipe_value);
+    let mut output = JsonMap::new();
+
+    for field in &object.fields {
+        let field_path = object_field_rule_path(path, &field.key);
+        limits.check_object_key(&field.key, &field_path)?;
+        let value = match &field.value {
+            V2ObjectFieldValue::Expr(expr) => {
+                eval_v2_expr(expr, record, context, out, &field_path, &field_ctx)?
+            }
+            V2ObjectFieldValue::Value(value) => EvalValue::Value(value.clone()),
+        };
+        if let EvalValue::Value(value) = value {
+            budget.try_push_field(&field.key, &value, limits, &field_path)?;
+            output.insert(field.key.clone(), value);
+        }
+    }
+
+    let value = JsonValue::Object(output);
+    limits.check_generated_json_value(&value, path)?;
+    Ok(EvalValue::Value(value))
+}

--- a/crates/rulemorph/src/v2_model.rs
+++ b/crates/rulemorph/src/v2_model.rs
@@ -52,6 +52,7 @@ pub enum V2Ref {
 #[derive(Debug, Clone, PartialEq)]
 pub enum V2Step {
     Op(V2OpStep),
+    Object(V2ObjectStep),
     CustomCall(V2CustomCallStep),
     Let(V2LetStep),
     If(V2IfStep),
@@ -65,6 +66,23 @@ pub enum V2Step {
 pub struct V2OpStep {
     pub op: String,
     pub args: Vec<V2Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct V2ObjectStep {
+    pub fields: Vec<V2ObjectField>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct V2ObjectField {
+    pub key: String,
+    pub value: V2ObjectFieldValue,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum V2ObjectFieldValue {
+    Expr(V2Expr),
+    Value(JsonValue),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -125,6 +143,24 @@ pub enum V2ComparisonOp {
     Lt,
     Lte,
     Match,
+}
+
+pub(crate) fn object_field_rule_path(base_path: &str, key: &str) -> String {
+    if is_simple_object_field_key(key) {
+        format!("{}.object.{}", base_path, key)
+    } else {
+        let quoted = serde_json::to_string(key).unwrap_or_else(|_| "\"<invalid>\"".to_string());
+        format!("{}.object[{}]", base_path, quoted)
+    }
+}
+
+fn is_simple_object_field_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 // =============================================================================

--- a/crates/rulemorph/src/v2_operator/inventory/list/json.rs
+++ b/crates/rulemorph/src/v2_operator/inventory/list/json.rs
@@ -3,6 +3,14 @@ use crate::v2_operator::types::{V2OperatorMetadata, V2OperatorTrace};
 
 pub(super) const JSON_OPERATORS: &[V2OperatorMetadata] = &[
     op(
+        "object",
+        range(1, Some(1)),
+        V2OperatorTrace::Delegated,
+        false,
+        false,
+        NO_SCOPE,
+    ),
+    op(
         "merge",
         range(1, None),
         V2OperatorTrace::EagerArgs,

--- a/crates/rulemorph/src/v2_parser/pipe/tests/expr/basic.rs
+++ b/crates/rulemorph/src/v2_parser/pipe/tests/expr/basic.rs
@@ -51,6 +51,35 @@ fn test_parse_v2_expr_literal_object_with_op_key_start_pipe() {
 }
 
 #[test]
+fn test_parse_v2_expr_literal_object_with_object_key_start_pipe() {
+        // Multi-step pipe keeps the first object as a literal start even if it has an object key.
+        let value = json!([{"object": {"name": "alice"}}, "keys"]);
+        let expr = parse_v2_expr(&value).unwrap();
+
+        if let V2Expr::Pipe(pipe) = expr {
+            assert_eq!(pipe.start, V2Start::Literal(json!({"object": {"name": "alice"}})));
+            assert_eq!(pipe.steps.len(), 1);
+            assert!(matches!(&pipe.steps[0], V2Step::Op(op) if op.op == "keys"));
+        } else {
+            panic!("Expected Pipe expression");
+        }
+}
+
+#[test]
+fn test_parse_v2_expr_single_object_step_uses_implicit_pipe_start() {
+        let value = json!([{"object": {"name": "$.name"}}]);
+        let expr = parse_v2_expr(&value).unwrap();
+
+        if let V2Expr::Pipe(pipe) = expr {
+            assert_eq!(pipe.start, V2Start::ImplicitPipeValue);
+            assert_eq!(pipe.steps.len(), 1);
+            assert!(matches!(&pipe.steps[0], V2Step::Object(_)));
+        } else {
+            panic!("Expected Pipe expression");
+        }
+}
+
+#[test]
 fn test_parse_v2_expr_single_ref() {
         // Single reference without steps
         let value = json!("@input.name");

--- a/crates/rulemorph/src/v2_parser/step.rs
+++ b/crates/rulemorph/src/v2_parser/step.rs
@@ -1,5 +1,6 @@
 use crate::v2_model::{
-    V2CallArg, V2CustomCallStep, V2IfStep, V2LetStep, V2MapStep, V2OpStep, V2Step,
+    V2CallArg, V2CustomCallStep, V2IfStep, V2LetStep, V2MapStep, V2ObjectField, V2ObjectFieldValue,
+    V2ObjectStep, V2OpStep, V2Step,
 };
 use crate::v2_operator::is_valid_operator;
 use serde_json::Value as JsonValue;
@@ -15,6 +16,9 @@ pub fn parse_v2_step(value: &JsonValue) -> Result<V2Step, V2ParseError> {
         JsonValue::Object(obj) => {
             // Check for op step: { op: "name", args: [...] }
             if let Some(op_name) = obj.get("op").and_then(|v| v.as_str()) {
+                if op_name == "object" {
+                    return parse_object_step_explicit(obj.get("args"));
+                }
                 let args = if let Some(args_val) = obj.get("args") {
                     parse_v2_expr_args(args_val)?
                 } else {
@@ -45,6 +49,9 @@ pub fn parse_v2_step(value: &JsonValue) -> Result<V2Step, V2ParseError> {
             // This handles cases like { multiply: [1.1] }, { concat: ["@out.name"] }, etc.
             if obj.len() == 1 {
                 let (op_name, args_val) = obj.iter().next().unwrap();
+                if op_name == "object" {
+                    return parse_object_step(args_val);
+                }
                 // Skip reserved keywords
                 if !["op", "let", "if", "map", "then", "else", "cond"].contains(&op_name.as_str()) {
                     if !is_valid_operator(op_name)
@@ -92,6 +99,52 @@ pub fn parse_v2_step(value: &JsonValue) -> Result<V2Step, V2ParseError> {
             "step must be object or string".to_string(),
         )),
     }
+}
+
+fn parse_object_step_explicit(args: Option<&JsonValue>) -> Result<V2Step, V2ParseError> {
+    let Some(JsonValue::Array(args)) = args else {
+        return Err(V2ParseError::InvalidStep(
+            "object step expects exactly one object argument".to_string(),
+        ));
+    };
+    if args.len() != 1 || !matches!(args.first(), Some(JsonValue::Object(_))) {
+        return Err(V2ParseError::InvalidStep(
+            "object step expects exactly one object argument".to_string(),
+        ));
+    }
+    parse_object_step(&args[0])
+}
+
+fn parse_object_step(value: &JsonValue) -> Result<V2Step, V2ParseError> {
+    let JsonValue::Object(map) = value else {
+        return Err(V2ParseError::InvalidStep(
+            "object step argument must be an object".to_string(),
+        ));
+    };
+    let fields = map
+        .iter()
+        .map(|(key, value)| {
+            Ok(V2ObjectField {
+                key: key.clone(),
+                value: parse_object_field_value(value)?,
+            })
+        })
+        .collect::<Result<Vec<_>, V2ParseError>>()?;
+    Ok(V2Step::Object(V2ObjectStep { fields }))
+}
+
+fn parse_object_field_value(value: &JsonValue) -> Result<V2ObjectFieldValue, V2ParseError> {
+    if let JsonValue::Object(map) = value
+        && map.len() == 1
+    {
+        if let Some(expr) = map.get("expr") {
+            return Ok(V2ObjectFieldValue::Expr(parse_v2_expr(expr)?));
+        }
+        if let Some(value) = map.get("value") {
+            return Ok(V2ObjectFieldValue::Value(value.clone()));
+        }
+    }
+    Ok(V2ObjectFieldValue::Expr(parse_v2_expr(value)?))
 }
 
 pub(crate) fn parse_custom_call_step(

--- a/crates/rulemorph/src/v2_parser/tests.rs
+++ b/crates/rulemorph/src/v2_parser/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::v2_model::{V2Condition, V2Ref, V2Step};
+use crate::v2_model::{V2Condition, V2ObjectFieldValue, V2Ref, V2Step};
 
 include!("tests/ref_parse.rs");
 include!("tests/step.rs");

--- a/crates/rulemorph/src/v2_parser/tests/step.rs
+++ b/crates/rulemorph/src/v2_parser/tests/step.rs
@@ -96,6 +96,73 @@ mod v2_step_parser_tests {
     }
 
     #[test]
+    fn test_parse_object_step_shorthand() {
+        let value = json!({
+            "object": {
+                "name": ["$.name", "uppercase"],
+                "tags": { "value": ["new", "vip"] },
+                "meta": { "source": "literal" }
+            }
+        });
+
+        let step = parse_v2_step(&value).unwrap();
+        if let V2Step::Object(object) = step {
+            assert_eq!(object.fields.len(), 3);
+            let name = object
+                .fields
+                .iter()
+                .find(|field| field.key == "name")
+                .expect("name field");
+            assert!(matches!(name.value, V2ObjectFieldValue::Expr(_)));
+            let tags = object
+                .fields
+                .iter()
+                .find(|field| field.key == "tags")
+                .expect("tags field");
+            assert!(matches!(tags.value, V2ObjectFieldValue::Value(_)));
+            let meta = object
+                .fields
+                .iter()
+                .find(|field| field.key == "meta")
+                .expect("meta field");
+            assert!(matches!(meta.value, V2ObjectFieldValue::Expr(_)));
+        } else {
+            panic!("Expected Object step");
+        }
+    }
+
+    #[test]
+    fn test_parse_object_step_explicit_op_form() {
+        let value = json!({
+            "op": "object",
+            "args": [
+                {
+                    "id": "@input.id"
+                }
+            ]
+        });
+
+        let step = parse_v2_step(&value).unwrap();
+        if let V2Step::Object(object) = step {
+            assert_eq!(object.fields.len(), 1);
+            assert_eq!(object.fields[0].key, "id");
+        } else {
+            panic!("Expected Object step");
+        }
+    }
+
+    #[test]
+    fn test_parse_object_step_rejects_invalid_args() {
+        let value = json!({
+            "op": "object",
+            "args": []
+        });
+
+        let err = parse_v2_step(&value).unwrap_err();
+        assert!(err.to_string().contains("object step expects exactly one object argument"));
+    }
+
+    #[test]
     fn test_parse_complex_pipe_with_steps() {
         // Complex pipe with multiple step types
         let arr = vec![

--- a/crates/rulemorph/src/v2_validator/dependencies.rs
+++ b/crates/rulemorph/src/v2_validator/dependencies.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::error::ErrorCode;
-use crate::v2_model::{V2Condition, V2Expr, V2Pipe, V2Ref, V2Start, V2Step};
+use crate::v2_model::{V2Condition, V2Expr, V2ObjectFieldValue, V2Pipe, V2Ref, V2Start, V2Step};
 
 use super::V2ValidationCtx;
 
@@ -40,6 +40,13 @@ fn collect_out_refs_from_step(step: &V2Step, refs: &mut HashSet<String>) {
         V2Step::Op(op_step) => {
             for arg in &op_step.args {
                 collect_out_refs_recursive(arg, refs);
+            }
+        }
+        V2Step::Object(object_step) => {
+            for field in &object_step.fields {
+                if let V2ObjectFieldValue::Expr(expr) = &field.value {
+                    collect_out_refs_recursive(expr, refs);
+                }
             }
         }
         V2Step::CustomCall(call_step) => {

--- a/crates/rulemorph/src/v2_validator/operators.rs
+++ b/crates/rulemorph/src/v2_validator/operators.rs
@@ -31,6 +31,15 @@ pub(super) fn validate_v2_op_step(
         return;
     }
 
+    if op_step.op == "object" {
+        ctx.push_error(
+            ErrorCode::InvalidExprShape,
+            "object must use the object step form",
+            base_path,
+        );
+        return;
+    }
+
     // Check if op is known
     if !is_valid_op(&op_step.op) {
         ctx.push_error(

--- a/crates/rulemorph/src/v2_validator/steps.rs
+++ b/crates/rulemorph/src/v2_validator/steps.rs
@@ -1,4 +1,7 @@
-use crate::v2_model::{V2Expr, V2IfStep, V2LetStep, V2MapStep, V2Pipe, V2Start, V2Step};
+use crate::v2_model::{
+    V2Expr, V2IfStep, V2LetStep, V2MapStep, V2ObjectFieldValue, V2ObjectStep, V2Pipe, V2Start,
+    V2Step, object_field_rule_path,
+};
 use crate::v2_parser::{custom_call_step_candidate, parse_custom_call_step};
 
 use super::conditions::validate_v2_condition;
@@ -115,6 +118,7 @@ fn validate_v2_step(
 ) {
     match step {
         V2Step::Op(op_step) => operators::validate_v2_op_step(op_step, base_path, scope, ctx),
+        V2Step::Object(object_step) => validate_v2_object_step(object_step, base_path, scope, ctx),
         V2Step::CustomCall(call_step) => {
             let call_scope = scope.clone().with_pipe();
             validate_custom_call_args(call_step, base_path, &call_scope, ctx);
@@ -123,6 +127,35 @@ fn validate_v2_step(
         V2Step::If(if_step) => validate_v2_if_step(if_step, base_path, scope, ctx),
         V2Step::Map(map_step) => validate_v2_map_step(map_step, base_path, scope, ctx),
         V2Step::Ref(v2_ref) => validate_v2_ref(v2_ref, base_path, scope, ctx),
+    }
+}
+
+fn validate_v2_object_step(
+    object_step: &V2ObjectStep,
+    base_path: &str,
+    scope: &V2Scope,
+    ctx: &mut V2ValidationCtx<'_>,
+) {
+    let max_key_bytes = crate::normalization::NormalizationOptions::default().max_object_key_bytes;
+    for field in &object_step.fields {
+        let field_path = object_field_rule_path(base_path, &field.key);
+        if field.key.is_empty() {
+            ctx.push_error(
+                crate::error::ErrorCode::InvalidExprShape,
+                "object field key must not be empty",
+                &field_path,
+            );
+        }
+        if field.key.len() > max_key_bytes {
+            ctx.push_error(
+                crate::error::ErrorCode::InvalidExprShape,
+                "object key bytes exceed configured limit",
+                &field_path,
+            );
+        }
+        if let V2ObjectFieldValue::Expr(expr) = &field.value {
+            validate_v2_expr(expr, &field_path, scope, ctx);
+        }
     }
 }
 

--- a/crates/rulemorph/src/v2_validator/steps.rs
+++ b/crates/rulemorph/src/v2_validator/steps.rs
@@ -136,20 +136,12 @@ fn validate_v2_object_step(
     scope: &V2Scope,
     ctx: &mut V2ValidationCtx<'_>,
 ) {
-    let max_key_bytes = crate::normalization::NormalizationOptions::default().max_object_key_bytes;
     for field in &object_step.fields {
         let field_path = object_field_rule_path(base_path, &field.key);
         if field.key.is_empty() {
             ctx.push_error(
                 crate::error::ErrorCode::InvalidExprShape,
                 "object field key must not be empty",
-                &field_path,
-            );
-        }
-        if field.key.len() > max_key_bytes {
-            ctx.push_error(
-                crate::error::ErrorCode::InvalidExprShape,
-                "object key bytes exceed configured limit",
                 &field_path,
             );
         }

--- a/crates/rulemorph/src/v2_validator/tests/operators.rs
+++ b/crates/rulemorph/src/v2_validator/tests/operators.rs
@@ -168,6 +168,32 @@ fn test_validate_zip_with_item_scope_allowed() {
 }
 
 #[test]
+fn test_validate_v2_expr_rejects_object_as_plain_op_step() {
+    let expr = V2Expr::Pipe(V2Pipe {
+        start: V2Start::Literal(json!({})),
+        steps: vec![V2Step::Op(V2OpStep {
+            op: "object".to_string(),
+            args: vec![V2Expr::Pipe(V2Pipe {
+                start: V2Start::Literal(json!({"id": 1})),
+                steps: vec![],
+            })],
+        })],
+    });
+    let scope = V2Scope::new();
+    let mut ctx = V2ValidationCtx::new(None);
+
+    validate_v2_expr(&expr, "test", &scope, &mut ctx);
+
+    assert!(
+        ctx.errors()
+            .iter()
+            .any(|err| err.code == ErrorCode::InvalidExprShape),
+        "expected object plain op to fail validation, got: {:?}",
+        ctx.errors()
+    );
+}
+
+#[test]
 fn test_validate_v2_expr_rejects_unimplemented_op() {
     let expr = V2Expr::Pipe(V2Pipe {
         start: V2Start::Literal(json!("hello")),

--- a/crates/rulemorph/src/v2_validator/types.rs
+++ b/crates/rulemorph/src/v2_validator/types.rs
@@ -90,6 +90,7 @@ fn infer_json_type(value: &JsonValue) -> V2Type {
 fn infer_step_result_type(step: &V2Step, _input_type: &V2Type) -> V2Type {
     match step {
         V2Step::Op(op_step) => infer_op_result_type(&op_step.op),
+        V2Step::Object(_) => V2Type::Object,
         V2Step::CustomCall(_) => V2Type::Unknown,
         V2Step::Let(_) => V2Type::Unknown, // Let returns last expression or input
         V2Step::If(_) => V2Type::Unknown,  // Could be either branch

--- a/crates/rulemorph/src/validator/codecs.rs
+++ b/crates/rulemorph/src/validator/codecs.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeSet;
 
 use crate::error::ErrorCode;
 use crate::model::{Expr, Mapping, RuleFile, V2RuleStep};
-use crate::v2_model::{V2CallArg, V2Condition, V2Expr, V2OpStep, V2Pipe, V2Start, V2Step};
+use crate::v2_model::{
+    V2CallArg, V2Condition, V2Expr, V2ObjectFieldValue, V2OpStep, V2Pipe, V2Start, V2Step,
+    object_field_rule_path,
+};
 use crate::v2_parser::{parse_v2_condition, parse_v2_expr};
 
 use super::ValidationCtx;
@@ -206,6 +209,17 @@ fn validate_pipe_codec_refs(pipe: &V2Pipe, base_path: &str, ctx: &mut Validation
         let step_path = format!("{}[{}]", base_path, index + 1);
         match step {
             V2Step::Op(op) => validate_op_codec_refs(op, &step_path, ctx),
+            V2Step::Object(object) => {
+                for field in &object.fields {
+                    if let V2ObjectFieldValue::Expr(expr) = &field.value {
+                        validate_v2_expr_codec_refs(
+                            expr,
+                            &object_field_rule_path(&step_path, &field.key),
+                            ctx,
+                        );
+                    }
+                }
+            }
             V2Step::If(if_step) => {
                 validate_condition_codec_refs(&if_step.cond, &format!("{}.cond", step_path), ctx);
                 validate_pipe_codec_refs(&if_step.then_branch, &format!("{}.then", step_path), ctx);
@@ -248,6 +262,17 @@ fn validate_pipe_codec_refs(pipe: &V2Pipe, base_path: &str, ctx: &mut Validation
 fn validate_v2_step_codec_refs(step: &V2Step, base_path: &str, ctx: &mut ValidationCtx<'_>) {
     match step {
         V2Step::Op(op) => validate_op_codec_refs(op, base_path, ctx),
+        V2Step::Object(object) => {
+            for field in &object.fields {
+                if let V2ObjectFieldValue::Expr(expr) = &field.value {
+                    validate_v2_expr_codec_refs(
+                        expr,
+                        &object_field_rule_path(base_path, &field.key),
+                        ctx,
+                    );
+                }
+            }
+        }
         V2Step::If(if_step) => {
             validate_condition_codec_refs(&if_step.cond, &format!("{}.cond", base_path), ctx);
             validate_pipe_codec_refs(&if_step.then_branch, &format!("{}.then", base_path), ctx);

--- a/crates/rulemorph/tests/dto_inference.rs
+++ b/crates/rulemorph/tests/dto_inference.rs
@@ -170,6 +170,40 @@ mappings:
 }
 
 #[test]
+fn dto_infers_object_builder_static_shape() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: payload
+    expr:
+      - object:
+          name: ["@input.name", uppercase]
+          age: ["@input.age", int]
+          nested:
+            - object:
+                active: true
+    required: true
+"#;
+
+    let rust = render(yaml, DtoLanguage::Rust);
+    assert!(rust.contains("pub payload: RecordPayload,"));
+    assert!(rust.contains("pub name: Option<String>,"));
+    assert!(rust.contains("pub age: Option<i64>,"));
+    assert!(rust.contains("pub nested: Option<RecordPayloadNested>,"));
+    assert!(rust.contains("pub active: Option<bool>,"));
+
+    let typescript = render(yaml, DtoLanguage::TypeScript);
+    assert!(typescript.contains("payload: RecordPayload;"));
+    assert!(typescript.contains("name?: string;"));
+    assert!(typescript.contains("age?: number;"));
+    assert!(typescript.contains("nested?: RecordPayloadNested;"));
+    assert!(typescript.contains("active?: boolean;"));
+}
+
+#[test]
 fn dto_reuses_synthetic_parent_out_shapes() {
     let yaml = r#"
 version: 2

--- a/crates/rulemorph/tests/object_builder.rs
+++ b/crates/rulemorph/tests/object_builder.rs
@@ -224,6 +224,116 @@ mappings:
 }
 
 #[test]
+fn object_builder_static_validation_does_not_freeze_configurable_key_limit() {
+    let long_key = "k".repeat(NormalizationOptions::default().max_object_key_bytes + 1);
+    let yaml = format!(
+        r#"
+version: 2
+input:
+  format: json
+  json: {{}}
+mappings:
+  - target: value
+    expr:
+      - object:
+          ? "{}"
+          : 1
+"#,
+        long_key
+    );
+    let rule = parse_rule_file(&yaml).expect("parse rule with long static key");
+
+    validate_rule_file(&rule).expect("static validation should not hard-code runtime key limit");
+
+    let mut options = NormalizationOptions::default();
+    options.max_object_key_bytes = long_key.len();
+    transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect("raised runtime key limit should allow long static key");
+
+    let mut options = NormalizationOptions::default();
+    options.max_object_key_bytes = 4;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("runtime key limit should remain fail-closed");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("object key bytes"));
+}
+
+#[test]
+fn object_builder_rejects_nested_generated_object_limits() {
+    let nested_key_limit = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          payload:
+            value:
+              too_long: 1
+"#;
+    let rule = parse_rule_file(nested_key_limit).expect("parse nested key rule");
+    let mut options = NormalizationOptions::default();
+    options.max_object_key_bytes = 4;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("nested generated key should respect key limit");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("object key bytes"));
+
+    let nested_field_limit = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          payload:
+            value:
+              a: 1
+              b: 2
+"#;
+    let rule = parse_rule_file(nested_field_limit).expect("parse nested field rule");
+    let mut options = NormalizationOptions::default();
+    options.max_object_fields = 1;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("nested generated object should respect field limit");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("object field count"));
+}
+
+#[test]
+fn object_builder_map_accumulates_generated_json_budget() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - "@input.items"
+      - map:
+        - object:
+            payload: "@item"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse map object rule");
+    let mut options = NormalizationOptions::default();
+    options.max_generated_json_bytes = 30;
+    let err = transform_input_with_options(
+        &rule,
+        InputData::Text(r#"{"items":["abcdef","abcdef"]}"#),
+        None,
+        &options,
+    )
+    .expect_err("map should enforce generated JSON bytes across the full output array");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("generated JSON bytes"));
+}
+
+#[test]
 fn object_builder_trace_records_fields_and_sanitizes_field_key_metadata() {
     let yaml = r#"
 version: 2

--- a/crates/rulemorph/tests/object_builder.rs
+++ b/crates/rulemorph/tests/object_builder.rs
@@ -1,0 +1,315 @@
+use rulemorph::{
+    InputData, NormalizationOptions, TraceAttributeValue, TraceEventKind, TransformErrorKind,
+    TransformTraceOptions, parse_rule_file, transform_input, transform_input_with_options,
+    transform_input_with_trace, validate_rule_file,
+};
+
+fn transform_json(rule_yaml: &str, input: &str) -> serde_json::Value {
+    let rule = parse_rule_file(rule_yaml).expect("parse rule");
+    let output = transform_input(&rule, InputData::Text(input), None).expect("transform");
+    output
+        .as_array()
+        .and_then(|items| items.first())
+        .cloned()
+        .unwrap_or(output)
+}
+
+fn transform_err(rule_yaml: &str, input: &str) -> rulemorph::TransformError {
+    let rule = parse_rule_file(rule_yaml).expect("parse rule");
+    transform_input(&rule, InputData::Text(input), None).expect_err("transform error")
+}
+
+#[test]
+fn object_builder_builds_nested_missing_null_literal_arrays_and_dynamodb_item() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - "@input"
+      - object:
+          name: ["$.name", uppercase]
+          age: ["$.age", int]
+          tags:
+            value: ["new", "vip"]
+          profile:
+            - object:
+                label: ["$.name", lowercase]
+          missing: "$.missing"
+          nil: null
+      - to_typed_value: dynamodb_item
+"#;
+
+    let output = transform_json(yaml, r#"{"name":"Alice","age":"31"}"#);
+    assert_eq!(output["value"]["name"], serde_json::json!({"S":"ALICE"}));
+    assert_eq!(output["value"]["age"], serde_json::json!({"N":"31"}));
+    assert_eq!(
+        output["value"]["tags"],
+        serde_json::json!({"L":[{"S":"new"},{"S":"vip"}]})
+    );
+    assert_eq!(
+        output["value"]["profile"],
+        serde_json::json!({"M":{"label":{"S":"alice"}}})
+    );
+    assert_eq!(output["value"]["nil"], serde_json::json!({"NULL":true}));
+    assert!(output["value"].get("missing").is_none());
+}
+
+#[test]
+fn object_builder_validates_static_shape_and_field_exprs() {
+    let valid = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          id: "@input.id"
+"#;
+    let rule = parse_rule_file(valid).expect("parse valid rule");
+    validate_rule_file(&rule).expect("valid object rule");
+
+    let invalid_args = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - op: object
+        args: []
+"#;
+    let rule = parse_rule_file(invalid_args).expect("parse invalid rule");
+    let errors = validate_rule_file(&rule).expect_err("object args should fail");
+    assert!(format!("{errors:?}").contains("InvalidExprShape"));
+
+    let invalid_field_expr = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          id: "@bad-ref"
+"#;
+    let rule = parse_rule_file(invalid_field_expr).expect("parse invalid rule");
+    let errors = validate_rule_file(&rule).expect_err("field expr should fail");
+    assert!(format!("{errors:?}").contains("InvalidExprShape"));
+}
+
+#[test]
+fn object_builder_rejects_empty_keys_and_configured_resource_limits() {
+    let empty_key = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          "": "@input.id"
+"#;
+    let err = transform_err(empty_key, r#"{"id":"u1"}"#);
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("object field key must not be empty"));
+
+    let field_limit = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          a: 1
+          b: 2
+"#;
+    let rule = parse_rule_file(field_limit).expect("parse rule");
+    let mut options = NormalizationOptions::default();
+    options.max_object_fields = 1;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("field limit");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("object field count"));
+
+    let key_limit = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          long_key: 1
+"#;
+    let rule = parse_rule_file(key_limit).expect("parse rule");
+    let mut options = NormalizationOptions::default();
+    options.max_object_key_bytes = 4;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("key limit");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("object key bytes"));
+
+    let generated_limit = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          a: 1
+          b: 2
+"#;
+    let rule = parse_rule_file(generated_limit).expect("parse rule");
+    let mut options = NormalizationOptions::default();
+    options.max_generated_json_nodes = 2;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("node limit");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("generated JSON node count"));
+
+    let depth_limit = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          nested:
+            value:
+              inner:
+                leaf: 1
+"#;
+    let rule = parse_rule_file(depth_limit).expect("parse rule");
+    let mut options = NormalizationOptions::default();
+    options.max_object_depth = 1;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("depth limit");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("object depth"));
+
+    let byte_limit = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          payload: "abcdef"
+"#;
+    let rule = parse_rule_file(byte_limit).expect("parse rule");
+    let mut options = NormalizationOptions::default();
+    options.max_generated_json_bytes = 8;
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("byte limit");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(err.message.contains("generated JSON bytes"));
+}
+
+#[test]
+fn object_builder_trace_records_fields_and_sanitizes_field_key_metadata() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          "api_token": "@input.api_token"
+          "line\nbreak": "@input.name"
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let traced = transform_input_with_trace(
+        &rule,
+        InputData::Text(r#"{"api_token":"secret-token","name":"Alice"}"#),
+        None,
+        &TransformTraceOptions::redacted(),
+    )
+    .expect("traced transform");
+
+    let field_events = traced
+        .trace
+        .records
+        .iter()
+        .flat_map(|record| record.events.iter())
+        .filter(|event| {
+            event.kind == TraceEventKind::ArgEval && event.operator.as_deref() == Some("object")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(field_events.len(), 2);
+
+    let secret_event = field_events
+        .iter()
+        .find(|event| event.attributes.contains_key("field_key_redaction_reason"))
+        .expect("secret-like key is redacted");
+    assert!(matches!(
+        secret_event.attributes.get("field_key_redaction_reason"),
+        Some(TraceAttributeValue::String(value)) if value == "secret_like_path"
+    ));
+    assert!(!secret_event.attributes.contains_key("field_key"));
+    assert!(
+        !field_events.iter().any(|event| event
+            .rule_path
+            .as_deref()
+            .is_some_and(|path| path.contains("api_token"))),
+        "secret-like field key must not appear in redacted trace rule_path"
+    );
+
+    let escaped_event = field_events
+        .iter()
+        .find(|event| match event.attributes.get("field_key") {
+            Some(TraceAttributeValue::String(value)) => value.contains("\\n"),
+            _ => false,
+        })
+        .expect("control characters are escaped in field_key attr");
+    assert!(matches!(
+        escaped_event.attributes.get("field_key"),
+        Some(TraceAttributeValue::String(value)) if value == "line\\nbreak"
+    ));
+}
+
+#[test]
+fn object_builder_checks_generated_bytes_before_evaluating_later_fields() {
+    let yaml = r#"
+version: 2
+input:
+  format: json
+  json: {}
+mappings:
+  - target: value
+    expr:
+      - object:
+          payload: "abcdef"
+          should_not_eval: ["not-a-number", int]
+"#;
+    let rule = parse_rule_file(yaml).expect("parse rule");
+    let mut options = NormalizationOptions::default();
+    options.max_generated_json_bytes = 8;
+
+    let err = transform_input_with_options(&rule, InputData::Text("{}"), None, &options)
+        .expect_err("byte limit should fail before later field evaluation");
+    assert_eq!(err.kind, TransformErrorKind::ExprError);
+    assert!(
+        err.message.contains("generated JSON bytes"),
+        "unexpected error: {err:?}"
+    );
+}

--- a/crates/rulemorph/tests/transform_trace_semantics/operator_inventory/fixtures/cases.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics/operator_inventory/fixtures/cases.rs
@@ -70,6 +70,10 @@ const OPERATOR_CASES: &[OperatorCase] = &[
         "deep_merge",
         r#"["@input.deep_left", {"deep_merge": "@input.deep_right"}]"#,
     ),
+    (
+        "object",
+        r#"["@input", {"object": {"name": ["@input.s", "uppercase"], "age": "@input.n"}}]"#,
+    ),
     ("get", r#"["@input.obj", {"get": "a"}]"#),
     ("pick", r#"["@input.obj", {"pick": "a"}]"#),
     ("omit", r#"["@input.obj", {"omit": "b"}]"#),

--- a/crates/rulemorph/tests/transform_trace_semantics/operator_inventory/fixtures/expected_inventory.rs
+++ b/crates/rulemorph/tests/transform_trace_semantics/operator_inventory/fixtures/expected_inventory.rs
@@ -50,6 +50,7 @@ const EXPECTED_INVENTORY: &[&str] = &[
     "gt",
     "gte",
     "match",
+    "object",
     "merge",
     "deep_merge",
     "get",

--- a/crates/rulemorph_cli/src/direct/output_spec.rs
+++ b/crates/rulemorph_cli/src/direct/output_spec.rs
@@ -4,7 +4,10 @@ use std::collections::HashSet;
 use rulemorph::{
     Expr, ExprChain, ExprOp, ExprRef, NormalizationOptions, PathToken, parse_path,
     serde_guard::parse_json_value_strict,
-    v2_model::{V2CallArg, V2Comparison, V2Condition, V2Expr, V2Pipe, V2Ref, V2Start, V2Step},
+    v2_model::{
+        V2CallArg, V2Comparison, V2Condition, V2Expr, V2ObjectFieldValue, V2Pipe, V2Ref, V2Start,
+        V2Step,
+    },
     v2_parser::parse_v2_expr,
 };
 
@@ -455,6 +458,10 @@ fn scan_v2_step_refs(step: &V2Step, root: &str) -> bool {
     match step {
         V2Step::Ref(reference) => is_v2_root_ref(reference, root),
         V2Step::Op(op) => op.args.iter().any(|expr| scan_v2_expr_refs(expr, root)),
+        V2Step::Object(object) => object.fields.iter().any(|field| match &field.value {
+            V2ObjectFieldValue::Expr(expr) => scan_v2_expr_refs(expr, root),
+            V2ObjectFieldValue::Value(_) => false,
+        }),
         V2Step::CustomCall(call) => call.with.as_ref().is_some_and(|args| {
             args.iter().any(|(_, arg)| match arg {
                 V2CallArg::Expr(expr) => scan_v2_expr_refs(expr, root),

--- a/crates/rulemorph_cli/src/input/limits.rs
+++ b/crates/rulemorph_cli/src/input/limits.rs
@@ -100,6 +100,11 @@ fn apply_limit_override(
         "excel-shared-string-bytes" => options.max_excel_shared_string_bytes = value,
         "excel-styles" => options.max_excel_styles = value,
         "range-items" => options.max_range_items = Some(value),
+        "object-fields" => options.max_object_fields = value,
+        "object-key-bytes" => options.max_object_key_bytes = value,
+        "object-depth" => options.max_object_depth = value,
+        "generated-json-nodes" => options.max_generated_json_nodes = value,
+        "generated-json-bytes" => options.max_generated_json_bytes = value,
         _ => return Err(format!("unknown limit `{}`", name)),
     }
     Ok(())

--- a/crates/rulemorph_cli/tests/cli/limits/overrides.rs
+++ b/crates/rulemorph_cli/tests/cli/limits/overrides.rs
@@ -50,6 +50,31 @@ fn cli_limit_override_accepts_unlimited_range_items() {
 }
 
 #[test]
+fn cli_limit_override_accepts_object_builder_limits() {
+    let base = fixtures_dir().join("t01_csv_basic");
+    let mut cmd = cargo_bin_cmd!("rulemorph");
+    let output = cmd
+        .arg("transform")
+        .arg("-r")
+        .arg(base.join("rules.yaml"))
+        .arg("-i")
+        .arg(base.join("input.csv"))
+        .arg("--limit")
+        .arg("object-fields=100")
+        .arg("--limit")
+        .arg("object-key-bytes=1024")
+        .arg("--limit")
+        .arg("object-depth=32")
+        .arg("--limit")
+        .arg("generated-json-nodes=1000")
+        .arg("--limit")
+        .arg("generated-json-bytes=65536")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
 fn cli_rejects_unknown_limit_override() {
     let base = fixtures_dir().join("t01_csv_basic");
     let mut cmd = cargo_bin_cmd!("rulemorph");

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/v2_helpers.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/v2_helpers.rs
@@ -71,7 +71,7 @@ pub(super) fn build_pipe_steps(
                 &step_path,
                 &current_ctx,
             ),
-            V2Step::CustomCall(_) => {
+            V2Step::Object(_) | V2Step::CustomCall(_) => {
                 let single_step_pipe = V2Pipe {
                     start: V2Start::PipeValue,
                     steps: vec![step.clone()],

--- a/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/v2_helpers/labels.rs
+++ b/crates/rulemorph_endpoint/src/endpoint_engine/trace_graph/v2_helpers/labels.rs
@@ -12,6 +12,7 @@ pub(super) fn v2_start_label(start: &V2Start) -> String {
 pub(super) fn v2_step_label(step: &V2Step) -> String {
     match step {
         V2Step::Op(op) => op.op.clone(),
+        V2Step::Object(_) => "object".to_string(),
         V2Step::CustomCall(call) => call.op.clone(),
         V2Step::Let(let_step) => format!(
             "let {}",

--- a/crates/rulemorph_mcp/src/tools/list_ops/inventory.rs
+++ b/crates/rulemorph_mcp/src/tools/list_ops/inventory.rs
@@ -15,6 +15,7 @@ pub(super) fn ops_json(category_docs: Value) -> Value {
             "pad_end",
             "lookup",
             "lookup_first",
+            "object",
             "merge",
             "deep_merge",
             "get",
@@ -86,6 +87,7 @@ pub(super) fn ops_json(category_docs: Value) -> Value {
                 "pad_end"
             ],
             "json_ops": [
+                "object",
                 "merge",
                 "deep_merge",
                 "get",

--- a/crates/rulemorph_mcp/tests/stdio/catalog/tools/list_ops.rs
+++ b/crates/rulemorph_mcp/tests/stdio/catalog/tools/list_ops.rs
@@ -51,6 +51,7 @@ fn list_ops_success() {
             "pad_end",
             "lookup",
             "lookup_first",
+            "object",
             "merge",
             "deep_merge",
             "get",

--- a/docs/rules_spec_en.md
+++ b/docs/rules_spec_en.md
@@ -121,6 +121,7 @@ Huge or dynamic paths used by `get` / `pick` / `omit` also fall back to JSON.
 `default` / `coalesce` do not narrow dynamic or unknown input into a concrete type by themselves.
 
 `optional` means a field may be omitted. `nullable` means a present field may contain `null`.
+Fields built by the `object` OP are inferred as optional because each field expression may evaluate to `missing`.
 JSON integer literals that do not fit in a signed 64-bit integer are treated as JSON fallback types, because Rust / Go / JVM DTO integer outputs use `i64` / `int64` / `Long`.
 
 `defs.*.returns` also participates in DTO inference. Object `returns` become nested DTO shapes. For custom OPs with a `mappings` body and no explicit `returns`, the object shape is synthesized from the body targets. Fields that cannot be narrowed use the language's JSON fallback type.
@@ -918,6 +919,8 @@ rulemorph transform -r rules.yaml -i workbook.xlsx --limits-file limits.toml
 
 `range` emits at most 10,000 items by default. Use `range-items=<integer>` to change that cap. `range-items=unlimited` removes the per-range cap for trusted local input/rules. In `--limits-file`, write it as a string, for example `range-items = "unlimited"`. Even with `range-items=unlimited`, generated arrays from `range`, `map`, `flat_map`, `flatten`, and similar operators are still bounded by `array-len`.
 
+The `object` OP can generate JSON objects from a rule, so it has dedicated limits as well. Defaults are `object-fields=10000`, `object-key-bytes=4096`, `object-depth=64`, `generated-json-nodes=100000`, and `generated-json-bytes=10485760`. Override them with names such as `--limit object-fields=...` or `--limit generated-json-bytes=...`; `--limits-file` uses the same names. `array-len` remains the array-generation cap and is not reused as the object safety boundary.
+
 These options only increase processing limits. Safety invariants such as duplicate key rejection, XML DTD/entity rejection, HTML no-network/no-JS behavior, Excel no-macro/no-formula-evaluation behavior, and MCP pathless branch guard are not configurable.
 
 ## Record filter (`record_when`)
@@ -1190,7 +1193,7 @@ Support status:
 ### Operation categories
 
 - String ops: `concat`, `to_string`, `trim`, `lowercase`, `uppercase`, `replace`, `split`, `pad_start`, `pad_end`
-- JSON ops: `merge`, `deep_merge`, `get`, `pick`, `omit`, `keys`, `values`, `entries`, `len`, `from_entries`, `object_flatten`, `object_unflatten`
+- JSON ops: `object`, `merge`, `deep_merge`, `get`, `pick`, `omit`, `keys`, `values`, `entries`, `len`, `from_entries`, `object_flatten`, `object_unflatten`
 - Array ops: `map`, `filter`, `flat_map`, `flatten`, `take`, `drop`, `slice`, `chunk`, `zip`, `zip_with`, `unzip`, `group_by`, `key_by`, `partition`, `unique`, `distinct_by`, `sort_by`, `find`, `find_index`, `index_of`, `contains`, `sum`, `avg`, `min`, `max`, `reduce`, `fold`, `first`, `last`
 - Numeric ops: `+` / `add`, `-` / `subtract`, `*` / `multiply`, `/` / `divide`, `round`, `abs`, `floor`, `ceil`, `trunc`, `sqrt`, `sign`, `mod`, `pow`, `clamp`, `range`, `to_base`, `sum`, `avg`, `min`, `max`
 - Date ops: `date_format`, `to_unixtime`
@@ -1203,6 +1206,7 @@ Support status:
 
 - `to_*`: conversions (e.g., `to_string`, `to_base`, `to_unixtime`)
 - `*_by`: key-based variants (`group_by`, `key_by`, `distinct_by`, `sort_by`)
+- `object`: builder that creates objects from v2 expressions
 - `object_*`: object-specific structural ops (`object_flatten`, `object_unflatten`)
 
 ### Core operations
@@ -1290,6 +1294,29 @@ expr:
 
 ### JSON operations
 
+`object` evaluates multiple v2 expressions and builds one JSON object.
+When a field value evaluates to `missing`, that field is omitted. `null` remains `null`.
+Keys are literal field names; `user.name` is one key named `"user.name"`, not a nested path.
+Use nested `object` when nested output is needed.
+
+```yaml
+expr:
+  - "@input"
+  - object:
+      name: ["$.name", uppercase]
+      age: ["$.age", int]
+      tags:
+        value: ["new", "vip"]
+      profile:
+        - object:
+            label: ["$.name", lowercase]
+      missing: "$.missing"
+```
+
+In this example, the current pipe value before `object` is `@input`, so `$` inside field expressions points at the input record.
+Use the `value` wrapper for literal array field values. Use the `expr` wrapper when an object-shaped field value must be interpreted as an expression.
+When piping the `object` output to another OP in a multi-step pipe, put an explicit start value as shown above. To return only the object, use a single-step pipe such as `expr: [{ object: { id: "@input.id" } }]`.
+
 Path arguments:
 - `pick`/`omit` accept one or more path strings as separate args.
 - A single arg may also be an array of strings (e.g., `@context.paths`).
@@ -1304,6 +1331,7 @@ Example:
 
 | op | args | description | support |
 | --- | --- | --- | --- |
+| `object` | `1` | Build a JSON object from a field map of v2 expressions. Omit `missing` fields. | `runtime` |
 | `merge` | `>=1` | Shallow merge (rightmost wins). | `runtime` |
 | `deep_merge` | `>=1` | Recursive merge for objects; arrays are replaced. | `runtime` |
 | `get` | `1` | Get value at path; missing if path is absent. | `runtime` |

--- a/docs/rules_spec_ja.md
+++ b/docs/rules_spec_ja.md
@@ -127,6 +127,7 @@ mappings:
 `default` / `coalesce` は dynamic/unknown input を具体型へ狭める根拠には使いません。
 
 `optional` は field が省略される可能性、`nullable` は field 値が `null` になり得る可能性を表します。
+`object` OP で生成する field は field expr が `missing` になり得るため、DTO 推論では optional field として扱います。
 JSON integer literal が signed 64-bit integer に収まらない場合は、Rust / Go / JVM 系 DTO の `i64` / `int64` / `Long` で安全に表現できないため JSON fallback 型として扱います。
 
 `defs` の `returns` は DTO 推論にも使われます。`returns` が object の場合は nested DTO shape として伝播します。`mappings` body の関数OPで `returns` を省略した場合は、body の `target` から object shape を合成します。推論できない field は JSON fallback 型になります。
@@ -922,6 +923,8 @@ rulemorph transform -r rules.yaml -i workbook.xlsx --limits-file limits.toml
 
 `range` OP の生成数は既定で 10,000 要素までです。`range-items=<integer>` で上限を変更できます。`range-items=unlimited` は trusted なローカル入力/ルール向けに `range` 単体の上限制約を外します。`--limits-file` で指定する場合は `range-items = "unlimited"` のように文字列で書きます。`range-items=unlimited` の場合でも、`range`/`map`/`flat_map`/`flatten` などが生成する配列の総量は `array-len` で制限されます。
 
+`object` OP は rule ごとに JSON object を生成できるため、専用 limit でも制限されます。既定値は `object-fields=10000`、`object-key-bytes=4096`、`object-depth=64`、`generated-json-nodes=100000`、`generated-json-bytes=10485760` です。これらは `--limit object-fields=...`、`--limit generated-json-bytes=...` のように変更でき、`--limits-file` でも同じ名前を使います。`array-len` は配列生成の上限であり、object 生成の安全境界には流用されません。
+
 これらは処理量の上限を広げるだけです。duplicate key rejection、XML DTD/entity rejection、HTML no-network/no-JS、Excel no-macro/no-formula-evaluation、MCP pathless branch guard などの安全性 invariant は変更できません。
 
 ## Record filter（`record_when`）
@@ -1255,7 +1258,7 @@ when:
 ### カテゴリ
 
 - 文字列系: `concat`, `to_string`, `trim`, `lowercase`, `uppercase`, `replace`, `split`, `pad_start`, `pad_end`
-- JSON 操作: `merge`, `deep_merge`, `get`, `pick`, `omit`, `keys`, `values`, `entries`, `len`, `from_entries`, `object_flatten`, `object_unflatten`
+- JSON 操作: `object`, `merge`, `deep_merge`, `get`, `pick`, `omit`, `keys`, `values`, `entries`, `len`, `from_entries`, `object_flatten`, `object_unflatten`
 - 配列 op: `map`, `filter`, `flat_map`, `flatten`, `take`, `drop`, `slice`, `chunk`, `zip`, `zip_with`, `unzip`, `group_by`, `key_by`, `partition`, `unique`, `distinct_by`, `sort_by`, `find`, `find_index`, `index_of`, `contains`, `sum`, `avg`, `min`, `max`, `reduce`, `fold`, `first`, `last`
 - 数値系: `+` / `add`, `-` / `subtract`, `*` / `multiply`, `/` / `divide`, `round`, `abs`, `floor`, `ceil`, `trunc`, `sqrt`, `sign`, `mod`, `pow`, `clamp`, `range`, `to_base`, `sum`, `avg`, `min`, `max`
 - 日付系: `date_format`, `to_unixtime`
@@ -1268,6 +1271,7 @@ when:
 
 - `to_*`: 変換系（`to_string`, `to_base`, `to_unixtime`）
 - `*_by`: キー指定の派生（`group_by`, `key_by`, `distinct_by`, `sort_by`）
+- `object`: v2 expr から object を組み立てる builder
 - `object_*`: object 構造専用（`object_flatten`, `object_unflatten`）
 
 ### コアオペレーション
@@ -1355,6 +1359,29 @@ expr:
 
 ### JSON 操作
 
+`object` は複数の v2 expr を評価して 1 つの JSON object を生成します。
+field value が `missing` の場合、その field は出力されません。`null` は `null` として残ります。
+key は literal field 名であり、`user.name` は nested path ではなく `"user.name"` という 1 key です。
+nested object が必要な場合は nested `object` を使います。
+
+```yaml
+expr:
+  - "@input"
+  - object:
+      name: ["$.name", uppercase]
+      age: ["$.age", int]
+      tags:
+        value: ["new", "vip"]
+      profile:
+        - object:
+            label: ["$.name", lowercase]
+      missing: "$.missing"
+```
+
+上の例では `object` 実行前の current pipe value が `@input` なので、field expr 内の `$` は入力 record を指します。
+literal array を field value にしたい場合は `value` wrapper を使います。object value を明示的に expr として扱いたい場合は `expr` wrapper を使えます。
+multi-step pipe で `object` の出力を次の OP へ渡す場合は、上のように明示的な start value を置いてください。単独で object を返す場合は `expr: [{ object: { id: "@input.id" } }]` のように single-step pipe として書けます。
+
 パス引数:
 - `pick`/`omit` はパス文字列を複数引数で指定できます。
 - 1 つの引数で文字列配列（例: `@context.paths`）も指定可能です。
@@ -1369,6 +1396,7 @@ expr:
 
 | op | args | 説明 | 対応 |
 | --- | --- | --- | --- |
+| `object` | `1` | v2 expr の field map から JSON object を生成。`missing` field は省略。 | `runtime` |
 | `merge` | `>=1` | 浅い merge（右勝ち）。 | `runtime` |
 | `deep_merge` | `>=1` | object は再帰 merge、配列は置換。 | `runtime` |
 | `get` | `1` | パスの値を取得。存在しない場合は `missing`。 | `runtime` |


### PR DESCRIPTION
## Summary
- Add the v2 `object` builder operator for constructing JSON objects inside expression pipelines.
- Wire the operator through parsing, runtime evaluation, traced evaluation, validation, DTO inference, direct-mode scans, endpoint trace graph helpers, MCP inventory, and ja/en docs.
- Add object-specific resource limits and trace redaction hardening, including incremental generated-object budgeting and secret-like field-key path redaction.

## Validation
- `cargo fmt`
- `cargo test`
- Codex Security diff scan completed before the final fixes; follow-up security fixes were regression-tested in `crates/rulemorph/tests/object_builder.rs`.

## Notes
- Base branch: `v0.3.4`
- The design note is intentionally kept outside git-tracked PR history under ignored local docs.